### PR TITLE
cmt/{agent,scylla-manager}: STARTUP ERROR sleep before exiting (#2823)

### DIFF
--- a/pkg/cmd/agent/main.go
+++ b/pkg/cmd/agent/main.go
@@ -5,11 +5,21 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 )
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(rootCmd.OutOrStderr(), "\nSTARTUP ERROR: %s\n\n", err)
+
+		// Due to a bug in systemd [1] last log messages for failed processes
+		// are lost. They are still visible with journalctl -xe but not all
+		// users know that. To make the logs visible in systemctl status we wait
+		// here for a bit over a second before exiting.
+		//
+		// [1] https://github.com/systemd/systemd/issues/2913
+		time.Sleep(1100 * time.Millisecond)
+
 		os.Exit(1)
 	}
 

--- a/pkg/cmd/scylla-manager/main.go
+++ b/pkg/cmd/scylla-manager/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 )
 
 func init() {
@@ -14,6 +15,15 @@ func init() {
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(rootCmd.OutOrStderr(), "\nSTARTUP ERROR: %s\n\n", err)
+
+		// Due to a bug in systemd [1] last log messages for failed processes
+		// are lost. They are still visible with journalctl -xe but not all
+		// users know that. To make the logs visible in systemctl status we wait
+		// here for a bit over a second before exiting.
+		//
+		// [1] https://github.com/systemd/systemd/issues/2913
+		time.Sleep(1100 * time.Millisecond)
+
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This works around systemd bug and makes STARTUP ERROR visible in systemctl status.

```
[support@ip-172-31-0-11 ~]$ sudo systemctl status scylla-manager-agent
● scylla-manager-agent.service - Scylla Manager Agent
   Loaded: loaded (/usr/lib/systemd/system/scylla-manager-agent.service; disabled; vendor preset: disabled)
   Active: failed (Result: exit-code) since Tue 2021-07-06 15:19:12 UTC; 158ms ago
  Process: 25147 ExecStart=/usr/bin/scylla-manager-agent (code=exited, status=1/FAILURE)
 Main PID: 25147 (code=exited, status=1/FAILURE)

Jul 06 15:19:10 ip-172-31-0-11.eu-central-1.compute.internal systemd[1]: Started Scylla Manager Agent.
Jul 06 15:19:10 ip-172-31-0-11.eu-central-1.compute.internal scylla-manager-agent[25147]: STARTUP ERROR: yaml: unmarshal errors:
Jul 06 15:19:10 ip-172-31-0-11.eu-central-1.compute.internal scylla-manager-agent[25147]: line 1: cannot unmarshal !!str `dasasdd...` into config.AgentConfig
```

The workaround works by sleeping a bit over 1 second giving time to flush logs to journalclt.

Fixes #2823