### PR TITLE
cmd/sctool: status, render hyphen on no data (#2842)

### DIFF
--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -152,12 +152,28 @@ func (cs ClusterStatus) Render(w io.Writer) error {
 		}
 
 		var (
-			cpus          = fmt.Sprintf("%d", s.CPUCount)
-			mem           = StringByteCount(s.TotalRAM)
-			scyllaVersion = version.Short(s.ScyllaVersion)
-			agentVersion  = version.Short(s.AgentVersion)
-			uptime        = (time.Duration(s.Uptime) * time.Second).String()
+			cpus          = "-"
+			mem           = "-"
+			scyllaVersion = "-"
+			agentVersion  = "-"
+			uptime        = "-"
 		)
+		if s.CPUCount > 0 {
+			cpus = fmt.Sprintf("%d", s.CPUCount)
+		}
+		if s.TotalRAM > 0 {
+			mem = StringByteCount(s.TotalRAM)
+		}
+		if s.ScyllaVersion != "" {
+			scyllaVersion = version.Short(s.ScyllaVersion)
+		}
+		if s.AgentVersion != "" {
+			agentVersion = version.Short(s.AgentVersion)
+		}
+		if s.Uptime > 0 {
+			uptime = (time.Duration(s.Uptime) * time.Second).String()
+		}
+
 		cs.addRow(t, s.Status, apiStatuses, s.Host, uptime, cpus, mem, scyllaVersion, agentVersion, s.HostID)
 	}
 


### PR DESCRIPTION
Fixes #2842

Example

```
sctool status
Cluster: test (65d9a572-4d94-45e9-a00a-4f55e9c5a689)
Datacenter: dc1
╭────┬─────────────┬─────────────┬────────────┬────────────────┬─────────┬──────┬──────────┬────────┬──────────┬──────────────────────────────────────╮
│    │ Alternator  │ CQL         │ REST       │ Address        │ Uptime  │ CPUs │ Memory   │ Scylla │ Agent    │ Host ID                              │
├────┼─────────────┼─────────────┼────────────┼────────────────┼─────────┼──────┼──────────┼────────┼──────────┼──────────────────────────────────────┤
│ UN │ ERROR (0ms) │ ERROR (0ms) │ DOWN (1ms) │ 192.168.100.11 │ -       │ -    │ -        │ -      │ -        │ da32b3b3-3f01-4642-b16c-37cbbc5df71f │
│ UN │ UP (15ms)   │ UP (14ms)   │ UP (10ms)  │ 192.168.100.12 │ 3h4m33s │ 4    │ 31.11GiB │ 4.2.1  │ Snapshot │ 0217f0b3-5a54-4730-935b-7e4b0c77cbb3 │
│ UN │ UP (19ms)   │ UP (2ms)    │ UP (13ms)  │ 192.168.100.13 │ 3h4m33s │ 4    │ 31.11GiB │ 4.2.1  │ Snapshot │ 14a6c1b0-264d-4a7a-951c-efa4f10fce9c │
╰────┴─────────────┴─────────────┴────────────┴────────────────┴─────────┴──────┴──────────┴────────┴──────────┴──────────────────────────────────────╯
Errors:
- 192.168.100.11 alternator: get node info: fetch node info: node info: giving up after 2 attempts: agent [HTTP 500]
- 192.168.100.11 CQL: fetch node info: node info: giving up after 2 attempts: agent [HTTP 500]
- 192.168.100.11 REST: agent [HTTP 502]
```
