### PR TITLE
Health check SSL DOWN fix

### DIFF
--- a/docs/source/sctool/status.rst
+++ b/docs/source/sctool/status.rst
@@ -17,6 +17,7 @@ Available statuses are:
 
 * UP - Situation normal
 * DOWN - Failed to connect to host or CQL error
+* ERROR - Precondition failure, no request was sent
 * UNAUTHORISED - Wrong username or password - only if ``username`` is specified for cluster
 * TIMEOUT - Timeout
 
@@ -26,6 +27,7 @@ Available statuses are:
 
 * UP - Situation normal
 * DOWN - Failed to connect to host
+* ERROR - Precondition failure, no request was sent
 * HTTP XXX - HTTP failure and its status code
 * UNAUTHORISED - Missing or Incorrect :ref:`Authentication Token <configure-auth-token>` was used
 * TIMEOUT - Timeout
@@ -50,15 +52,15 @@ Example: status
 .. code-block:: none
 
    sctool status -c prod-cluster
-      Datacenter: eu-west
-      ╭────┬────────────┬───────────┬───────────┬───────────────┬──────────┬──────┬──────────┬────────┬──────────┬──────────────────────────────────────╮
-      │    │ Alternator │ CQL       │ REST      │ Address       │ Uptime   │ CPUs │ Memory   │ Scylla │ Agent    │ Host ID                              │
-      ├────┼────────────┼───────────┼───────────┼───────────────┼──────────┼──────┼──────────┼────────┼──────────┼──────────────────────────────────────┤
-      │ UN │ UP (4ms)   │ UP (3ms)  │ UP (2ms)  │ 34.203.122.52 │ 237h2m1s │ 4    │ 15.43GiB │ 4.1.0  │ 2.2.0    │ 8bfd18f1-ac3b-4694-bcba-30bc272554df │
-      │ UN │ UP (15ms)  │ UP (11ms) │ UP (12ms) │ 10.0.138.46   │ 237h2m1s │ 4    │ 15.43GiB │ 4.1.0  │ 2.2.0    │ 238acd01-813c-4c55-bd65-5219bb19bc20 │
-      │ UN │ UP (17ms)  │ UP (5ms)  │ UP (7ms)  │ 10.0.196.204  │ 237h2m1s │ 4    │ 15.43GiB │ 4.1.0  │ 2.2.0    │ bde4581a-b25e-49fc-8cd9-1651d7683f80 │
-      │ UN │ UP (10ms)  │ UP (4ms)  │ UP (5ms)  │ 10.0.66.115   │ 237h2m1s │ 4    │ 15.43GiB │ 4.1.0  │ 2.2.0    │ 918a52aa-cc42-43a4-a499-f7b1ccb53b18 │
-      ╰────┴────────────┴───────────┴───────────┴───────────────┴──────────┴──────┴──────────┴────────┴──────────┴──────────────────────────────────────╯
+   Datacenter: eu-west
+   ╭────┬────────────┬───────────┬───────────┬───────────────┬──────────┬──────┬──────────┬────────┬──────────┬──────────────────────────────────────╮
+   │    │ Alternator │ CQL       │ REST      │ Address       │ Uptime   │ CPUs │ Memory   │ Scylla │ Agent    │ Host ID                              │
+   ├────┼────────────┼───────────┼───────────┼───────────────┼──────────┼──────┼──────────┼────────┼──────────┼──────────────────────────────────────┤
+   │ UN │ UP (4ms)   │ UP (3ms)  │ UP (2ms)  │ 34.203.122.52 │ 237h2m1s │ 4    │ 15.43GiB │ 4.1.0  │ 2.2.0    │ 8bfd18f1-ac3b-4694-bcba-30bc272554df │
+   │ UN │ UP (15ms)  │ UP (11ms) │ UP (12ms) │ 10.0.138.46   │ 237h2m1s │ 4    │ 15.43GiB │ 4.1.0  │ 2.2.0    │ 238acd01-813c-4c55-bd65-5219bb19bc20 │
+   │ UN │ UP (17ms)  │ UP (5ms)  │ UP (7ms)  │ 10.0.196.204  │ 237h2m1s │ 4    │ 15.43GiB │ 4.1.0  │ 2.2.0    │ bde4581a-b25e-49fc-8cd9-1651d7683f80 │
+   │ UN │ UP (10ms)  │ UP (4ms)  │ UP (5ms)  │ 10.0.66.115   │ 237h2m1s │ 4    │ 15.43GiB │ 4.1.0  │ 2.2.0    │ 918a52aa-cc42-43a4-a499-f7b1ccb53b18 │
+   ╰────┴────────────┴───────────┴───────────┴───────────────┴──────────┴──────┴──────────┴────────┴──────────┴──────────────────────────────────────╯
 
 Dynamic Status Timeouts
 =======================

--- a/pkg/service/healthcheck/model.go
+++ b/pkg/service/healthcheck/model.go
@@ -11,6 +11,7 @@ const (
 	statusDown         = `DOWN`
 	statusTimeout      = `TIMEOUT`
 	statusUnauthorized = `UNAUTHORIZED`
+	statusError        = `ERROR`
 	statusHTTP         = `HTTP`
 )
 

--- a/pkg/service/healthcheck/model.go
+++ b/pkg/service/healthcheck/model.go
@@ -7,11 +7,12 @@ import (
 )
 
 const (
-	statusUp           = `UP`
-	statusDown         = `DOWN`
+	statusUp   = `UP`
+	statusDown = `DOWN`
+
+	statusError        = `ERROR`
 	statusTimeout      = `TIMEOUT`
 	statusUnauthorized = `UNAUTHORIZED`
-	statusError        = `ERROR`
 	statusHTTP         = `HTTP`
 )
 
@@ -24,10 +25,13 @@ type NodeStatus struct {
 	SSL              bool    `json:"ssl"`
 	AlternatorStatus string  `json:"alternator_status"`
 	AlternatorRtt    float64 `json:"alternator_rtt_ms"`
+	AlternatorCause  string  `json:"alternator_cause"`
 	CQLStatus        string  `json:"cql_status"`
 	CQLRtt           float64 `json:"cql_rtt_ms"`
+	CQLCause         string  `json:"cql_cause"`
 	RESTStatus       string  `json:"rest_status"`
 	RESTRtt          float64 `json:"rest_rtt_ms"`
+	RESTCause        string  `json:"rest_cause"`
 	TotalRAM         int64   `json:"total_ram"`
 	Uptime           int64   `json:"uptime"`
 	CPUCount         int64   `json:"cpu_count"`

--- a/swagger/gen/scylla-manager/models/cluster_status.go
+++ b/swagger/gen/scylla-manager/models/cluster_status.go
@@ -52,6 +52,9 @@ type ClusterStatusItems0 struct {
 	// agent version
 	AgentVersion string `json:"agent_version,omitempty"`
 
+	// alternator cause
+	AlternatorCause string `json:"alternator_cause,omitempty"`
+
 	// alternator rtt ms
 	AlternatorRttMs float32 `json:"alternator_rtt_ms,omitempty"`
 
@@ -60,6 +63,9 @@ type ClusterStatusItems0 struct {
 
 	// cpu count
 	CPUCount int64 `json:"cpu_count,omitempty"`
+
+	// cql cause
+	CqlCause string `json:"cql_cause,omitempty"`
 
 	// cql rtt ms
 	CqlRttMs float32 `json:"cql_rtt_ms,omitempty"`
@@ -75,6 +81,9 @@ type ClusterStatusItems0 struct {
 
 	// host id
 	HostID string `json:"host_id,omitempty"`
+
+	// rest cause
+	RestCause string `json:"rest_cause,omitempty"`
 
 	// rest rtt ms
 	RestRttMs float32 `json:"rest_rtt_ms,omitempty"`

--- a/swagger/scylla-manager.json
+++ b/swagger/scylla-manager.json
@@ -100,6 +100,9 @@
             "type": "number",
             "format": "float"
           },
+          "alternator_cause": {
+            "type": "string"
+          },
           "cql_status": {
             "type": "string"
           },
@@ -107,12 +110,18 @@
             "type": "number",
             "format": "float"
           },
+          "cql_cause": {
+            "type": "string"
+          },
           "rest_status": {
             "type": "string"
           },
           "rest_rtt_ms": {
             "type": "number",
             "format": "float"
+          },
+          "rest_cause": {
+            "type": "string"
           },
           "total_ram": {
             "type": "integer"

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -1,8 +1,9 @@
 all: help
 
-COMPOSE    = docker-compose
-CQLSH      = $(COMPOSE) exec scylla-manager-db cqlsh
-CQLSH_NODE = $(COMPOSE) exec dc1_node_1 cqlsh
+COMPOSE    := docker-compose
+CQLSH      := $(COMPOSE) exec scylla-manager-db cqlsh
+CQLSH_NODE := $(COMPOSE) exec dc1_node_1 cqlsh
+YQ         := ../bin/yq
 
 include .env
 
@@ -18,7 +19,7 @@ up:
 	@cd scylla/certs && ./generate.sh
 	@echo "==> Generating Scylla configuration"
 ifeq ($(SM_SSL_ENABLED),yes)
-	@yq merge -x scylla/config/scylla.yaml scylla/config/scylla-ssl.yaml > scylla/scylla.yaml
+	@$(YQ) merge -x scylla/config/scylla.yaml scylla/config/scylla-ssl.yaml > scylla/scylla.yaml
 	@cp scylla/config/cqlshrc-ssl scylla/cqlshrc
 else
 	@cp scylla/config/scylla.yaml scylla/scylla.yaml

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -17,7 +17,7 @@ up:
 	@echo "==> Generating encryption files"
 	@cd scylla/certs && ./generate.sh
 	@echo "==> Generating Scylla configuration"
-ifdef SSL_ENABLED
+ifeq ($(SM_SSL_ENABLED),yes)
 	@yq merge -x scylla/config/scylla.yaml scylla/config/scylla-ssl.yaml > scylla/scylla.yaml
 	@cp scylla/config/cqlshrc-ssl scylla/cqlshrc
 else

--- a/testing/scylla/config/scylla-ssl.yaml
+++ b/testing/scylla/config/scylla-ssl.yaml
@@ -1,7 +1,5 @@
 # Scylla SSL enabled configuration.
 
-# Disable default port access but leave option for debugging.
-native_transport_port: 9999
 native_transport_port_ssl: 9142
 client_encryption_options:
     enabled: true


### PR DESCRIPTION
This patchset fixes #2817 and extends `sctool status` command with ERROR status and error details describing the root cause of ERROR or DOWN status. Example

```
sctool status
  Cluster: test (85cd024b-fc9c-47d4-b577-4943cb78a27d)
  Datacenter: dc1
  ╭────┬────────────┬─────────────┬──────────┬────────────────┬──────────┬──────┬──────────┬────────┬──────────┬──────────────────────────────────────╮
  │    │ Alternator │ CQL         │ REST     │ Address        │ Uptime   │ CPUs │ Memory   │ Scylla │ Agent    │ Host ID                              │
  ├────┼────────────┼─────────────┼──────────┼────────────────┼──────────┼──────┼──────────┼────────┼──────────┼──────────────────────────────────────┤
  │ UN │ UP (3ms)   │ ERROR (0ms) │ UP (2ms) │ 192.168.100.11 │ 2h23m36s │ 4    │ 31.11GiB │ 4.2.1  │ Snapshot │ cff207fb-4f2e-43c9-b06f-e756ccd2ebb1 │
  │ UN │ UP (2ms)   │ ERROR (0ms) │ UP (6ms) │ 192.168.100.12 │ 2h23m36s │ 4    │ 31.11GiB │ 4.2.1  │ Snapshot │ 4ade9e51-cc75-4f28-bbae-f99c0c149762 │
  │ UN │ UP (2ms)   │ ERROR (0ms) │ UP (1ms) │ 192.168.100.13 │ 2h23m36s │ 4    │ 31.11GiB │ 4.2.1  │ Snapshot │ 5c5f64a1-53f5-4a19-a16b-4dcab0c661a9 │
  ╰────┴────────────┴─────────────┴──────────┴────────────────┴──────────┴──────┴──────────┴────────┴──────────┴──────────────────────────────────────╯
  Errors:
  - 192.168.100.11 CQL: fetch TLS config: get SSL user cert from secrets store: not found
  - 192.168.100.12 CQL: fetch TLS config: get SSL user cert from secrets store: not found
  - 192.168.100.13 CQL: fetch TLS config: get SSL user cert from secrets store: not found
```

As for the issue itself it seems to be working just fine in 2.4 if Scylla does not require client certificate.
If Scylla shall require client certificate and Scylla Manager would not have a client certificate it results in status DOWN which is somewhat expected.
With this patch the status becomes ERROR (for any init/prepare failure) and there is error description immediately available for clarity.