### PR TITLE
dist/Makefile:Fix tag creation during build

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,28 +1,23 @@
 RELEASE      := 0.$(shell date +%Y%m%d).$(shell git describe --always)
+VERSION	     ?= 2.6-dev
 
-ifeq "$(VERSION)" ""
-$(error Please specify VERSION e.g. VERSION=2.0)
+ifdef $$VERSION
+VERSION := $$VERSION
 endif
-
-TAG := $(shell git describe --tags)
 
 VERSION_NAME := $(VERSION)-$(RELEASE)
-
-ifneq "$(TAG)" ""
-$(shell git tag $(VERSION_NAME))
-else
-$(shell git tag -d $(VERSION_NAME))
-endif
+$(shell echo $(VERSION) > .version)
+$(shell echo $(RELEASE) > .release)
 
 GORELEASER := goreleaser --rm-dist
-
 .PHONY: release
 release:
+	git tag $(VERSION_NAME) || true
 	$(GORELEASER) --skip-publish --skip-validate
 
 .PHONY: snapshot
 snapshot:
-	$(GORELEASER) --snapshot
+	GORELEASER_CURRENT_TAG=$(VERSION_NAME) $(GORELEASER) --snapshot
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
In #2810 we started building manager using goreleaser tool.

Once merging i saw an error (also managed to repreduce it locally)
```
fatal: No tags can describe '0b9ff39c6cd145048f1a2f32bbfe15dd335c1001'.
Try --always, or create some tags.
error: tag '2.4-dev-0.20210823.0b9ff39c' not found.
goreleaser --rm-dist --skip-publish --skip-validate
   • releasing...
   • loading config file       file=.goreleaser.yaml
   • loading environment variables
   • getting and validating git state
   ⨯ release failed after 0.02s error=git doesn't contain any tags. Either add a tag or use --snapshot
make: *** [Makefile:21: release] Error 1
```

Looks like i missed this during debug with some other changes

Fixing it here

Related to scylladb/scylla-pkg#2308