### PR TITLE
[2.4] healthcheck: fix deadlock during removal of lost nodes metrics (#2843)

### DIFF
--- a/pkg/service/healthcheck/metrics_test.go
+++ b/pkg/service/healthcheck/metrics_test.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2021 ScyllaDB
+
+package healthcheck
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/scylladb/scylla-manager/pkg/util/uuid"
+)
+
+// Removing of cluster metrics deadlocked when number of metrics exceeded buffered channel length
+// used for metric collection.
+// Issue #2843
+func TestRemoveClusterMetricsWhenNumberOfMetricsExceedsDefaultChannelLength_2843(t *testing.T) {
+	clusterID := uuid.MustRandom()
+	metric := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "scylla_manager",
+		Subsystem: "healthcheck",
+		Name:      "status",
+	}, []string{clusterKey, hostKey})
+	for i := 0; i < 3*10*metricBufferSize; i++ {
+		hl := prometheus.Labels{
+			clusterKey: clusterID.String(),
+			hostKey:    uuid.MustRandom().String(),
+		}
+		metric.With(hl).Set(1)
+	}
+	r := Runner{metrics: &runnerMetrics{
+		status:  metric,
+		rtt:     metric,
+		timeout: metric,
+	}}
+
+	r.removeMetricsForCluster(clusterID)
+}


### PR DESCRIPTION
When buffered channel used for collecting metrics was full,
goroutine trying to write to it was keeping read lock.
Reading side of this channel was deleting metrics which requires taking
a write lock on the same mutex. This resulted in deadlock.

Fixes #2843
