### PR TITLE
add upgrade content

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,7 @@ Scylla Manager
    config/index
    swagger/index
    scylla-monitoring
+   upgrade/index
    troubleshooting
    older-versions
    Slack <https://scylladb-users.slack.com/archives/C01ERVBPWLU>
@@ -60,4 +61,5 @@ Scylla Manager Server has two connections with each Scylla node:
 Installation
 ============
 
-To proceed with installation go to :doc:`Install Scylla Manager <install-scylla-manager>`.
+* To proceed with a new installation go to :doc:`Install Scylla Manager <install-scylla-manager>`.
+* To upgrade an existing installation go to `Upgrade Guides <upgrade/index>`_.

--- a/docs/source/upgrade/index.rst
+++ b/docs/source/upgrade/index.rst
@@ -1,0 +1,22 @@
+=======================
+Upgrade Scylla Manager
+=======================
+
+.. toctree::
+   :hidden:
+   
+   Scylla Manager 2.x.a to Scylla Manager 2.y.b </upgrade/upgrade-guide-from-2.x.a-to-2.y.b/index>
+   Scylla Manager 2.2 to Scylla Manager 2.3 </upgrade/upgrade-guide-from-2.x.a-to-2.y.b/upgrade-2.x.a-to-2.y.b>
+   Scylla Manager 2.1 to Scylla Manager 2.2 </upgrade/upgrade-guide-from-2.x.a-to-2.y.b/upgrade-2.x.a-to-2.y.b>
+   Scylla Manager 2.0 to Scylla Manager 2.1 </upgrade/upgrade-guide-from-2.x.a-to-2.y.b/upgrade-2.x.a-to-2.y.b>
+   Scylla Manager 1.4 to Scylla Manager 2.0 </upgrade/upgrade-guide-from-1.4-to-2.0/index>
+   Scylla Manager 1.3 to Scylla Manager 1.4 </upgrade/upgrade-guide-from-1.3-to-1.4/index>
+   Scylla Manager 1.2 to Scylla Manager 1.3 </upgrade/upgrade-guide-from-1.2-to-1.3/index>
+   Scylla Manager 1.1 to Scylla Manager 1.2</upgrade/upgrade-guide-from-manager-1.1.x-to-1.2.x>
+   Scylla Manager 1.0 to Scylla Manager 1.1</upgrade/upgrade-guide-from-manager-1.0.x-to-1.1.x>
+   Scylla Manager 1.x Maintenance Release </upgrade/upgrade-guide-maintenance-1.x.y-to-1.x.z/index>
+
+You can use the provided upgrade guides to upgrade your existing version of Scylla Manager. This upgrade guide contains instructions for both the open source and Enterprise version.
+
+
+Choose an upgrade path from the left pane menu.

--- a/docs/source/upgrade/upgrade-guide-from-1.2-to-1.3/index.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.2-to-1.3/index.rst
@@ -1,0 +1,34 @@
+=================================
+Upgrade Scylla Manager 1.2 to 1.3
+=================================
+
+.. toctree::
+   :hidden:
+
+   Scylla Manager 1.2 to Scylla Manager 1.3 for Centos 7<upgrade-guide-from-manager-1.2.x-to-1.3.x-CentOS>
+   Scylla Manager 1.2 to Scylla Manager 1.3 for Ubuntu 16<upgrade-guide-from-manager-1.2.x-to-1.3.x-ubuntu>
+   Metrics Update - Scylla Manager 1.2 to 1.3 <manager-metric-update-1.2-to-1.3>
+
+.. raw:: html
+
+
+   <div class="panel callout radius animated">
+            <div class="row">
+              <div class="medium-3 columns">
+                <h5 id="getting-started">Upgrade Scylla Manager 1.2 to 1.3</h5>
+              </div>
+              <div class="medium-9 columns">
+
+Procedures for upgrading Scylla Manager from 1.2 to 1.3.
+
+* :doc:`Upgrade Guide - Scylla Manager 1.2.x to 1.3.x on CentOS 7<upgrade-guide-from-manager-1.2.x-to-1.3.x-CentOS>`
+
+* :doc:`Upgrade Guide - Scylla Manager 1.2.x to 1.3.x on Ubuntu 16<upgrade-guide-from-manager-1.2.x-to-1.3.x-ubuntu>`
+
+* :doc:`Scylla Manager Metrics Update - Scylla Manager 1.2 to 1.3<manager-metric-update-1.2-to-1.3>`
+
+.. raw:: html
+
+   </div>
+   </div>
+   </div>

--- a/docs/source/upgrade/upgrade-guide-from-1.2-to-1.3/manager-metric-update-1.2-to-1.3.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.2-to-1.3/manager-metric-update-1.2-to-1.3.rst
@@ -1,0 +1,32 @@
+========================================================
+Scylla Manager Metric Update - Scylla Manager 1.2 to 1.3
+========================================================
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+Scylla Manager 1.3 Dashboards are available for use with Scylla Monitoring Stack
+
+The following metrics are new in Scylla Manager 1.3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* `scylla_manager.healthcheck.cql_status` - This metric measures the CQL status and is used in the Scylla Manager Health Check. The metric is labeled with the cluster and host and reports the following values:
+
+  - `0` - not checked
+  - `1` - success
+  - `-1` - failure
+
+* `scylla_manager.healthcheck.cql_rtt_ms` - This metric measures the CQL latency and is used in the Scylla Manager Health Check. The metric is labeled with the cluster and host and reports the latency in milliseconds. 
+
+The following metric was updated from Scylla Manager 1.2 to Scylla Manager 1.3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* `scylla_manager.repair.progress` now aggregates progress in percentage and has the following additional labels:
+ 
+  - cluster
+  - task
+  - keyspace 
+  - host
+
+Previously, this metric reported the aggregated keyspace and host progress. Now it reports the aggregated keyspace progress and aggregated total progress. This is implemented by leaving appropriate labels blank. In the total progress metric the only set label is `cluster` and `task`.
+

--- a/docs/source/upgrade/upgrade-guide-from-1.2-to-1.3/upgrade-guide-from-manager-1.2.x-to-1.3.x-CentOS.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.2-to-1.3/upgrade-guide-from-manager-1.2.x-to-1.3.x-CentOS.rst
@@ -1,0 +1,179 @@
+
+
+========================================================
+Upgrade Guide - Scylla Manager 1.2.x to 1.3.x on CentOS
+========================================================
+
+Enterprise customers who use Scylla Manager 1.2.x are encouraged to upgrade to 1.3.x.
+For new installations please see `Scylla Manager - Download and Install <https://www.scylladb.com/enterprise-download/#manager>`_.
+The steps below instruct you how to upgrade the Scylla Manager server while keeping the manager datastore intact.
+If you are not running Scylla Manager 1.2.x, do not perform this upgrade procedure. This procedure only covers upgrades from Scylla Manager 1.2.x to 1.3.x.
+
+Please contact `Scylla Enterprise Support <https://www.scylladb.com/product/support/>`_ team with any questions.
+
+Upgrade Notes
+=================
+
+* This upgrade brings to sctool a new command: ``status``. This command shows a listing of the individual nodes in the cluster and records the CQL availability on the nodes.
+
+* Health Check - This upgrade introduces a new feature where each node is monitored by Scylla Manager. When Scylla Manager detects that a node is down an alert message is sent to Scylla Monitoring. Alternitively, you can use the ``sctool status``` command to show the live cluster status. 
+
+* Automated health check - When a cluster is added a new health check task is automatically added to the cluster. Following an upgrade, all existing clusters will have an health check task as well. 
+
+* The sctool argument ``interval-days`` has been renamed to ``interval`` as it now supports more granular time units. For example: ``3d2h10m``. The available time units are ``d``, ``h``, ``m``, and ``s``.
+
+* The sctool command ``cluster list`` no longer displays the **host** column in the results table. This was removed because it was easy to be mislead that this node was the only node being used. Adding a cluster (``cluster add``) still takes a ``--host`` argument, but when all the available nodes are discovered they are persisted and used for subsequent interactions with ScyllaDB.
+
+
+
+Upgrade Procedure
+=================
+
+* Backup the data
+* Download and install new packages
+* Validate that the upgrade was successful
+
+Backup the Scylla Manager data
+-------------------------------
+Scylla Manager server persists its data to a Scylla cluster (data store). Before upgrading, backup the ``scylla_manager`` keyspace from Scylla Manager's backend, following this `backup procedure </operating-scylla/procedures/backup-restore/backup/>`_.
+
+Download and install the new release
+------------------------------------
+
+.. _upgrade-manager-1.2.x-to-1.3.x-previous-release:
+
+Before upgrading, check what version you are currently running now using ``rpm -q scylla-manager``. You should use the same version that you had previously installed in case you want to :ref:`rollback <upgrade-manager-1.2.x-to-1.3.x-rollback-procedure-centos>` the upgrade.
+
+
+To upgrade:
+
+
+1. Update the `Update the Scylla Manager repo: <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.3.x**
+
+2. Run:
+
+.. code:: sh
+
+   sudo yum update scylla-manager -y
+
+3. Reload your shell execute the below command to reload ``sctool`` code completion.
+
+.. code:: sh
+
+   source /etc/bash_completion.d/sctool.bash
+
+
+Validate
+--------
+1. Check that Scylla Manager service is running with ``sudo systemctl status scylla-manager.service``. Confirm the service is active (running). If not, then start it with ``systemctl start scylla-manager.service``.
+2. Confirm that the upgrade changed the Client and Server version. Run ``sctool version`` and make sure both are 1.3.x version. For example:
+
+.. code-block:: none
+
+   sctool version
+   Client version: 1.3.0-0.20181130.03ae248
+   Server version: 1.3.0-0.20181130.03ae248
+
+3. Confirm that following the update, that your managed clusters are still present. Run ``sctool cluster list``
+
+.. code-block:: none
+  
+   sctool cluster list
+   ╭──────────────────────────────────────┬──────────┬───────────────╮
+   │ cluster id                           │ name     │ssh user       │
+   ├──────────────────────────────────────┼──────────┼───────────────┤
+   │ db7faf98-7cc4-4a08-b707-2bc59d65551e │ cluster  │scylla-manager │
+   ╰──────────────────────────────────────┴──────────┴───────────────╯
+
+4. Confirm that following the upgrade, there is a healtcheck task for each existing cluster. Run ``sctool task list`` to list the tasks.
+
+
+.. code-block:: none
+
+
+   sctool task list -c cluster --all
+   ╭──────────────────────────────────────────────────┬───────────────────────────────┬──────┬────────────┬────────╮
+   │ task                                             │ next run                      │ ret. │ properties │ status │
+   ├──────────────────────────────────────────────────┼───────────────────────────────┼──────┼────────────┼────────┤
+   │ healthcheck/afe9a610-e4c7-4d05-860e-5a0ddf14d7aa │ 10 Dec 18 20:21 UTC (+15s)    │ 0    │            │ RUNNING│
+   │ repair/4d79ee63-7721-4105-8c6a-5b98c65c3e21      │ 12 Dec 18 00:00 UTC (+7d)     │ 3    │            │ NEW    │
+   ╰──────────────────────────────────────────────────┴───────────────────────────────┴──────┴────────────┴────────╯
+
+.. _upgrade-manager-1.2.x-to-1.3.x-rollback-procedure-centos:
+
+Rollback Procedure
+==================
+
+The following procedure describes a rollback from Scylla Manager 1.3 to 1.2. Apply this procedure if an upgrade from 1.2 to 1.3 failed for any reason.
+
+**Warning:** note that you may lose the manged clusters after downgrade. Should this happen, you will need to add the managed clusters clusters manually.
+
+* Downgrade to :ref:`previous release <upgrade-manager-1.2.x-to-1.3.x-previous-release>`
+* Start Scylla Manager
+* Valdate Scylla Manager version
+
+Downgrade to previous release
+-----------------------------
+1. Stop Scylla Manager
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+2. Drop the ``scylla_manager`` keyspace from the remote datastore
+
+.. code:: sh
+
+   cqlsh -e "DROP KEYSPACE scylla_manager"
+
+3. Remove Scylla Manager repo
+
+.. code:: sh
+
+   sudo rm -rf /etc/yum.repos.d/scylla-manager.repo
+   sudo yum clean all
+   sudo rm -rf /var/cache/yum
+
+4. Update the `Scylla Manager repo <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.2.x**
+
+5. Install previous version
+
+.. code:: sh
+
+   sudo yum downgrade scylla-manager scylla-manager-server scylla-manager-client -y
+
+Rollback the Scylla Manager database
+------------------------------------
+
+1. Start Scylla Manager to reinitialize the data base schema.
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+2. Stop Scylla Manager to avoid issues while restoring the backup. If you did not perform any backup before upgrading then you are done now and can continue at "Start Scylla Manager".
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+3. Restore the database backup if you performed a backup by following the instructions in `Restore from a Backup </operating-scylla/procedures/backup-restore/restore/>`_.
+   You can skip step 1 since the Scylla Manager has done this for you.
+
+Start Scylla Manager
+--------------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+Validate Scylla Manager Version
+-------------------------------
+
+Validate Scylla Manager version:
+
+.. code:: sh
+
+   sctool version
+
+The version should match with the results you had :ref:`previously <upgrade-manager-1.2.x-to-1.3.x-previous-release>`.

--- a/docs/source/upgrade/upgrade-guide-from-1.2-to-1.3/upgrade-guide-from-manager-1.2.x-to-1.3.x-ubuntu.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.2-to-1.3/upgrade-guide-from-manager-1.2.x-to-1.3.x-ubuntu.rst
@@ -1,0 +1,188 @@
+
+
+==========================================================
+upgrade guide - Scylla Manager 1.2.x to 1.3.x on Ubuntu 16
+==========================================================
+
+Enterprise customers who use Scylla Manager 1.2.x are encouraged to upgrade to 1.3.x.
+For new installations please see `Scylla Manager - Download and Install <https://www.scylladb.com/enterprise-download/#manager>`_.
+The steps below instruct you how to upgrade the Scylla Manager server while keeping the manager datastore intact.
+If you are not running Scylla Manager 1.2.x, do not perform this upgrade procedure. This procedure only covers upgrades from Scylla Manager 1.2.x to 1.3.x.
+
+Please contact `Scylla Enterprise Support <https://www.scylladb.com/product/support/>`_ team with any questions.
+
+Upgrade Notes
+=================
+
+* This upgrade brings to sctool a new command: ``status``. This command shows a listing of the individual nodes in the cluster and records the CQL availability on the nodes.
+
+* Health Check - This upgrade introduces a new feature where each node is monitored by Scylla Manager. When Scylla Manager detects that a node is down an alert message is sent to Scylla Monitoring. Alternitively, you can use the ``sctool status``` command to show the live cluster status. 
+
+* Automated health check - When a cluster is added a new health check task is automatically added to the cluster. Following an upgrade, all existing clusters will have an health check task as well. 
+
+* The sctool argument ``interval-days`` has been renamed to ``interval`` as it now supports more granular time units. For example: ``3d2h10m``. The available time units are ``d``, ``h``, ``m``, and ``s``.
+
+* The sctool command ``cluster list`` no longer displays the **host** column in the results table. This was removed because it was easy to be mislead that this node was the only node being used. Adding a cluster (``cluster add``) still takes a ``--host`` argument, but when all the available nodes are discovered they are persisted and used for subsequent interactions with ScyllaDB.
+
+
+
+Upgrade Procedure
+=================
+
+* Backup the data
+* Download and install new packages
+* Validate that the upgrade was successful
+
+Backup the Scylla Manager data
+-------------------------------
+Scylla Manager server persists its data to a Scylla cluster (data store). Before upgrading, backup the ``scylla_manager`` keyspace from Scylla Manager's backend, following this `backup procedure </operating-scylla/procedures/backup-restore/backup/>`_.
+
+Download and install the new release
+------------------------------------
+
+.. _upgrade-manager-1.2.x-to-1.3.x-previous-release:
+
+Before upgrading, check what version you are currently running now using ``rpm -q scylla-manager``. You should use the same version that you had previously installed in case you want to :ref:`rollback <upgrade-manager-1.2.x-to-1.3.x-rollback-procedure-ubuntu>` the upgrade.
+
+
+To upgrade:
+
+
+1. Update the `Update the Scylla Manager repo: <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.3.x**
+
+2. Run:
+
+.. code:: sh
+
+   sudo apt-get update
+   sudo apt-get dist-upgrade scylla-manager*
+
+3. Restart the service
+
+.. code:: sh
+
+   sudo systemctl restart scylla-manager.service
+
+
+4. Reload your shell execute the below command to reload ``sctool`` code completion.
+
+.. code:: sh
+
+   source /etc/bash_completion.d/sctool.bash
+
+
+Validate
+--------
+1. Check that Scylla Manager service is running with ``sudo systemctl status scylla-manager.service``. Confirm the service is active (running). If not, then start it with ``systemctl start scylla-manager.service``.
+2. Confirm that the upgrade changed the Client and Server version. Run ``sctool version`` and make sure both are 1.3.x version. For example:
+
+.. code-block:: none
+
+   sctool version
+   Client version: 1.3.0-0.20181130.03ae248
+   Server version: 1.3.0-0.20181130.03ae248
+
+3. Confirm that following the update, that your managed clusters are still present. Run ``sctool cluster list``
+
+.. code-block:: none
+  
+   sctool cluster list
+   ╭──────────────────────────────────────┬──────────┬───────────────╮
+   │ cluster id                           │ name     │ssh user       │
+   ├──────────────────────────────────────┼──────────┼───────────────┤
+   │ db7faf98-7cc4-4a08-b707-2bc59d65551e │ cluster  │scylla-manager │
+   ╰──────────────────────────────────────┴──────────┴───────────────╯
+
+4. Confirm that following the upgrade, there is a healtcheck task for each existing cluster. Run ``sctool task list`` to list the tasks.
+
+
+.. code-block:: none
+
+
+   sctool task list -c cluster --all
+   ╭──────────────────────────────────────────────────┬───────────────────────────────┬──────┬────────────┬────────╮
+   │ task                                             │ next run                      │ ret. │ properties │ status │
+   ├──────────────────────────────────────────────────┼───────────────────────────────┼──────┼────────────┼────────┤
+   │ healthcheck/afe9a610-e4c7-4d05-860e-5a0ddf14d7aa │ 10 Dec 18 20:21 UTC (+15s)    │ 0    │            │ RUNNING│
+   │ repair/4d79ee63-7721-4105-8c6a-5b98c65c3e21      │ 12 Dec 18 00:00 UTC (+7d)     │ 3    │            │ NEW    │
+   ╰──────────────────────────────────────────────────┴───────────────────────────────┴──────┴────────────┴────────╯
+
+.. _upgrade-manager-1.2.x-to-1.3.x-rollback-procedure-ubuntu:
+
+Rollback Procedure
+==================
+
+The following procedure describes a rollback from Scylla Manager 1.3 to 1.2. Apply this procedure if an upgrade from 1.2 to 1.3 failed for any reason.
+
+**Warning:** note that you may lose the manged clusters after downgrade. Should this happen, you will need to add the managed clusters clusters manually.
+
+* Downgrade to :ref:`previous release <upgrade-manager-1.2.x-to-1.3.x-previous-release>`
+* Start Scylla Manager
+* Valdate Scylla Manager version
+
+Downgrade to previous release
+-----------------------------
+1. Stop Scylla Manager
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+2. Drop the ``scylla_manager`` keyspace from the remote datastore
+
+.. code:: sh
+
+   cqlsh -e "DROP KEYSPACE scylla_manager"
+
+3. Remove Scylla Manager repo
+
+.. code:: sh
+
+   sudo rm -rf /etc/apt/sources.list.d/scylla-manager.list
+
+4. Update the `Scylla Manager repo <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.2.x**
+
+5. Install previous version
+
+.. code:: sh
+
+   sudo apt-get update
+   sudo apt-get remove scylla-manager\* -y
+   sudo apt-get install scylla-manager scylla-manager-server scylla-manager-client
+   sudo systemctl unmask scylla-manager.service
+
+Rollback the Scylla Manager database
+------------------------------------
+
+1. Start Scylla Manager to reinitialize the data base schema.
+
+.. code:: sh
+          
+   sudo systemctl start scylla-manager
+
+2. Stop Scylla Manager to avoid issues while restoring the backup. If you did not perform any backup before upgrading then you are done now and can continue at "Start Scylla Manager".
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+3. Restore the database backup if you performed a backup by following the instructions in `Restore from a Backup </operating-scylla/procedures/backup-restore/restore/>`_.
+   You can skip step 1 since the Scylla Manager has done this for you.
+
+Start Scylla Manager
+--------------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+Validate Scylla Manager Version
+-------------------------------
+
+Validate Scylla Manager version:
+
+.. code:: sh
+
+   sctool version
+
+The version should match with the results you had :ref:`previously <upgrade-manager-1.2.x-to-1.3.x-previous-release>`.

--- a/docs/source/upgrade/upgrade-guide-from-1.3-to-1.4/index.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.3-to-1.4/index.rst
@@ -1,0 +1,34 @@
+=================================
+Upgrade Scylla Manager 1.3 to 1.4
+=================================
+
+.. toctree::
+   :hidden:
+
+   Scylla Manager 1.3 to Scylla Manager 1.4 for Centos 7<upgrade-guide-from-manager-1.3.x-to-1.4.x-CentOS>
+   Scylla Manager 1.3 to Scylla Manager 1.4 for Ubuntu 16<upgrade-guide-from-manager-1.3.x-to-1.4.x-ubuntu>
+   Metrics Update - Scylla Manager 1.3 to 1.4 <manager-metric-update-1.3-to-1.4>
+
+.. raw:: html
+
+
+   <div class="panel callout radius animated">
+            <div class="row">
+              <div class="medium-4 columns">
+                <h5 id="getting-started">Upgrade Scylla Manager 1.3 to 1.4</h5>
+              </div>
+              <div class="medium-9 columns">
+
+Procedures for upgrading Scylla Manager from 1.3 to 1.4.
+
+* :doc:`Upgrade Guide - Scylla Manager 1.3.x to 1.4.x on CentOS 7<upgrade-guide-from-manager-1.3.x-to-1.4.x-CentOS>`
+
+* :doc:`Upgrade Guide - Scylla Manager 1.3.x to 1.4.x on Ubuntu 16<upgrade-guide-from-manager-1.3.x-to-1.4.x-ubuntu>`
+
+* :doc:`Scylla Manager Metrics Update - Scylla Manager 1.3 to 1.4<manager-metric-update-1.3-to-1.4>`
+
+.. raw:: html
+
+   </div>
+   </div>
+   </div>

--- a/docs/source/upgrade/upgrade-guide-from-1.3-to-1.4/manager-metric-update-1.3-to-1.4.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.3-to-1.4/manager-metric-update-1.3-to-1.4.rst
@@ -1,0 +1,21 @@
+========================================================
+Scylla Manager Metric Update - Scylla Manager 1.3 to 1.4
+========================================================
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+Scylla Manager 1.4 Dashboards are available for use with Scylla Monitoring Stack
+
+The following metrics are new in Scylla Manager 1.4
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* `scylla_manager_healthcheck_rest_status` - This metric measures the CQL status and is used in the Scylla Manager Health Check. The metric is labeled with the cluster and host and reports the following values:
+
+  - `0` - not checked
+  - `1` - success
+  - `-1` - failure
+
+* `scylla_manager_healthcheck_rest_rtt_ms` - This metric measures the CQL latency and is used in the Scylla Manager Health Check. The metric is labeled with the cluster and host and reports the latency in milliseconds. 
+
+

--- a/docs/source/upgrade/upgrade-guide-from-1.3-to-1.4/upgrade-guide-from-manager-1.3.x-to-1.4.x-CentOS.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.3-to-1.4/upgrade-guide-from-manager-1.3.x-to-1.4.x-CentOS.rst
@@ -1,0 +1,181 @@
+
+
+========================================================
+Upgrade Guide - Scylla Manager 1.3.x to 1.4.x on CentOS
+========================================================
+
+Enterprise customers who use Scylla Manager 1.3.x are encouraged to upgrade to 1.4.x.
+For new installations please see `Scylla Manager - Download and Install <https://www.scylladb.com/enterprise-download/#manager>`_.
+The steps below instruct you how to upgrade the Scylla Manager server while keeping the manager datastore intact.
+If you are not running Scylla Manager 1.3.x, do not perform this upgrade procedure. This procedure only covers upgrades from Scylla Manager 1.3.x to 1.4.x.
+
+Please contact `Scylla Enterprise Support <https://www.scylladb.com/product/support/>`_ team with any questions.
+
+Upgrade Notes
+=================
+
+* This upgrade brings to sctool a new command: ``status``. This command shows a listing of the individual nodes in the cluster and records the CQL availability on the nodes.
+
+* Health Check - This upgrade introduces a new feature where each node is monitored by Scylla Manager. When Scylla Manager detects that a node is down an alert message is sent to Scylla Monitoring. Alternitively, you can use the ``sctool status``` command to show the live cluster status. 
+
+* Automated health check - When a cluster is added a new health check task is automatically added to the cluster. Following an upgrade, all existing clusters will have an health check task as well. 
+
+* The sctool argument ``interval-days`` has been renamed to ``interval`` as it now supports more granular time units. For example: ``3d2h10m``. The available time units are ``d``, ``h``, ``m``, and ``s``.
+
+* The sctool command ``cluster list`` no longer displays the **host** column in the results table. This was removed because it was easy to be mislead that this node was the only node being used. Adding a cluster (``cluster add``) still takes a ``--host`` argument, but when all the available nodes are discovered they are persisted and used for subsequent interactions with ScyllaDB.
+
+
+
+Upgrade Procedure
+=================
+
+* Backup the data
+* Download and install new packages
+* Validate that the upgrade was successful
+
+Backup the Scylla Manager data
+-------------------------------
+Scylla Manager server persists its data to a Scylla cluster (data store). Before upgrading, backup the ``scylla_manager`` keyspace from Scylla Manager's backend, following this `backup procedure </procedures/backup/>`_.
+
+Download and install the new release
+------------------------------------
+
+.. _upgrade-manager-1.3.x-to-1.4.x-previous-release:
+
+Before upgrading, check what version you are currently running now using ``rpm -q scylla-manager``. You should use the same version that you had previously installed in case you want to :ref:`rollback <upgrade-manager-1.3.x-to-1.4.x-rollback-procedure-centos>` the upgrade.
+
+
+To upgrade:
+
+
+1. Update the `Update the Scylla Manager repo: <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.4.x**
+
+2. Run:
+
+.. code:: sh
+
+   sudo yum update scylla-manager -y
+
+3. Reload your shell execute the below command to reload ``sctool`` code completion.
+
+.. code:: sh
+
+   source /etc/bash_completion.d/sctool.bash
+
+
+Validate
+--------
+1. Check that Scylla Manager service is running with ``sudo systemctl status scylla-manager.service``. Confirm the service is active (running). If not, then start it with ``systemctl start scylla-manager.service``.
+2. Confirm that the upgrade changed the Client and Server version. Run ``sctool version`` and make sure both are 1.3.x version. For example:
+
+.. code-block:: none
+
+   sctool version
+   Client version: 1.4-0.20190324.247a5585
+   Server version: 1.4-0.20190324.247a5585
+
+
+3. Confirm that following the update, that your managed clusters are still present. Run ``sctool cluster list``
+
+.. code-block:: none
+  
+   sctool cluster list
+   ╭──────────────────────────────────────┬──────────┬───────────────╮
+   │ cluster id                           │ name     │ssh user       │
+   ├──────────────────────────────────────┼──────────┼───────────────┤
+   │ db7faf98-7cc4-4a08-b707-2bc59d65551e │ cluster  │scylla-manager │
+   ╰──────────────────────────────────────┴──────────┴───────────────╯
+
+4. Confirm that following the upgrade, there is a healtcheck task for each existing cluster. Run ``sctool task list`` to list the tasks.
+
+
+.. code-block:: none
+
+
+   sctool task list -c cluster 
+   ╭──────────────────────────────────────────────────────┬───────────────────────────────┬──────┬────────────┬────────╮
+   │ task                                                 │ next run                      │ ret. │ arguments  │ status │
+   ├──────────────────────────────────────────────────────┼───────────────────────────────┼──────┼────────────┼────────┤
+   │ healthcheck/afe9a610-e4c7-4d05-860e-5a0ddf14d7aa     │ 01 May 19 20:31 UTC (+15s)    │ 0    │            │ RUNNING│
+   │ healthcheck_api/597f237f-103d-4994-8167-3ff591150b7e │ 01 May 19 21:31:01 UTC (+1h)  │ 0    │            │ NEW    │
+   │ repair/4d79ee63-7721-4105-8c6a-5b98c65c3e21          │ 01 May 19 00:00 UTC (+7d)     │ 3    │            │ NEW    │
+   ╰──────────────────────────────────────────────────────┴───────────────────────────────┴──────┴────────────┴────────╯
+
+.. _upgrade-manager-1.3.x-to-1.4.x-rollback-procedure-centos:
+
+Rollback Procedure
+==================
+
+The following procedure describes a rollback from Scylla Manager 1.4 to 1.3. Apply this procedure if an upgrade from 1.3 to 1.4 failed for any reason.
+
+**Warning:** note that you may lose the manged clusters after downgrade. Should this happen, you will need to add the managed clusters clusters manually.
+
+* Downgrade to :ref:`previous release <upgrade-manager-1.3.x-to-1.4.x-previous-release>`
+* Start Scylla Manager
+* Valdate Scylla Manager version
+
+Downgrade to previous release
+-----------------------------
+1. Stop Scylla Manager
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+2. Drop the ``scylla_manager`` keyspace from the remote datastore
+
+.. code:: sh
+
+   cqlsh -e "DROP KEYSPACE scylla_manager"
+
+3. Remove Scylla Manager repo
+
+.. code:: sh
+
+   sudo rm -rf /etc/yum.repos.d/scylla-manager.repo
+   sudo yum clean all
+   sudo rm -rf /var/cache/yum
+
+4. Update the `Scylla Manager repo <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.3.x**
+
+5. Install previous version
+
+.. code:: sh
+
+   sudo yum downgrade scylla-manager scylla-manager-server scylla-manager-client -y
+
+Rollback the Scylla Manager database
+------------------------------------
+
+1. Start Scylla Manager to reinitialize the data base schema.
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+2. Stop Scylla Manager to avoid issues while restoring the backup. If you did not perform any backup before upgrading then you are done now and can continue at "Start Scylla Manager".
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+3. Restore the database backup if you performed a backup by following the instructions in `Restore from a Backup </procedures/restore/>`_
+   You can skip step 1 since the Scylla Manager has done this for you.
+
+Start Scylla Manager
+--------------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+Validate Scylla Manager Version
+-------------------------------
+
+Validate Scylla Manager version:
+
+.. code:: sh
+
+   sctool version
+
+The version should match with the results you had :ref:`previously <upgrade-manager-1.3.x-to-1.4.x-previous-release>`.

--- a/docs/source/upgrade/upgrade-guide-from-1.3-to-1.4/upgrade-guide-from-manager-1.3.x-to-1.4.x-ubuntu.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.3-to-1.4/upgrade-guide-from-manager-1.3.x-to-1.4.x-ubuntu.rst
@@ -1,0 +1,189 @@
+
+
+==========================================================
+upgrade guide - Scylla Manager 1.3.x to 1.4.x on Ubuntu 16
+==========================================================
+
+Enterprise customers who use Scylla Manager 1.3.x are encouraged to upgrade to 1.4.x.
+For new installations please see `Scylla Manager - Download and Install <https://www.scylladb.com/enterprise-download/#manager>`_.
+The steps below instruct you how to upgrade the Scylla Manager server while keeping the manager datastore intact.
+If you are not running Scylla Manager 1.3.x, do not perform this upgrade procedure. This procedure only covers upgrades from Scylla Manager 1.3.x to 1.4.x.
+
+Please contact `Scylla Enterprise Support <https://www.scylladb.com/product/support/>`_ team with any questions.
+
+Upgrade Notes
+=================
+
+* This upgrade brings to sctool a new command: ``status``. This command shows a listing of the individual nodes in the cluster and records the CQL availability on the nodes.
+
+* Health Check - This upgrade introduces a new feature where each node is monitored by Scylla Manager. When Scylla Manager detects that a node is down an alert message is sent to Scylla Monitoring. Alternitively, you can use the ``sctool status``` command to show the live cluster status. 
+
+* Automated health check - When a cluster is added a new health check task is automatically added to the cluster. Following an upgrade, all existing clusters will have an health check task as well. 
+
+* The sctool argument ``interval-days`` has been renamed to ``interval`` as it now supports more granular time units. For example: ``3d2h10m``. The available time units are ``d``, ``h``, ``m``, and ``s``.
+
+* The sctool command ``cluster list`` no longer displays the **host** column in the results table. This was removed because it was easy to be mislead that this node was the only node being used. Adding a cluster (``cluster add``) still takes a ``--host`` argument, but when all the available nodes are discovered they are persisted and used for subsequent interactions with ScyllaDB.
+
+
+
+Upgrade Procedure
+=================
+
+* Backup the data
+* Download and install new packages
+* Validate that the upgrade was successful
+
+Backup the Scylla Manager data
+-------------------------------
+Scylla Manager server persists its data to a Scylla cluster (data store). Before upgrading, backup the ``scylla_manager`` keyspace from Scylla Manager's backend, following this `backup procedure </procedures/backup/>`_.
+
+Download and install the new release
+------------------------------------
+
+.. _upgrade-manager-1.3.x-to-1.4.x-previous-release:
+
+Before upgrading, check what version you are currently running now using ``rpm -q scylla-manager``. You should use the same version that you had previously installed in case you want to :ref:`rollback <upgrade-manager-1.3.x-to-1.4.x-rollback-procedure-ubuntu>` the upgrade.
+
+
+To upgrade:
+
+
+1. Update the `Update the Scylla Manager repo: <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.4.x**
+
+2. Run:
+
+.. code:: sh
+
+   sudo apt-get update
+   sudo apt-get dist-upgrade scylla-manager*
+
+3. Restart the service
+
+.. code:: sh
+
+   sudo systemctl restart scylla-manager.service
+
+
+4. Reload your shell execute the below command to reload ``sctool`` code completion.
+
+.. code:: sh
+
+   source /etc/bash_completion.d/sctool.bash
+
+
+Validate
+--------
+1. Check that Scylla Manager service is running with ``sudo systemctl status scylla-manager.service``. Confirm the service is active (running). If not, then start it with ``systemctl start scylla-manager.service``.
+2. Confirm that the upgrade changed the Client and Server version. Run ``sctool version`` and make sure both are 1.4.x version. For example:
+
+.. code-block:: none
+
+   sctool version
+   Client version: 1.4.0-0.20181130.03ae248
+   Server version: 1.4.0-0.20181130.03ae248
+
+3. Confirm that following the update, that your managed clusters are still present. Run ``sctool cluster list``
+
+.. code-block:: none
+  
+   sctool cluster list
+   ╭──────────────────────────────────────┬──────────┬───────────────╮
+   │ cluster id                           │ name     │ssh user       │
+   ├──────────────────────────────────────┼──────────┼───────────────┤
+   │ db7faf98-7cc4-4a08-b707-2bc59d65551e │ cluster  │scylla-manager │
+   ╰──────────────────────────────────────┴──────────┴───────────────╯
+
+4. Confirm that following the upgrade, there is a healtcheck task for each existing cluster. Run ``sctool task list`` to list the tasks.
+
+
+.. code-block:: none
+
+
+   sctool task list -c cluster
+   ╭──────────────────────────────────────────────────────┬───────────────────────────────┬──────┬────────────┬────────╮
+   │ task                                                 │ next run                      │ ret. │ arguments  │ status │
+   ├──────────────────────────────────────────────────────┼───────────────────────────────┼──────┼────────────┼────────┤
+   │ healthcheck/afe9a610-e4c7-4d05-860e-5a0ddf14d7aa     │ 01 May 19 20:31 UTC (+15s)    │ 0    │            │ RUNNING│
+   │ healthcheck_api/597f237f-103d-4994-8167-3ff591150b7e │ 01 May 19 21:31:01 UTC (+1h)  │ 0    │            │ NEW    │
+   │ repair/4d79ee63-7721-4105-8c6a-5b98c65c3e21          │ 01 May 19 00:00 UTC (+7d)     │ 3    │            │ NEW    │
+   ╰──────────────────────────────────────────────────────┴───────────────────────────────┴──────┴────────────┴────────╯
+
+.. _upgrade-manager-1.3.x-to-1.4.x-rollback-procedure-ubuntu:
+
+Rollback Procedure
+==================
+
+The following procedure describes a rollback from Scylla Manager 1.4 to 1.3. Apply this procedure if an upgrade from 1.3 to 1.4 failed for any reason.
+
+**Warning:** note that you may lose the manged clusters after downgrade. Should this happen, you will need to add the managed clusters clusters manually.
+
+* Downgrade to :ref:`previous release <upgrade-manager-1.3.x-to-1.4.x-previous-release>`
+* Start Scylla Manager
+* Valdate Scylla Manager version
+
+Downgrade to previous release
+-----------------------------
+1. Stop Scylla Manager
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+2. Drop the ``scylla_manager`` keyspace from the remote datastore
+
+.. code:: sh
+
+   cqlsh -e "DROP KEYSPACE scylla_manager"
+
+3. Remove Scylla Manager repo
+
+.. code:: sh
+
+   sudo rm -rf /etc/apt/sources.list.d/scylla-manager.list
+
+4. Update the `Scylla Manager repo <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.3.x**
+
+5. Install previous version
+
+.. code:: sh
+
+   sudo apt-get update
+   sudo apt-get remove scylla-manager\* -y
+   sudo apt-get install scylla-manager scylla-manager-server scylla-manager-client
+   sudo systemctl unmask scylla-manager.service
+
+Rollback the Scylla Manager database
+------------------------------------
+
+1. Start Scylla Manager to reinitialize the data base schema.
+
+.. code:: sh
+          
+   sudo systemctl start scylla-manager
+
+2. Stop Scylla Manager to avoid issues while restoring the backup. If you did not perform any backup before upgrading then you are done now and can continue at "Start Scylla Manager".
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+3. Restore the database backup if you performed a backup by following the instructions in `Restore from a Backup </procedures/restore/>`_
+   You can skip step 1 since the Scylla Manager has done this for you.
+
+Start Scylla Manager
+--------------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+Validate Scylla Manager Version
+-------------------------------
+
+Validate Scylla Manager version:
+
+.. code:: sh
+
+   sctool version
+
+The version should match with the results you had :ref:`previously <upgrade-manager-1.3.x-to-1.4.x-previous-release>`.

--- a/docs/source/upgrade/upgrade-guide-from-1.4-to-2.0/index.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.4-to-2.0/index.rst
@@ -1,0 +1,31 @@
+=================================
+Upgrade Scylla Manager 1.4 to 2.0
+=================================
+
+.. toctree::
+   :hidden:
+
+   Scylla Manager 1.4 to Scylla Manager 2.0 <upgrade-guide-from-manager-1.4.x-to-2.0.x>
+   Metrics Update - Scylla Manager 1.4 to 2.0 <manager-metric-update-1.4-to-2.0>
+
+.. raw:: html
+
+
+   <div class="panel callout radius animated">
+            <div class="row">
+              <div class="medium-4 columns">
+                <h5 id="getting-started">Upgrade Scylla Manager 1.4 to 2.0</h5>
+              </div>
+              <div class="medium-9 columns">
+
+Procedures for upgrading Scylla Manager from 1.4 to 2.0.
+
+* :doc:`Upgrade Guide - Scylla Manager 1.4.x to 2.0.x on CentOS 7, RHEL 7, Ubuntu 16, and Debian 9 <upgrade-guide-from-manager-1.4.x-to-2.0.x>`
+
+* :doc:`Scylla Manager Metrics Update - Scylla Manager 1.4 to 2.0 <manager-metric-update-1.4-to-2.0>`
+
+.. raw:: html
+
+   </div>
+   </div>
+   </div>

--- a/docs/source/upgrade/upgrade-guide-from-1.4-to-2.0/manager-metric-update-1.4-to-2.0.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.4-to-2.0/manager-metric-update-1.4-to-2.0.rst
@@ -1,0 +1,17 @@
+========================================================
+Scylla Manager Metric Update - Scylla Manager 1.4 to 2.0
+========================================================
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+Scylla Manager 2.0 Dashboards are available for use with Scylla Monitoring Stack
+
+The following metrics are new in Scylla Manager 2.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* scylla_manager_backup_avg_upload_bandwidth - reports the average upload speed in bytes/sec since start of the upload
+* scylla_manager_backup_bytes_done - reports the number of bytes that have uploaded so far.
+* scylla_manager_backup_bytes_left - reports the Number of remaning bytes to be backed up.
+* scylla_manager_backup_percent_progress- reports the current backup progress as a percentage.

--- a/docs/source/upgrade/upgrade-guide-from-1.4-to-2.0/upgrade-guide-from-manager-1.4.x-to-2.0.x.rst
+++ b/docs/source/upgrade/upgrade-guide-from-1.4-to-2.0/upgrade-guide-from-manager-1.4.x-to-2.0.x.rst
@@ -1,0 +1,243 @@
+
+
+=============================================
+Upgrade Guide - Scylla Manager 1.4.x to 2.0.x 
+=============================================
+
+**Supported Operating Systems:** CentOS/RHEL 7, Ubuntu 16 and 18, Debian 9
+
+Enterprise customers who use Scylla Manager 1.4.x are encouraged to upgrade to 2.0.x. For new installations please see `Scylla Manager - Download and Install <https://www.scylladb.com/enterprise-download/#manager>`_. The steps below instruct you how to upgrade the Scylla Manager server while keeping the manager datastore intact. If you are not running Scylla Manager 1.4.x, do not perform this upgrade procedure. This procedure only covers upgrades from Scylla Manager 1.4.x to 2.0.x. If you want to upgrade to 2.0 from lower versions please upgrade to 1.4.x first.
+
+
+Please contact `Scylla Enterprise Support <https://www.scylladb.com/product/support/>`_ team with any questions. For release information, see the `Release Notes <https://www.scylladb.com/product/release-notes/>`_.
+
+Upgrade Procedure
+=================
+
+**Workflow:**
+
+#. `Stop the Scylla Manager Server`_
+#. `Backup the Scylla Manager data`_
+#. Install the `Scylla Manager server 2.0 </operating-scylla/manager/2.0/install/>`_
+#. Install the `Scylla Manager Agent </operating-scylla/manager/2.0/install-agent/>`_ (with the most up to date version)latest agent on eachthe node. Confirm the nodes all start and make sure they are started.
+#. `Start the Scylla Manager server`_
+#. `Validate`_ that the upgrade was successful
+#. (optional) Remove ssh artifacts from the nodes
+#. (optional) Configure auth token in the agent configuration, and update cluster in Scylla Manager.
+
+
+Stop the Scylla Manager Server
+------------------------------
+
+**Procedure**
+
+#. Make sure that no task is running (all tasks have DONE status) before stopping the server:
+
+   .. code-block:: none
+
+      sctool task list -c <cluster_id|cluster_name>
+
+#. Stop the Scylla Manager:
+
+   .. code-block:: none
+
+      sudo systemctl stop scylla-manager
+
+
+Backup the Scylla Manager data
+-------------------------------
+Scylla Manager server persists its data to a Scylla cluster (data store). Before upgrading, backup the ``scylla_manager`` keyspace from Scylla Manager's backend, following this `backup procedure </procedures/backup/>`_.
+
+Install new Scylla Manager server 2.0
+-------------------------------------
+
+.. _upgrade-manager-1.4.x-to-2.0.x-previous-release:
+
+Before upgrading, check what version you are **currently** running:
+
+**CentOS / RHEL** 
+
+.. code-block:: bash
+   
+   rpm -q scylla-manager
+
+
+**Ubuntu / Debian**
+
+.. code-block:: bash
+
+   dpkg -s scylla-manager
+
+Save the details of this version so you can :ref:`rollback <upgrade-manager-1.4.x-to-2.0.x-rollback-procedure-centos>` to it.
+
+
+
+To upgrade:
+
+
+Follow the procedure described in: `Install new Scylla Manager server 2.0 </operating-scylla/manager/2.0/install/>`_
+
+Download, Install and Start Scylla Manager Agent
+------------------------------------------------
+
+Follow the instructions described in `Install the Scylla Manager Agent </operating-scylla/manager/2.0/install-agent/>`_ for installing the Scylla Manager Agent on every node in the cluster. 
+
+Start the Scylla Manager Server
+-------------------------------
+
+From the Scylla Manager Server, run:
+
+.. code-block:: none
+
+   sudo systemctl start scylla-manager
+
+
+Configure Scylla Manager to work with the authentication token
+--------------------------------------------------------------
+
+
+Copy the authentication `token </operating-scylla/manager/2.0/install-agent/#token>`_ you created when installating the scylla-manager-agent:
+
+.. code-block:: none
+    
+    sctool cluster update --auth-token=6Es3dm24U72NzAu9ANWmU3C4ALyVZhwwPZZPWtK10eYGHJ24wMoh9SQxRZEluWMc0qDrsWCCshvfhk9uewOimQS2x5yNTYUEoIkO1VpSmTFu5fsFyoDgEkmNrCJpXtfM -c cluster-name
+
+
+
+Validate
+--------
+#. Check that Scylla Manager service is running with ``sudo systemctl status scylla-manager.service``. Confirm the service is active (running). If not, then start it with ``systemctl start scylla-manager.service``.
+#. Confirm that the upgrade changed the Client and Server version. Run ``sctool version`` and make sure both are 2.0.x version. For example:
+
+   .. code-block:: none
+
+      sctool version
+      Client version: 2.0-0.20191220.5407198e
+      Server version: 2.0-0.20191220.5407198e
+
+#. Confirm that following the update, that your managed clusters are still present. Run ``sctool cluster list``
+
+   .. code-block:: none
+  
+      sctool cluster list
+      ╭──────────────────────────────────────┬──────────╮
+      │ cluster id                           │ name     │
+      ├──────────────────────────────────────┼──────────┤
+      │ db7faf98-7cc4-4a08-b707-2bc59d65551e │ cluster  │
+      ╰──────────────────────────────────────┴──────────╯
+
+#. Confirm that following the upgrade, status is up and running
+
+
+   .. code-block:: none
+  
+      sctool status -c <cluster_id|cluster_name>
+      Datacenter: AWS_1
+      ╭───────────┬─────┬───────────┬───────────────╮
+      │ CQL       │ SSL │ REST      │ Host          │
+      ├───────────┼─────┼───────────┼───────────────┤
+      │ UP (56ms) │ OFF │ UP (37ms) │ 127.0.0.1     │
+      │ UP (56ms) │ OFF │ UP (25ms) │ 127.0.0.2     │
+      │ UP (56ms) │ OFF │ UP (25ms) │ 127.0.0.3     │
+      ╰───────────┴─────┴───────────┴───────────────╯
+
+.. _upgrade-manager-1.4.x-to-2.0.x-rollback-procedure-centos:
+
+Rollback Procedure
+==================
+
+The following procedure describes a rollback from Scylla Manager 2.0 to 1.4. Apply this procedure if an upgrade from 1.4 to 2.0 failed for any reason.
+
+**Warning:** note that you may lose the manged clusters after downgrade. Should this happen, you will need to add the managed clusters clusters manually.
+
+* Downgrade to :ref:`previous release <upgrade-manager-1.4.x-to-2.0.x-previous-release>`
+* Start Scylla Manager
+* Valdate Scylla Manager version
+
+Downgrade to previous release
+-----------------------------
+#. Stop Scylla Manager
+
+   .. code:: sh
+
+      sudo systemctl stop scylla-manager
+
+#. Drop the ``scylla_manager`` keyspace from the remote datastore
+
+   .. code:: sh
+
+      cqlsh -e "DROP KEYSPACE scylla_manager"
+
+#. Remove Scylla Manager repo
+
+   **CentOS / RHEL**
+
+   .. code:: sh
+
+      sudo rm -f /etc/yum.repos.d/scylla-manager.repo
+      sudo yum clean all
+      sudo rm -rf /var/cache/yum
+
+   **Ubuntu / Debian**
+
+   .. code:: sh
+
+      sudo rm -f /etc/apt/sources.list.d/scylla-manager.list
+
+
+#. Update the `Scylla Manager repo <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.4.x**
+
+#. Install previous version
+
+   **CentOS / RHEL**
+
+   .. code:: sh
+
+      sudo yum downgrade scylla-manager scylla-manager-server scylla-manager-client -y
+ 
+
+   **Ubuntu / Debian**
+
+   .. code:: sh
+
+      sudo apt-get update
+      sudo apt-get remove scylla-manager\* -y
+      sudo apt-get install scylla-manager scylla-manager-server scylla-manager-client
+      sudo systemctl unmask scylla-manager.service
+
+
+Rollback the Scylla Manager database
+------------------------------------
+
+#. Start Scylla Manager to reinitialize the data base schema.
+
+   .. code:: sh
+
+      sudo systemctl start scylla-manager
+
+#. Stop Scylla Manager to avoid issues while restoring the backup. If you did not perform any backup before upgrading then you are done now and can continue at "Start Scylla Manager".
+
+   .. code:: sh
+
+      sudo systemctl stop scylla-manager
+
+#. Restore the database backup if you performed a backup by following the instructions in `Restore from a Backup </procedures/restore/>`_
+   You can skip step 1 since the Scylla Manager has done this for you.
+
+Start Scylla Manager
+--------------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+Validate Scylla Manager Version
+-------------------------------
+
+Validate Scylla Manager version:
+
+.. code:: sh
+
+   sctool version
+
+The version should match with the version infomation you were running :ref:`previously <upgrade-manager-1.4.x-to-2.0.x-previous-release>`.

--- a/docs/source/upgrade/upgrade-guide-from-2.x.a-to-2.y.b/index.rst
+++ b/docs/source/upgrade/upgrade-guide-from-2.x.a-to-2.y.b/index.rst
@@ -1,0 +1,21 @@
+======================================
+Upgrade Scylla Manager 2.x.a to 2.y.b
+======================================
+
+.. toctree::
+   :hidden:
+   :titlesonly:
+
+   Scylla Manager 2.x.a to Scylla Manager 2.y.b<upgrade-2.x.a-to-2.y.b>
+   Fix for row-level repairs<upgrade-row-level-repair>
+
+
+.. panel-box::
+  :title: Upgrade Scylla Manager
+  :id: "getting-started"
+  :class: my-panel
+
+  Procedures for upgrading to a new version of Scylla Manager.
+
+  * `Scylla Manager Upgrade - Scylla Manager 2.x.a to 2.y.b <upgrade-2.x.a-to-2.y.b/>`_
+  * `Fix for row-level repairs <upgrade-row-level-repair/>`_

--- a/docs/source/upgrade/upgrade-guide-from-2.x.a-to-2.y.b/upgrade-2.x.a-to-2.y.b.rst
+++ b/docs/source/upgrade/upgrade-guide-from-2.x.a-to-2.y.b/upgrade-2.x.a-to-2.y.b.rst
@@ -1,0 +1,467 @@
+=======================================================
+Scylla Manager Upgrade - Scylla Manager 2.x.a to 2.y.b
+=======================================================
+
+This document describes upgrade guide between two following *Minor* or *Patch* releases of Scylla Manager 2.x.y
+
+.. toctree::
+   :maxdepth: 2
+
+Applicable versions
+===================
+
+This guide covers upgrading Scylla Manager version 2.x.a to version 2.y.b, on the following platforms:
+
+- Red Hat Enterprise Linux, version 7
+- CentOS, version 7
+- Debian, version 9
+- Ubuntu, versions 16.04, 18.04
+
+Upgrade Procedure
+=================
+
+.. note:: In Scylla Manager 2.x.a new component called Scylla Manager Agent is introduced which is running on each scylla node in the cluster as a sidecar. Upgrading this component means commands have to be executed for each node separately.
+
+Upgrade procedure for the Scylla Manager includes upgrade of three components server, client, and the agent. Entire cluster shutdown is NOT needed. Scylla will be running while the manager components are upgraded. Overview of the required steps:
+
+- Stop all Scylla Manager tasks (or wait for them to finish)
+- Stop the Scylla Manager Server 2.x.a
+- Stop the Scylla Manager Agent 2.x.a on all nodes
+- Upgrade the Scylla Manager Server and Client to 2.y.b
+- Upgrade the Scylla Manager Agent to 2.y.b on all nodes
+- Run `scyllamgr_agent_setup` script on all nodes
+- Reconcile configuration files
+- Start the Scylla Manager Agent 2.y.b on all nodes
+- Start the Scylla Manager Server 2.y.b
+- Validate status of the cluster
+
+Upgrade steps
+=============
+
+Stop all Scylla Manager tasks (or wait for them to finish)
+----------------------------------------------------------
+
+**On the Manager Server** check current status of the manager tasks:
+
+.. code:: sh
+
+    sctool task list -c <cluster>
+
+None of the listed tasks should have status in RUNNING.
+
+Stop the Scylla Manager Server 2.x.a
+------------------------------------
+
+**On the Manager Server** instruct Systemd to stop the server process:
+
+.. code:: sh
+
+    sudo systemctl stop scylla-manager
+
+Ensure that it is stopped with:
+
+.. code:: sh
+
+    sudo systemctl status scylla-manager
+
+It should have a status of *“Active: inactive (dead)”*.
+
+Stop the Scylla Manager Agent 2.x.a on all nodes
+------------------------------------------------
+
+**On each scylla node** in the cluster run:
+
+.. code:: sh
+
+    sudo systemctl stop scylla-manager-agent
+
+Ensure that it is stopped with:
+
+.. code:: sh
+
+    sudo systemctl status scylla-manager-agent
+
+It should have a status of *“Active: inactive (dead)”*.
+
+Upgrade the Scylla Manager Server and Client to 2.y.b
+-----------------------------------------------------
+
+**On the Manager Server** instruct package manager to update server and the client:
+
+CentOS, Red Hat:
+
+.. code:: sh
+
+    sudo yum update scylla-manager-server scylla-manager-client -y
+
+Debian, Ubuntu:
+
+.. code:: sh
+
+    sudo apt-get update
+    sudo apt-get install scylla-manager-server scylla-manager-client -y
+
+.. note:: When using apt-get, if a previous version of the Scylla Manager package had a modified configuration file, you will be asked what to do with this file during the installation process. In order to keep both files for reconciliation (covered later in the procedure), select the "keep your currently-installed version" option when prompted. 
+
+Upgrade the Scylla Manager Agent to 2.y.b on all nodes
+------------------------------------------------------
+
+**On each scylla node** instruct package manager to update the agent:
+
+CentOS, Red Hat:
+
+.. code:: sh
+
+    sudo yum update scylla-manager-agent -y
+
+Debian, Ubuntu:
+
+.. code:: sh
+
+    sudo apt-get update
+    sudo apt-get install scylla-manager-agent -y
+
+.. note:: With apt-get, if a previous version of the package had a modified configuration file, you will be asked during installation what to do with it. Please select "keep your currently-installed version" option to keep both previous and new default configuration file for later reconciliation.
+
+Run `scyllamgr_agent_setup` script on all nodes
+-----------------------------------------------
+
+.. note:: Script mentioned in this section is added in version 2.0.2 so it won't be available for earlier versions.
+
+This step requires sudo rights:
+
+.. code:: sh
+
+    $ sudo scyllamgr_agent_setup
+    Do you want to create scylla-helper.slice if it does not exist?
+    Yes - limit Scylla Manager Agent and other helper programs memory. No - skip this step.
+    [YES/no] YES
+    Do you want the Scylla Manager Agent service to automatically start when the node boots?
+    Yes - automatically start Scylla Manager Agent when the node boots. No - skip this step.
+    [YES/no] YES
+
+First step relates to limiting resources that are available to the agent and second
+instructs systemd to run agent on node restart.
+
+Reconcile configuration files
+-----------------------------
+
+Upgrades can create changes to the structure and values of the default yaml configuration file. If the previous version's configuration file was modified with custom values, this could result in a conflict. The upgrade procedure can't resolve this without help from an administrator. If you followed instructions from the upgrade packages sections of this document, and you elected to save both the new and old configuration files, the new version of the configuration file is saved in the same directory as the old one with an added extension suffix for both server and agent. These files are stored in the `/etc/scylla-manager` directory.
+
+On a CentOS configuration, a conflict looks like:
+
+.. code:: sh
+
+    # On the Scylla Manager node
+    /etc/scylla-manager/scylla-manager.yaml # old file containing custom values
+    /etc/scylla-manager/scylla-manager.yaml.rpmnew # new default file from new version
+    # On all Scylla nodes
+    /etc/scylla-manager-agent/scylla-manager-agent.yaml # old file containing custom values
+    /etc/scylla-manager-agent/scylla-manager-agent.yaml.rpmnew # new default file from new version
+
+On an Ubuntu configuration, a conflict looks like:
+
+.. code:: sh
+
+    # On the Scylla Manager node
+    /etc/scylla-manager/scylla-manager.yaml # old file containing custom values
+    /etc/scylla-manager/scylla-manager.yaml.dpkg-dist # new default file from new version
+    # On all Scylla nodes
+    /etc/scylla-manager-agent/scylla-manager-agent.yaml # old file containing custom values
+    /etc/scylla-manager-agent/scylla-manager-agent.yaml.dpkg-dist # new default file from new version
+
+It is required to manually inspect both files and reconcile old values with the new configuration. Remember to carry over any custom values like database credentials, backup, repair, and any other configuration. This can be done by manually updating values in the new config file and then renaming files:
+
+For CentOS:
+
+.. code:: sh
+
+    # On the Scylla Manager node
+    cd /etc/scylla-manager/
+    mv scylla-manager.yaml scylla-manager.yaml.old  #renames the old config file as old
+    mv scylla-manager.yaml.rpmnew scylla-manager.yaml
+    # On all Scylla nodes
+    cd /etc/scylla-manager-agent/
+    mv scylla-manager-agent.yaml scylla-manager-agent.yaml.old
+    mv scylla-manager-agent.yaml.rpmnew scylla-manager-agent.yaml
+
+For Ubuntu:
+
+.. code:: sh
+
+    # On the Scylla Manager node
+    cd /etc/scylla-manager/
+    mv scylla-manager.yaml scylla-manager.yaml.old
+    mv scylla-manager.yaml.dpkg-dist scylla-manager.yaml
+    # On all Scylla nodes
+    cd /etc/scylla-manager-agent/
+    mv scylla-manager-agent.yaml scylla-manager-agent.yaml.old
+    mv scylla-manager-agent.yaml.dpkg-dist scylla-manager-agent.yaml
+
+**Guide to important configuration changes across versions:**
+
+Scylla Manager 2.2.x
+
+- Default ports changed. They are placed into a lower port bracket because higher bracket is reserved by the OS for incoming connections and this is to avoid potential conflicts.
+    - ``http`` old port was ``56080`` new port is ``5080``
+    - ``https`` old port was ``56443`` new port is ``5443``
+    - ``prometheus`` old port was ``56090`` new port is ``5090``
+    - ``debug`` old port waas ``56112`` new port is ``5112``
+- Repair changes:
+    - ``poll_interval`` was changed from ``200ms`` to ``50ms``.
+    - ``segments_per_repair``, ``shard_parallel_max``, ``shard_failed_segments_max``, and ``error_backoff`` were removed.
+    - ``graceful_stop_timeout`` and ``force_repair_type`` were added.
+
+Scylla Manager Agent 2.2.x
+
+- Default ports changed. They are placed into a lower port bracket because higher bracket is reserved by the OS for incoming connections and this is to avoid potential conflicts.
+    - ``prometheus`` old port was ``56090`` new port is ``5090``
+    - ``debug`` old port waas ``56112`` new port is ``5112``
+
+Start the Scylla Manager Agent 2.y.b on all nodes
+-------------------------------------------------
+
+**On each scylla node** instruct Systemd to start the agent process:
+
+.. code:: sh
+
+    sudo systemctl start scylla-manager-agent
+
+Ensure that it is running with:
+
+.. code:: sh
+
+    sudo systemctl status scylla-manager-agent
+
+It should have a status of *“Active: active (running)”*.
+
+Start the Scylla Manager Server 2.y.b
+-------------------------------------
+
+**On the Manager Server** instruct Systemd to start the server process:
+
+.. code:: sh
+
+    sudo systemctl daemon-reload
+    sudo systemctl start scylla-manager
+
+Ensure that it is started with:
+
+.. code:: sh
+
+    sudo systemctl status scylla-manager
+
+It should have a status of *“Active: active (running)”*.
+
+Validate status of the cluster
+------------------------------
+
+**On the Manager Server** check the version of the client and the server:
+
+.. code:: sh
+
+    sctool version
+    Client version: 2.y.b-0.20200123.7cf18f6b
+    Server version: 2.y.b-0.20200123.7cf18f6b
+
+Check that cluster is up:
+
+.. code:: sh
+
+    sctool status -c <cluster>
+
+All running nodes should be up.
+
+.. note:: In **Scylla Manager 2.2** the meaning of repair command's ``--intensity`` flag was changed. After starting the upgraded server, all previously scheduled repairs will remain with the original value of ``--intensity`` but that value will be interpreted differently. This parameter is now broken into two new components:
+
+    - ``--intensity`` which now affects the number of repaired segments in a single repair request to the cluster. By default value (0) scylla manager will try to determine the maximum segments possible based on cluster setup.
+    - ``--parallel`` which now affects how many repairs will be requested in parallel (given that only nodes that are not busy with the repair can be repaired in parallel). By default value (0) maximum possible parallelism will be applied.
+
+    Based on this breakdown you can update current repair tasks to achieve previous result. Update can be done with:
+
+        sctool repair update --intensity <value> --parallel <value> <type/task-id>
+
+Rollback Procedure
+==================
+
+.. note:: Rolling back to 2.x.a is not recommended because 2.y.b contains bug fixes and performance optimizations so you will be going back to a lesser version. This should be only used as a last resort.
+
+Rollback procedure contains the same steps as upgrade but with downgrading the components to older version:
+
+- Stop all Scylla Manager tasks (or wait for them to finish)
+- Stop the Scylla Manager Server 2.y.b
+- Stop the Scylla Manager Agent 2.y.b on all nodes
+- Downgrade the Scylla Manager Server and Client to 2.x.a
+- Downgrade the Scylla Manager Agent to 2.x.a on all nodes
+- Bring back old configuration (if there was conflict)
+- Start the Scylla Manager Agent 2.x.a on all nodes
+- Start the Scylla Manager Server 2.x.a
+- Validate status of the cluster
+
+Rollback steps
+==============
+
+Stop all Scylla Manager tasks (or wait for them to finish)
+----------------------------------------------------------
+
+**On the Manager Server** check current status of the manager tasks:
+
+.. code:: sh
+
+    sctool task list -c <cluster>
+
+None of the listed tasks should have status in RUNNING.
+
+Stop the Scylla Manager Server 2.y.b
+------------------------------------
+
+**On the Manager Server** instruct Systemd to stop the server process:
+
+.. code:: sh
+
+    sudo systemctl stop scylla-manager
+
+Ensure that it is stopped with:
+
+.. code:: sh
+
+    sudo systemctl status scylla-manager
+
+It should have a status of *“Active: inactive (dead)”*.
+
+Stop the Scylla Manager Agent 2.y.b on all nodes
+------------------------------------------------
+
+**On each scylla node** in the cluster run:
+
+.. code:: sh
+
+    sudo systemctl stop scylla-manager-agent
+
+Ensure that it is stopped with:
+
+.. code:: sh
+
+    sudo systemctl status scylla-manager-agent
+
+It should have a status of *“Active: inactive (dead)”*.
+
+Downgrade the Scylla Manager Server and Client to 2.x.a
+-------------------------------------------------------
+
+**On the Manager Server** instruct package manager to downgrade server and the client:
+
+CentOS, Red Hat:
+
+.. code:: sh
+
+    sudo yum downgrade scylla-manager-server-2.x.a* scylla-manager-client-2.x.a* -y
+
+Debian, Ubuntu:
+
+.. code:: sh
+
+    sudo apt-get install scylla-manager-server=2.x.a scylla-manager-client=2.x.a -y
+
+Downgrade the Scylla Manager Agent to 2.x.a on all nodes
+--------------------------------------------------------
+
+**On each scylla node** instruct package manager to downgrade the agent:
+
+CentOS, Red Hat:
+
+.. code:: sh
+
+    sudo yum downgrade scylla-manager-agent-2.x.a* -y
+
+Debian, Ubuntu:
+
+.. code:: sh
+
+    sudo apt-get install scylla-manager-agent=2.x.a -y
+
+Revert to the old configuration
+----------------------------------------------------
+
+If you followed instructions from the Upgrade Steps section and you had configuration conflict when upgrading, then listing the configuration directory should give you both new and old configuration:
+
+.. code:: sh
+
+    /etc/scylla-manager/scylla-manager.yaml # New version that you want to disable
+    /etc/scylla-manager/scylla-manager.yaml.old # Previous version that you want to rollback
+
+To restore the old configuration:
+
+.. code:: sh
+
+    cd /etc/scylla-manager/
+    mv scylla-manager.yaml scylla-manager.yaml.new
+    mv scylla-manager.yaml.old scylla-manager.yaml
+
+The procedure is the same for the Scylla Manager Agent (on all nodes):
+
+.. code:: sh
+
+    cd /etc/scylla-manager-agent/
+    mv scylla-manager-agent.yaml scylla-manager-agent.yaml.new
+    mv scylla-manager-agent.yaml.old scylla-manager-agent.yaml
+
+Start the Scylla Manager Agent 2.x.a on all nodes
+-------------------------------------------------
+
+On all nodes instruct Systemd to start the agent process:
+
+.. code:: sh
+
+    sudo systemctl start scylla-manager-agent
+
+Ensure that it is running with:
+
+.. code:: sh
+
+    sudo systemctl status scylla-manager-agent
+
+It should have a status of *“Active: active (running)”*.
+
+Start the Scylla Manager Server 2.x.a
+-------------------------------------
+
+**On the Manager Server** instruct Systemd to start the server process:
+
+.. code:: sh
+
+    sudo systemctl stop scylla-manager
+
+Ensure that it is stopped with:
+
+.. code:: sh
+
+    sudo systemctl status scylla-manager
+
+It should have a status of *“Active: active (running)”*.
+
+.. note:: In **Scylla Manager 2.2** the meaning of repair command's ``--intensity`` flag was changed. If you want to rollback changes that were broken down to ``--intensity`` and ``--parallel`` you would need to remove or disable task in question and create new with correct values.
+
+    For example:
+
+        sctool task update --enable false <type/task_id>
+        sctool repair [repair parameters]
+
+Validate status of the cluster
+------------------------------
+
+**On the Manager Server** check the version of the client and the server:
+
+.. code:: sh
+
+    sctool version
+    Client version: 2.x.a
+    Server version: 2.x.a
+
+Check that cluster is up:
+
+.. code:: sh
+
+    sctool status -c <cluster>
+
+All running nodes should be up.

--- a/docs/source/upgrade/upgrade-guide-from-2.x.a-to-2.y.b/upgrade-row-level-repair.rst
+++ b/docs/source/upgrade/upgrade-guide-from-2.x.a-to-2.y.b/upgrade-row-level-repair.rst
@@ -1,0 +1,26 @@
+=========================
+Fix for Row-level Repairs
+=========================
+
+.. toctree::
+   :maxdepth: 2
+
+Upgrade to  Manager 2.0.2 for Improved Repair Speeds in Scylla 3.1 and Higher
+=============================================================================
+
+One of the useful features of the Manager is how it handles repairs.
+Manager breaks down token ranges into smaller segments in order distribute load over all available shards.
+Result of this approach is more efficient repair execution.
+
+With the release of `Scylla 3.1 <https://www.scylladb.com/2019/10/15/introducing-scylla-open-source-3-1/>`_ new improvement called `row-level repair <https://www.scylladb.com/2019/08/13/scylla-open-source-3-1-efficiently-maintaining-consistency-with-row-level-repair/>`_ was introduced.
+This change approaches repair on the more granular level which makes optimizations done by the Manager obsolete.
+In practice we noticed degradation of repair execution time with repairs done by Manager on Scylla clusters with row-level repair feature enabled.
+
+Manager 2.0.2 introduces fix for handling repairs on clusters with row-level repair feature enabled.
+When Scylla Manager detects the feature is enabled, it delegates sharding to the Scylla node thus avoiding any split shards.
+If you experience slow repairs, please upgrade to Manager 2.0.2 or newer.
+
+Slowdowns are still possible if Scylla Manager is not configured correctly.
+If `segments_per_repair` configuration option (`scylla-manager.yaml`) is set to a low value, repair can still take a long time to finish.
+So for clusters with row-level repair it is recommended to set `segments_per_repair` to at least 16.
+The row-level repair feature is available from Scylla Open Source 3.1 and higher.

--- a/docs/source/upgrade/upgrade-guide-from-manager-1.0.x-to-1.1.x.rst
+++ b/docs/source/upgrade/upgrade-guide-from-manager-1.0.x-to-1.1.x.rst
@@ -1,0 +1,159 @@
+
+
+=============================================
+Upgrade Guide - Scylla Manager 1.0.x to 1.1.x
+=============================================
+
+Enterprise customers who use Scylla Manager 1.0.x are encouraged to upgrade to 1.1.x.
+The steps below instruct you how to upgrade the Scylla Manager server while keeping the manager datastore intact.
+If you are not running Scylla Manager 1.0.x, do not perform this upgrade procedure. This procedure only covers upgrades from Scylla Manager 1.0.x to 1.1.x.
+
+Please contact `Scylla Enterprise Support <https://www.scylladb.com/product/support/>`_ team with any question.
+
+
+Upgrade Procedure
+=================
+
+* Backup the data
+* Download and install new packages
+* Validate that the upgrade was successful
+
+Backup the data
+------------------------------
+Before any major procedure, like an upgrade, it is recommended to backup all the data to an external device.  It is recommended to backup the ``scylla_manager`` keyspace from Scylla Manager's backend, following this `backup procedure </operating-scylla/procedures/backup-restore/backup/>`_.
+
+Download and install the new release
+------------------------------------
+
+.. _upgrade-manager-1.0.x-to-1.1.x-previous-release:
+
+Before upgrading, check what version you are running now using ``rpm -qa | grep scylla-manager``. You should use the same version in case you want to :ref:`rollback <upgrade-manager-1.0.x-to-1.1.x-rollback-procedure>` the upgrade.
+
+
+To upgrade:
+
+
+1. Update the `Update the Scylla Manager repo: <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.1.x**
+2. Run:
+
+.. code:: sh
+
+   sudo yum update scylla-manager -y
+
+Validate
+--------
+1. Check Scylla Manager status with ``systemctl status scylla-manager.service``. Confirm the service is active (running).
+2. Confirm that the upgrade changed the Client and Server version. Run ``sctool version`` and make sure both are 1.1.x version 
+3. Confirm that following the update, that your managed clusters are still present. Run ``sctool cluster list``
+4. Confirm that following the upgrade, there are no repairs in a stopped state. Run ``sctool task list`` to list the repair tasks in progress. If any are in a stopped state, run ``sctool repair unit schedule <repair-unit-id> --start-date=now`` to resume.
+
+Update scylla-manager.yaml (optional)
+-------------------------------------
+
+As part of the upgrade procudre, paramaters were added to ``/etc/scylla-manager/scylla-manager.yaml``. See the new values below. There is no need to update the ``scylla-manager.yaml`` file as part of the upgrade.
+
+.. code-block:: yaml
+
+   # Repair service configuration.
+   repair:
+     # Granularity of repair. Repair works on segments, segment is a continuous
+     # token range.
+     #
+     # Set the maximal number of tokens in a segment (zero is no limit).
+     segment_size_limit: 0
+
+     # Set number of segments to be repaired in one Scylla command.
+     segments_per_repair: 1
+
+     # Error tolerance.
+     #
+     # Set how many segments may fail to repair. Note that the manager would retry
+     # to repair the failed segments. If the limit is exceeded, however, repair
+     # will stop and the next repair will start from the beginning.
+     segment_error_limit: 100
+
+     # Fail-fast, set to true if you want repair to stop on first error. Unlike
+     # segment_error_limit this allows for resuming the stopped repair.
+     stop_on_error: false
+
+     # Set wait time if Scylla failed to execute a repair command. Note that if
+     # stop_on_error is true this has no effect.
+     error_backoff: 10s
+
+     # Set how often to poll Scylla node for command status.
+     poll_interval: 200ms
+
+     # Set time offset between the automated scheduler run and the scheduled
+     # repairs. If scheduler runs at midnight the repairs would start at
+     # midnight + this value. This gives you the opportunity to audit and modify
+     # the scheduled repairs.
+     auto_schedule_delay: 2h
+
+     # Set maximal time after which a restarted repair is forced to start from the
+     # beginning.
+     max_run_age: 36h
+
+     # Distribution of data among cores (shards) within a node.
+     # Copy value from Scylla configuration file.
+     murmur3_partitioner_ignore_msb_bits: 12
+
+
+.. _upgrade-manager-1.0.x-to-1.1.x-rollback-procedure:
+
+Rollback Procedure
+==================
+
+The following procedure describes a rollback from Scylla Manager 1.1 to 1.0. Apply this procedure if an upgrade from 1.0 to 1.1 failed for any reason.
+
+**Warning:** note that you may lose the manged clusters after downgrade. Should this happen, you will need to add the managed clusters.
+
+* Downgrade to :ref:`previous release <upgrade-manager-1.0.x-to-1.1.x-previous-release>`
+* Start Scylla Manager
+* Valdate Scylla Manager version
+
+Downgrade to previous release
+-----------------------------
+1. Stop Scylla Manager
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+2. Drop scylla_manager keyspace from the remote datastore
+
+.. code:: sh
+
+   cqlsh -e "DROP KEYSPACE scylla_manager"
+
+3. Remove Scylla Manager repo
+
+.. code:: sh
+
+   sudo rm -rf /etc/yum.repos.d/scylla-manager.repo
+   sudo yum clean all
+
+4. Update the `Scylla Manager repo <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.0.x**
+
+5. Install previous version
+
+.. code:: sh
+
+   sudo yum downgrade scylla-manager scylla-manager-server scylla-manager-client -y
+
+
+Start Scylla Manager
+--------------------
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+Validate Scylla Manager Version
+-------------------------------
+
+Validate Scylla Manager version:
+
+.. code:: sh
+
+   sctool version
+
+The version should match with the results you had :ref:`previously <upgrade-manager-1.0.x-to-1.1.x-previous-release>`.

--- a/docs/source/upgrade/upgrade-guide-from-manager-1.1.x-to-1.2.x.rst
+++ b/docs/source/upgrade/upgrade-guide-from-manager-1.1.x-to-1.2.x.rst
@@ -1,0 +1,170 @@
+
+
+=============================================
+Upgrade Guide - Scylla Manager 1.1.x to 1.2.x
+=============================================
+
+Enterprise customers who use Scylla Manager 1.1.x are encouraged to upgrade to 1.2.x.
+For new installations please see `Scylla Manager - Download and Install <https://www.scylladb.com/enterprise-download/#manager>`_.
+The steps below instruct you how to upgrade the Scylla Manager server while keeping the manager datastore intact.
+If you are not running Scylla Manager 1.1.x, do not perform this upgrade procedure. This procedure only covers upgrades from Scylla Manager 1.1.x to 1.2.x.
+
+Please contact `Scylla Enterprise Support <https://www.scylladb.com/product/support/>`_ team with any question.
+
+Upgrade Notes
+=================
+
+* This upgrade brings internal changes incompatible with previous versions of Scylla Manager.
+  We have removed the repair unit concept and replaced it with a repair task that can be tuned using simple glob based pattern matching.
+  The pattern matching that is performed can be applied to filter out multiple keyspaces and tables as well as entire datacenters. 
+  A consequence of this is that custom repairs that previously were scheduled are removed during the upgrade and you may need to replace them.
+  A weekly repair task will be scheduled for each existing cluster so repairs will be performed automatically.
+
+* The Scylla Manager API is now using HTTPS by default. Their default values have changed to 56443 for HTTPS and 56080 for plain HTTP.
+  The port can be changed as needed in ``/etc/scylla-manager/scylla-manager.yaml``
+
+Upgrade Procedure
+=================
+
+* Backup the data
+* Download and install new packages
+* Validate that the upgrade was successful
+
+Backup the data
+------------------------------
+Before any major procedure, like an upgrade, it is recommended to backup all the data to an external device.  It is recommended to backup the ``scylla_manager`` keyspace from Scylla Manager's backend, following this `backup procedure </operating-scylla/procedures/backup-restore/backup/>`_.
+
+Download and install the new release
+------------------------------------
+
+.. _upgrade-manager-1.1.x-to-1.2.x-previous-release:
+
+Before upgrading, check what version you are currently running now using ``rpm -q scylla-manager``. You should use the same version that you had previously installed in case you want to :ref:`rollback <upgrade-manager-1.1.x-to-1.2.x-rollback-procedure>` the upgrade.
+
+
+To upgrade:
+
+
+1. Update the `Update the Scylla Manager repo: <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.2.x**
+2. Run:
+
+.. code:: sh
+
+   sudo yum update scylla-manager -y
+
+3. Reload your shell execute the below command to reload ``sctool`` code completion.
+
+.. code:: sh
+
+   source /etc/bash_completion.d/sctool.bash
+
+
+Validate
+--------
+1. Confirm that the upgrade changed the Client and Server version. Run ``sctool version`` and make sure both are 1.2.x version.
+2. If you get an error from the version check then make sure that Scylla Manager is running with ``systemctl status scylla-manager.service``. Confirm the service is active (running). If not, then start it with ``systemctl start scylla-manager.service``.
+3. Confirm that following the update, that your managed clusters are still present. Run ``sctool cluster list``
+4. Confirm that following the upgrade, there is one repair task in a NEW state for each existing cluster. Run ``sctool task list`` to list the repair tasks.
+
+Update scylla-manager.yaml (optional)
+-------------------------------------
+
+As part of the upgrade procudre, paramaters were changed in ``/etc/scylla-manager/scylla-manager.yaml``. See the new values below. There is no need to update the ``scylla-manager.yaml`` file as part of the upgrade.
+
+.. code-block:: yaml
+
+   # Bind REST API to the specified TCP address using HTTP protocol.
+   # http: 127.0.0.1:56080
+
+   # Bind REST API to the specified TCP address using HTTPS protocol.
+   https: 127.0.0.1:56443
+
+   # TLS certificate file to use for HTTPS.
+   tls_cert_file: /var/lib/scylla-manager/scylla_manager.crt
+
+   # TLS key file to use for HTTPS.
+   tls_key_file: /var/lib/scylla-manager/scylla_manager.key
+
+   # Bind prometheus API to the specified TCP address using HTTP protocol.
+   # By default it binds to all network interfaces but you can restrict it
+   # by specifying it like this 127:0.0.1:56090 or any other combination
+   # of ip and port.
+   prometheus: ':56090'
+
+.. _upgrade-manager-1.1.x-to-1.2.x-rollback-procedure:
+
+Rollback Procedure
+==================
+
+The following procedure describes a rollback from Scylla Manager 1.2 to 1.1. Apply this procedure if an upgrade from 1.0 to 1.1 failed for any reason.
+
+**Warning:** note that you may lose the manged clusters after downgrade. Should this happen, you will need to add the managed clusters clusters manually.
+
+* Downgrade to :ref:`previous release <upgrade-manager-1.1.x-to-1.2.x-previous-release>`
+* Start Scylla Manager
+* Valdate Scylla Manager version
+
+Downgrade to previous release
+-----------------------------
+1. Stop Scylla Manager
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+2. Drop the ``scylla_manager`` keyspace from the remote datastore
+
+.. code:: sh
+
+   cqlsh -e "DROP KEYSPACE scylla_manager"
+
+3. Remove Scylla Manager repo
+
+.. code:: sh
+
+   sudo rm -rf /etc/yum.repos.d/scylla-manager.repo
+   sudo yum clean all
+
+4. Update the `Scylla Manager repo <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.1.x**
+
+5. Install previous version
+
+.. code:: sh
+
+   sudo yum downgrade scylla-manager scylla-manager-server scylla-manager-client -y
+
+Rollback the Scylla Manager database
+------------------------------------
+
+1. Start Scylla Manager to reinitialize the data base schema.
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+2. Stop Scylla Manager to avoid issues while restoring the backup. If you did not perform any backup before upgrading then you are done now and can continue at "Start Scylla Manager".
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+3. Restore the database backup if you performed a backup by following the instructions in `Restore from a Backup </operating-scylla/procedures/backup-restore/restore/>`_.
+   You can skip step 1 since the Scylla Manager has done this for you.
+
+Start Scylla Manager
+--------------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+Validate Scylla Manager Version
+-------------------------------
+
+Validate Scylla Manager version:
+
+.. code:: sh
+
+   sctool version
+
+The version should match with the results you had :ref:`previously <upgrade-manager-1.1.x-to-1.2.x-previous-release>`.

--- a/docs/source/upgrade/upgrade-guide-maintenance-1.x.y-to-1.x.z/index.rst
+++ b/docs/source/upgrade/upgrade-guide-maintenance-1.x.y-to-1.x.z/index.rst
@@ -1,0 +1,35 @@
+=======================================================
+Upgrade Guide - Scylla  Manager 1.x Maintenance Release
+=======================================================
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   Ubuntu <upgrade-guide-from-manager-1.x.y-to-1.x.z-ubuntu>
+   CentOS <upgrade-guide-from-manager-1.x.y-to-1.x.z-CentOS>
+
+
+.. raw:: html
+
+
+   <div class="panel callout radius animated">
+            <div class="row">
+              <div class="medium-3 columns">
+                <h5 id="getting-started">Upgrade Scylla Manager</h5>
+              </div>
+              <div class="medium-9 columns">
+
+
+Upgrade guides are available for:
+
+* :doc:`Upgrade Guide - Scylla Manager 1.x.y to 1.x.z on CentOS <upgrade-guide-from-manager-1.x.y-to-1.x.z-CentOS>`
+* :doc:`Upgrade guide - Scylla Manager 1.x.y to 1.x.z on Ubuntu 16 <upgrade-guide-from-manager-1.x.y-to-1.x.z-ubuntu>`
+
+
+
+.. raw:: html
+
+   </div>
+   </div>
+   </div>

--- a/docs/source/upgrade/upgrade-guide-maintenance-1.x.y-to-1.x.z/upgrade-guide-from-manager-1.x.y-to-1.x.z-CentOS.rst
+++ b/docs/source/upgrade/upgrade-guide-maintenance-1.x.y-to-1.x.z/upgrade-guide-from-manager-1.x.y-to-1.x.z-CentOS.rst
@@ -1,0 +1,178 @@
+
+
+========================================================
+Upgrade Guide - Scylla Manager 1.x.y to 1.x.z on CentOS
+========================================================
+
+Enterprise customers who use Scylla Manager 1.x.y are encouraged to upgrade to 1.x.z.
+For new installations please see `Scylla Manager - Download and Install <https://www.scylladb.com/enterprise-download/#manager>`_.
+The steps below instruct you how to upgrade the Scylla Manager server while keeping the manager datastore intact.
+If you are not running Scylla Manager 1.x.y, do not perform this upgrade procedure. This procedure only covers upgrades from Scylla Manager 1.x.y to 1.x.z.
+
+Please contact `Scylla Enterprise Support <https://www.scylladb.com/product/support/>`_ team with any questions.
+
+Upgrade Notes
+=================
+
+* This upgrade brings to sctool a new command: ``status``. This command shows a listing of the individual nodes in the cluster and records the CQL availability on the nodes.
+
+* Health Check - This upgrade introduces a new feature where each node is monitored by Scylla Manager. When Scylla Manager detects that a node is down an alert message is sent to Scylla Monitoring. Alternitively, you can use the ``sctool status``` command to show the live cluster status. 
+
+* Automated health check - When a cluster is added a new health check task is automatically added to the cluster. Following an upgrade, all existing clusters will have an health check task as well. 
+
+* The sctool argument ``interval-days`` has been renamed to ``interval`` as it now supports more granular time units. For example: ``3d2h10m``. The available time units are ``d``, ``h``, ``m``, and ``s``.
+
+* The sctool command ``cluster list`` no longer displays the **host** column in the results table. This was removed because it was easy to be mislead that this node was the only node being used. Adding a cluster (``cluster add``) still takes a ``--host`` argument, but when all the available nodes are discovered they are persisted and used for subsequent interactions with ScyllaDB.
+
+
+
+Upgrade Procedure
+=================
+
+* Backup the data
+* Download and install new packages
+* Validate that the upgrade was successful
+
+Backup the Scylla Manager data
+-------------------------------
+Scylla Manager server persists its data to a Scylla cluster (data store). Before upgrading, backup the ``scylla_manager`` keyspace from Scylla Manager's backend, following this `backup procedure </operating-scylla/procedures/backup-restore/backup/>`_.
+
+Download and install the new release
+------------------------------------
+
+.. _upgrade-manager-1.x.y-to-1.x.z-previous-release:
+
+Before upgrading, check what version you are currently running now using ``rpm -q scylla-manager``. You should use the same version that you had previously installed in case you want to :ref:`rollback <upgrade-manager-1.x.z-to-1.x.y-rollback-procedure-centos>` the upgrade.
+
+
+To upgrade:
+
+
+1. Update the `Update the Scylla Manager repo: <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.x.y**
+
+2. Run:
+
+.. code:: sh
+
+   sudo yum update scylla-manager -y
+
+3. Reload your shell execute the below command to reload ``sctool`` code completion.
+
+.. code:: sh
+
+   source /etc/bash_completion.d/sctool.bash
+
+
+Validate
+--------
+1. Check that Scylla Manager service is running with ``sudo systemctl status scylla-manager.service``. Confirm the service is active (running). If not, then start it with ``systemctl start scylla-manager.service``.
+2. Confirm that the upgrade changed the Client and Server version. Run ``sctool version`` and make sure both are 1.x.z version. For example:
+
+.. code-block:: none
+
+   sctool version
+   Client version: 1.3.0-0.20181130.03ae248
+   Server version: 1.3.0-0.20181130.03ae248
+
+3. Confirm that following the update, that your managed clusters are still present. Run ``sctool cluster list``
+
+.. code-block:: none
+  
+   sctool cluster list
+   ╭──────────────────────────────────────┬──────────┬───────────────╮
+   │ cluster id                           │ name     │ssh user       │
+   ├──────────────────────────────────────┼──────────┼───────────────┤
+   │ db7faf98-7cc4-4a08-b707-2bc59d65551e │ cluster  │scylla-manager │
+   ╰──────────────────────────────────────┴──────────┴───────────────╯
+
+4. Confirm that following the upgrade, there is a healtcheck task for each existing cluster. Run ``sctool task list`` to list the tasks.
+
+
+.. code-block:: none
+
+
+   sctool task list -c cluster --all
+   ╭──────────────────────────────────────────────────┬───────────────────────────────┬──────┬────────────┬────────╮
+   │ task                                             │ next run                      │ ret. │ properties │ status │
+   ├──────────────────────────────────────────────────┼───────────────────────────────┼──────┼────────────┼────────┤
+   │ healthcheck/afe9a610-e4c7-4d05-860e-5a0ddf14d7aa │ 10 Dec 18 20:21 UTC (+15s)    │ 0    │            │ RUNNING│
+   │ repair/4d79ee63-7721-4105-8c6a-5b98c65c3e21      │ 12 Dec 18 00:00 UTC (+7d)     │ 3    │            │ NEW    │
+   ╰──────────────────────────────────────────────────┴───────────────────────────────┴──────┴────────────┴────────╯
+
+.. _upgrade-manager-1.x.z-to-1.x.y-rollback-procedure-centos:
+
+Rollback Procedure
+==================
+
+The following procedure describes a rollback from Scylla Manager 1.x.z to 1.x.y. Apply this procedure if an upgrade from 1.x.y to 1.x.z failed for any reason.
+
+**Warning:** note that you may lose the manged clusters after downgrade. Should this happen, you will need to add the managed clusters clusters manually.
+
+* Downgrade to :ref:`previous release <upgrade-manager-1.x.y-to-1.x.z-previous-release>`
+* Start Scylla Manager
+* Valdate Scylla Manager version
+
+Downgrade to previous release
+-----------------------------
+1. Stop Scylla Manager
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+2. Drop the ``scylla_manager`` keyspace from the remote datastore
+
+.. code:: sh
+
+   cqlsh -e "DROP KEYSPACE scylla_manager"
+
+3. Remove Scylla Manager repo
+
+.. code:: sh
+
+   sudo rm -rf /etc/yum.repos.d/scylla-manager.repo
+   sudo yum clean all
+
+4. Update the `Scylla Manager repo <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.x.y**
+
+5. Install previous version
+
+.. code:: sh
+
+   sudo yum downgrade scylla-manager scylla-manager-server scylla-manager-client -y
+
+Rollback the Scylla Manager database
+------------------------------------
+
+1. Start Scylla Manager to reinitialize the data base schema.
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+2. Stop Scylla Manager to avoid issues while restoring the backup. If you did not perform any backup before upgrading then you are done now and can continue at "Start Scylla Manager".
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+3. Restore the database backup if you performed a backup by following the instructions in `Restore from a Backup </operating-scylla/procedures/backup-restore/restore/>`_.
+   You can skip step 1 since the Scylla Manager has done this for you.
+
+Start Scylla Manager
+--------------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+Validate Scylla Manager Version
+-------------------------------
+
+Validate Scylla Manager version:
+
+.. code:: sh
+
+   sctool version
+
+The version should match with the results you had :ref:`previously <upgrade-manager-1.x.y-to-1.x.z-previous-release>`.

--- a/docs/source/upgrade/upgrade-guide-maintenance-1.x.y-to-1.x.z/upgrade-guide-from-manager-1.x.y-to-1.x.z-ubuntu.rst
+++ b/docs/source/upgrade/upgrade-guide-maintenance-1.x.y-to-1.x.z/upgrade-guide-from-manager-1.x.y-to-1.x.z-ubuntu.rst
@@ -1,0 +1,188 @@
+
+
+==========================================================
+Upgrade guide - Scylla Manager 1.x.y to 1.x.z on Ubuntu 16
+==========================================================
+
+Enterprise customers who use Scylla Manager 1.x.y are encouraged to upgrade to 1.x.z.
+For new installations please see `Scylla Manager - Download and Install <https://www.scylladb.com/enterprise-download/#manager>`_.
+The steps below instruct you how to upgrade the Scylla Manager server while keeping the manager datastore intact.
+If you are not running Scylla Manager 1.x.y, do not perform this upgrade procedure. This procedure only covers upgrades from Scylla Manager 1.x.y to 1.x.z.
+
+Please contact `Scylla Enterprise Support <https://www.scylladb.com/product/support/>`_ team with any questions.
+
+Upgrade Notes
+=================
+
+* This upgrade brings to sctool a new command: ``status``. This command shows a listing of the individual nodes in the cluster and records the CQL availability on the nodes.
+
+* Health Check - This upgrade introduces a new feature where each node is monitored by Scylla Manager. When Scylla Manager detects that a node is down an alert message is sent to Scylla Monitoring. Alternitively, you can use the ``sctool status``` command to show the live cluster status. 
+
+* Automated health check - When a cluster is added a new health check task is automatically added to the cluster. Following an upgrade, all existing clusters will have an health check task as well. 
+
+* The sctool argument ``interval-days`` has been renamed to ``interval`` as it now supports more granular time units. For example: ``3d2h10m``. The available time units are ``d``, ``h``, ``m``, and ``s``.
+
+* The sctool command ``cluster list`` no longer displays the **host** column in the results table. This was removed because it was easy to be mislead that this node was the only node being used. Adding a cluster (``cluster add``) still takes a ``--host`` argument, but when all the available nodes are discovered they are persisted and used for subsequent interactions with ScyllaDB.
+
+
+
+Upgrade Procedure
+=================
+
+* Backup the data
+* Download and install new packages
+* Validate that the upgrade was successful
+
+Backup the Scylla Manager data
+-------------------------------
+Scylla Manager server persists its data to a Scylla cluster (data store). Before upgrading, backup the ``scylla_manager`` keyspace from Scylla Manager's backend, following this `backup procedure </operating-scylla/procedures/backup-restore/backup/>`_.
+
+Download and install the new release
+------------------------------------
+
+.. _upgrade-manager-1.x.y-to-1.x.z-previous-release:
+
+Before upgrading, check what version you are currently running now using ``rpm -q scylla-manager``. You should use the same version that you had previously installed in case you want to :ref:`rollback <upgrade-manager-1.x.z-to-1.x.y-rollback-procedure-ubuntu>` the upgrade.
+
+
+To upgrade:
+
+
+1. Update the `Update the Scylla Manager repo: <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.x.y**
+
+2. Run:
+
+.. code:: sh
+
+   sudo apt-get update
+   sudo apt-get dist-upgrade scylla-manager*
+
+3. Restart the service
+
+.. code:: sh
+
+   sudo systemctl restart scylla-manager.service
+
+
+4. Reload your shell execute the below command to reload ``sctool`` code completion.
+
+.. code:: sh
+
+   source /etc/bash_completion.d/sctool.bash
+
+
+Validate
+--------
+1. Check that Scylla Manager service is running with ``sudo systemctl status scylla-manager.service``. Confirm the service is active (running). If not, then start it with ``systemctl start scylla-manager.service``.
+2. Confirm that the upgrade changed the Client and Server version. Run ``sctool version`` and make sure both are 1.x.y version. For example:
+
+.. code-block:: none
+
+   sctool version
+   Client version: 1.3.0-0.20181130.03ae248
+   Server version: 1.3.0-0.20181130.03ae248
+
+3. Confirm that following the update, that your managed clusters are still present. Run ``sctool cluster list``
+
+.. code-block:: none
+  
+   sctool cluster list
+   ╭──────────────────────────────────────┬──────────┬───────────────╮
+   │ cluster id                           │ name     │ssh user       │
+   ├──────────────────────────────────────┼──────────┼───────────────┤
+   │ db7faf98-7cc4-4a08-b707-2bc59d65551e │ cluster  │scylla-manager │
+   ╰──────────────────────────────────────┴──────────┴───────────────╯
+
+4. Confirm that following the upgrade, there is a healtcheck task for each existing cluster. Run ``sctool task list`` to list the tasks.
+
+
+.. code-block:: none
+
+
+   sctool task list -c cluster --all
+   ╭──────────────────────────────────────────────────┬───────────────────────────────┬──────┬────────────┬────────╮
+   │ task                                             │ next run                      │ ret. │ properties │ status │
+   ├──────────────────────────────────────────────────┼───────────────────────────────┼──────┼────────────┼────────┤
+   │ healthcheck/afe9a610-e4c7-4d05-860e-5a0ddf14d7aa │ 10 Dec 18 20:21 UTC (+15s)    │ 0    │            │ RUNNING│
+   │ repair/4d79ee63-7721-4105-8c6a-5b98c65c3e21      │ 12 Dec 18 00:00 UTC (+7d)     │ 3    │            │ NEW    │
+   ╰──────────────────────────────────────────────────┴───────────────────────────────┴──────┴────────────┴────────╯
+
+.. _upgrade-manager-1.x.z-to-1.x.y-rollback-procedure-ubuntu:
+
+Rollback Procedure
+==================
+
+The following procedure describes a rollback from Scylla Manager 1.x.z to 1.x.y Apply this procedure if an upgrade from 1.2 to 1.3 failed for any reason.
+
+**Warning:** note that you may lose the manged clusters after downgrade. Should this happen, you will need to add the managed clusters clusters manually.
+
+* Downgrade to :ref:`previous release <upgrade-manager-1.x.y-to-1.x.z-previous-release>`
+* Start Scylla Manager
+* Valdate Scylla Manager version
+
+Downgrade to previous release
+-----------------------------
+1. Stop Scylla Manager
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+2. Drop the ``scylla_manager`` keyspace from the remote datastore
+
+.. code:: sh
+
+   cqlsh -e "DROP KEYSPACE scylla_manager"
+
+3. Remove Scylla Manager repo
+
+.. code:: sh
+
+   sudo rm -rf /etc/apt/sources.list.d/scylla-manager.list
+
+4. Update the `Scylla Manager repo <https://www.scylladb.com/enterprise-download/#manager>`_ to **1.x.y**
+
+5. Install previous version
+
+.. code:: sh
+
+   sudo apt-get update
+   sudo apt-get remove scylla-manager\* -y
+   sudo apt-get install scylla-manager scylla-manager-server scylla-manager-client
+   sudo systemctl unmask scylla-manager.service
+
+Rollback the Scylla Manager database
+------------------------------------
+
+1. Start Scylla Manager to reinitialize the data base schema.
+
+.. code:: sh
+          
+   sudo systemctl start scylla-manager
+
+2. Stop Scylla Manager to avoid issues while restoring the backup. If you did not perform any backup before upgrading then you are done now and can continue at "Start Scylla Manager".
+
+.. code:: sh
+
+   sudo systemctl stop scylla-manager
+
+3. Restore the database backup if you performed a backup by following the instructions in `Restore from a Backup </operating-scylla/procedures/backup-restore/restore/>`_.
+   You can skip step 1 since the Scylla Manager has done this for you.
+
+Start Scylla Manager
+--------------------
+
+.. code:: sh
+
+   sudo systemctl start scylla-manager
+
+Validate Scylla Manager Version
+-------------------------------
+
+Validate Scylla Manager version:
+
+.. code:: sh
+
+   sctool version
+
+The version should match with the results you had :ref:`previously <upgrade-manager-1.x.y-to-1.x.z-previous-release>`.


### PR DESCRIPTION
Adds the Scylla Manager Upgrade guides to Scylla Manager. 
in going forward, we should limit what content appears in each version, but this move allows all of the upgrade content to live with the rest of the documentation. 

---