### PR TITLE
healthcheck simplification

### DIFF
--- a/dist/etc/scylla-manager.yaml
+++ b/dist/etc/scylla-manager.yaml
@@ -88,24 +88,19 @@ http: 127.0.0.1:5080
 #  user_cert_file:
 #  user_key_file
 
-# Healthcheck service configuration.
+# Health-check service configuration.
 #healthcheck:
-# Timeout for CQL status checks.
-#  timeout: 250ms
-#  ssl_timeout: 750ms
-#
-# Dynamic timeout calculates timeout based on past measurements.
-# It takes recent RTTs, calculates mean (m), standard deviation (stddev),
-# and returns timeout of next probe equal to m + stddev_multiplier * max(stddev, 1ms).
-#
-# Higher stddev_multiplier is recommended on stable network environments,
-# because standard deviation may be close to 0.
-#  dynamic_timeout:
-#    enabled: true
-#    probes: 200
-#    max_timeout: 30s
-#    stddev_multiplier: 5
-#
+# relative_timeout specifies timeout over median ping duration in probes.
+# The number of probes kept in memory is specified by the probes parameter.
+# There are separate probes for different DCs and ping types
+# (CQL, REST, Alternator).
+#  relative_timeout: 50ms
+# max_timeout specifies maximum ping timeout, zero means no limit.
+#  max_timeout: 30s
+# Probes specifies how many probes are kept in memory for calculation.
+# For different ping types and datacenters there are different probe sets.
+#  probes: 200
+
 # Backup service configuration.
 #backup:
 # Minimal amount of free disk space required to take a snapshot.

--- a/pkg/config/server_test.go
+++ b/pkg/config/server_test.go
@@ -67,15 +67,10 @@ func TestConfigModification(t *testing.T) {
 			UserKeyFile:  "ssl.key",
 		},
 		Healthcheck: healthcheck.Config{
-			Timeout:    time.Second,
-			SSLTimeout: time.Second,
-			DynamicTimeout: healthcheck.DynamicTimeoutConfig{
-				Enabled:          true,
-				Probes:           500,
-				StdDevMultiplier: 100,
-				MaxTimeout:       1 * time.Minute,
-			},
-			NodeInfoTTL: time.Second,
+			RelativeTimeout: time.Second,
+			MaxTimeout:      1 * time.Minute,
+			Probes:          500,
+			NodeInfoTTL:     time.Second,
 		},
 		Backup: backup.Config{
 			DiskSpaceFreeMinPercent:   1,

--- a/pkg/config/testdata/server/scylla-manager.yaml
+++ b/pkg/config/testdata/server/scylla-manager.yaml
@@ -31,13 +31,9 @@ ssl:
   user_cert_file: ssl.cert
 
 healthcheck:
-  timeout: 1s
-  ssl_timeout: 1s
-  dynamic_timeout:
-    enabled: true
-    probes: 500
-    max_timeout: 1m
-    stddev_multiplier: 100
+  relative_timeout: 1s
+  max_timeout: 1m
+  probes: 500
   node_info_ttl: 1s
 
 backup:

--- a/pkg/service/healthcheck/config.go
+++ b/pkg/service/healthcheck/config.go
@@ -18,44 +18,25 @@ var (
 
 // Config specifies the healthcheck service configuration.
 type Config struct {
-	// Timeout specifies CQL ping timeout.
-	Timeout time.Duration `yaml:"timeout"`
-	// SSLTimeout specifies encrypted CQL ping timeout.
-	SSLTimeout time.Duration `yaml:"ssl_timeout"`
-	// DynamicTimeout specifies dynamic timeout configuration.
-	DynamicTimeout DynamicTimeoutConfig `yaml:"dynamic_timeout"`
+	// RelativeTimeout specifies timeout over median ping duration in probes.
+	// The number of probes kept in memory is specified by the probes parameter.
+	// There are separate probes for different DCs and ping types
+	// (CQL, REST, Alternator).
+	RelativeTimeout time.Duration `yaml:"relative_timeout"`
+	// MaxTimeout specifies maximum ping timeout, zero means no limit.
+	MaxTimeout time.Duration `yaml:"max_timeout"`
+	// Probes specifies how many probes are kept in memory for calculation.
+	// For different ping types and datacenters there are different probe sets.
+	Probes int `yaml:"probes"`
 	// NodeInfoTTL specifies how long node info should be cached.
 	NodeInfoTTL time.Duration `yaml:"node_info_ttl"`
 }
 
-// DynamicTimeoutConfig specifies healthcheck dynamic timeouts.
-// Dynamic timeout calculates timeout based on past measurements.
-// It takes recent RTTs, calculates mean (m), standard deviation (stddev),
-// and returns timeout of next probe equal to m + stddev_multiplier * max(stddev, 1ms).
-type DynamicTimeoutConfig struct {
-	// Enabled controls whether dynamic timeout is enabled or not.
-	Enabled bool `yaml:"enabled"`
-	// Probes specifies how many recent probes are kept in memory and are
-	// part of calculations.
-	Probes int `yaml:"probes"`
-	// MaxTimeout specifies maximum value of calculated timeout.
-	// Zero MaxTimeout means no limit on learned dynamic timeout.
-	MaxTimeout time.Duration `yaml:"max_timeout"`
-	// StdDeviationMultiplier controls how many standard deviations should be added to the next timeout.
-	// For stable connections it's recommended to set this value high.
-	StdDevMultiplier int `yaml:"stddev_multiplier"`
-}
-
 func DefaultConfig() Config {
 	return Config{
-		Timeout:    250 * time.Millisecond,
-		SSLTimeout: 750 * time.Millisecond,
-		DynamicTimeout: DynamicTimeoutConfig{
-			Enabled:          true,
-			Probes:           200,
-			StdDevMultiplier: 5,
-			MaxTimeout:       30 * time.Second,
-		},
-		NodeInfoTTL: 5 * time.Minute,
+		RelativeTimeout: 50 * time.Millisecond,
+		MaxTimeout:      30 * time.Second,
+		Probes:          200,
+		NodeInfoTTL:     5 * time.Minute,
 	}
 }

--- a/pkg/service/healthcheck/export_test.go
+++ b/pkg/service/healthcheck/export_test.go
@@ -1,0 +1,11 @@
+// Copyright (C) 2017 ScyllaDB
+
+package healthcheck
+
+import "time"
+
+func (dt *dynamicTimeout) calculateTimeout() time.Duration {
+	dt.mu.RLock()
+	defer dt.mu.RUnlock()
+	return dt.calculateTimeoutLocked()
+}

--- a/pkg/service/healthcheck/metrics.go
+++ b/pkg/service/healthcheck/metrics.go
@@ -79,27 +79,6 @@ var (
 		Name:      "alternator_timeout_ms",
 		Help:      "Host Alternator Timeout",
 	}, []string{clusterKey, dcKey})
-
-	rttMean = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "scylla_manager",
-		Subsystem: "healthcheck",
-		Name:      "rtt_mean_ms",
-		Help:      "Statistical mean for the collection of recent runs",
-	}, []string{clusterKey, dcKey, pingTypeKey})
-
-	rttStandardDeviation = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "scylla_manager",
-		Subsystem: "healthcheck",
-		Name:      "standard_deviation_ms",
-		Help:      "Standard deviation for rtt duration over collection of recent runs",
-	}, []string{clusterKey, dcKey, pingTypeKey})
-
-	rttNoise = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "scylla_manager",
-		Subsystem: "healthcheck",
-		Name:      "noise_ms",
-		Help:      "How much to add to the mean to get timeout value",
-	}, []string{clusterKey, dcKey, pingTypeKey})
 )
 
 func init() {
@@ -113,9 +92,6 @@ func init() {
 		alternatorStatus,
 		alternatorRTT,
 		alternatorTimeout,
-		rttMean,
-		rttStandardDeviation,
-		rttNoise,
 	)
 }
 

--- a/pkg/service/healthcheck/runner.go
+++ b/pkg/service/healthcheck/runner.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scylladb/go-set/strset"
+	"github.com/scylladb/scylla-manager/pkg/ping"
 	"github.com/scylladb/scylla-manager/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/pkg/util/parallel"
 	"github.com/scylladb/scylla-manager/pkg/util/uuid"
@@ -79,7 +80,10 @@ func (r Runner) checkHosts(ctx context.Context, clusterID uuid.UUID, status []sc
 		r.metrics.rtt.With(hl).Set(float64(rtt.Milliseconds()))
 		r.metrics.timeout.With(dl).Set(float64(timeout.Milliseconds()))
 
-		dt.Record(rtt)
+		// Record RTT only in case of success or timeout.
+		if err == nil || errors.Is(err, ping.ErrTimeout) {
+			dt.Record(rtt)
+		}
 
 		return nil
 	})

--- a/pkg/service/healthcheck/runner.go
+++ b/pkg/service/healthcheck/runner.go
@@ -96,17 +96,9 @@ func (r Runner) removeMetricsForCluster(clusterID uuid.UUID) {
 			clusterKey: clusterID.String(),
 			dcKey:      dc,
 		}
-		dpl := prometheus.Labels{
-			clusterKey:  clusterID.String(),
-			dcKey:       dc,
-			pingTypeKey: pt,
-		}
 		r.metrics.status.Delete(hl)
 		r.metrics.rtt.Delete(hl)
 		r.metrics.timeout.Delete(dl)
-		rttMean.Delete(dpl)
-		rttStandardDeviation.Delete(dpl)
-		rttNoise.Delete(dpl)
 	})
 }
 

--- a/pkg/service/healthcheck/service.go
+++ b/pkg/service/healthcheck/service.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/scylla-manager/pkg/ping"
 	"github.com/scylladb/scylla-manager/pkg/ping/cqlping"
@@ -522,16 +521,7 @@ func (s *Service) timeout(clusterID uuid.UUID, dc string, pt pingType) (timeout 
 	if t, ok := s.dynamicTimeouts[key]; ok {
 		dt = t
 	} else {
-		dt = newDynamicTimeout(s.config.DynamicTimeout, func(mean, stddev, noise time.Duration) {
-			l := prometheus.Labels{
-				clusterKey:  clusterID.String(),
-				dcKey:       dc,
-				pingTypeKey: pt.String(),
-			}
-			rttMean.With(l).Set(float64(mean.Milliseconds()))
-			rttStandardDeviation.With(l).Set(float64(stddev.Milliseconds()))
-			rttNoise.With(l).Set(float64(noise.Milliseconds()))
-		})
+		dt = newDynamicTimeout(s.config.DynamicTimeout)
 		s.dynamicTimeouts[key] = dt
 	}
 

--- a/pkg/service/healthcheck/service_integration_test.go
+++ b/pkg/service/healthcheck/service_integration_test.go
@@ -192,7 +192,7 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, secretsStore store
 
 		golden := []NodeStatus{
 			{Datacenter: "dc1", Host: "192.168.100.11", CQLStatus: "UP", RESTStatus: "UP", AlternatorStatus: "UP"},
-			{Datacenter: "dc1", Host: "192.168.100.12", CQLStatus: "UP", RESTStatus: "DOWN", AlternatorStatus: "UP"},
+			{Datacenter: "dc1", Host: "192.168.100.12", CQLStatus: "UP", RESTStatus: "DOWN", RESTCause: "dial tcp 192.168.100.12:10001: connect: connection refused", AlternatorStatus: "UP"},
 			{Datacenter: "dc1", Host: "192.168.100.13", CQLStatus: "UP", RESTStatus: "UP", AlternatorStatus: "UP"},
 			{Datacenter: "dc2", Host: "192.168.100.21", CQLStatus: "UP", RESTStatus: "UP", AlternatorStatus: "UP"},
 			{Datacenter: "dc2", Host: "192.168.100.22", CQLStatus: "UP", RESTStatus: "UP", AlternatorStatus: "UP"},

--- a/pkg/service/healthcheck/service_integration_test.go
+++ b/pkg/service/healthcheck/service_integration_test.go
@@ -64,7 +64,7 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, secretsStore store
 
 	// Tests here do not test the dynamic t/o functionality
 	c := DefaultConfig()
-	c.DynamicTimeout.Enabled = false
+	c.MaxTimeout = time.Second
 
 	hrt := NewHackableRoundTripper(scyllaclient.DefaultTransport())
 	s, err := NewService(

--- a/pkg/service/healthcheck/timeout_test.go
+++ b/pkg/service/healthcheck/timeout_test.go
@@ -14,7 +14,7 @@ func TestDynamicTimeoutDoNotExceedMaxTimeout(t *testing.T) {
 		MaxTimeout:       time.Second,
 		StdDevMultiplier: 5,
 	}
-	dt := newDynamicTimeout(config, nil)
+	dt := newDynamicTimeout(config)
 
 	for i := 0; i < config.Probes; i++ {
 		dt.SaveProbe(2 * config.MaxTimeout)
@@ -32,7 +32,7 @@ func TestDynamicTimeoutOverridesOldestProbes(t *testing.T) {
 		MaxTimeout:       time.Second,
 		StdDevMultiplier: 5,
 	}
-	dt := newDynamicTimeout(config, nil)
+	dt := newDynamicTimeout(config)
 
 	for i := 0; i < config.Probes; i++ {
 		dt.SaveProbe(5 * time.Millisecond)

--- a/pkg/service/healthcheck/timeout_test.go
+++ b/pkg/service/healthcheck/timeout_test.go
@@ -8,41 +8,35 @@ import (
 )
 
 func TestDynamicTimeoutDoNotExceedMaxTimeout(t *testing.T) {
-	config := DynamicTimeoutConfig{
-		Enabled:          true,
-		Probes:           10,
-		MaxTimeout:       time.Second,
-		StdDevMultiplier: 5,
-	}
-	dt := newDynamicTimeout(config)
+	maxTimeout := time.Second
+	probes := 10
 
-	for i := 0; i < config.Probes; i++ {
-		dt.SaveProbe(2 * config.MaxTimeout)
+	dt := newDynamicTimeout(maxTimeout, probes)
+
+	for i := 0; i < probes; i++ {
+		dt.SaveProbe(2 * maxTimeout)
 	}
 
-	if dt.Timeout() != config.MaxTimeout {
+	if dt.Timeout() != maxTimeout {
 		t.Errorf("Expected timeout not not exceed max timeout")
 	}
 }
 
 func TestDynamicTimeoutOverridesOldestProbes(t *testing.T) {
-	config := DynamicTimeoutConfig{
-		Enabled:          true,
-		Probes:           10,
-		MaxTimeout:       time.Second,
-		StdDevMultiplier: 5,
-	}
-	dt := newDynamicTimeout(config)
+	maxTimeout := time.Second
+	probes := 10
 
-	for i := 0; i < config.Probes; i++ {
+	dt := newDynamicTimeout(maxTimeout, probes)
+
+	for i := 0; i < probes; i++ {
 		dt.SaveProbe(5 * time.Millisecond)
 	}
-	for i := 0; i < config.Probes; i++ {
+	for i := 0; i < probes; i++ {
 		dt.SaveProbe(10 * time.Millisecond)
 	}
 
 	// All probes are equal so stddev is 0 and mean is equal to value of probes
-	expectedTimeout := 10*time.Millisecond + time.Duration(config.StdDevMultiplier)*minStddev
+	expectedTimeout := 10*time.Millisecond + minStddev
 	if dt.Timeout() != expectedTimeout {
 		t.Errorf("Expected timeout equal to %s got %s", expectedTimeout, dt.Timeout())
 	}


### PR DESCRIPTION
New implementation of dynamicTimeout
- API is changed we no longer return a function to set result, there are two public functions Timeout and Record used by Service and Runners
- The average algorithm is changed from mean to median
- The stddev multiplier is replaced by explicit setting of acceptable time offset to the median value

New config options

```
# Health-check service configuration.
#healthcheck:
# relative_timeout specifies timeout over median ping duration in probes.
# The number of probes kept in memory is specified by the probes parameter.
# There are separate probes for different DCs and ping types
# (CQL, REST, Alternator).
#  relative_timeout: 50ms
# max_timeout specifies maximum ping timeout, zero means no limit.
#  max_timeout: 30s
# Probes specifies how many probes are kept in memory for calculation.
# For different ping types and datacenters there are different probe sets.
#  probes: 200
```

Fixes #2801