### PR TITLE
Open new docs issues in this repo

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -94,7 +94,7 @@ html_style = ''
 #
 html_theme_options = {
     'branch_substring_removed': 'branch-',
-    'github_issues_repository': 'scylladb/scylla-manager-issues',
+    'github_issues_repository': 'scylladb/scylla-manager',
     'header_links': [
     ('Scylla Manager', 'https://manager.docs.scylladb.com/'),
     ('Scylla Monitor', 'https://scylladb.github.io/scylla-monitoring/'),


### PR DESCRIPTION
Since the project is now open, better open issues in this repo (https://github.com/scylladb/scylla-manager/ )  and kill https://github.com/scylladb/scylla-manager-issues
