### PR TITLE
scheduler: add generic purpose scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,9 +125,11 @@ pkg-integration-test:
 
 .PHONY: pkg-stress-test
 pkg-stress-test: ## Run unit tests for a package in parallel in a loop to detect sporadic failures, requires PKG parameter
+pkg-stress-test: RUN=Test
+pkg-stress-test:
 	@echo "==> Running stress tests for package $(PKG) (race)"
 	@go test -race -c -o stress.test $(PKG)
-	@cd $(PKG); $(GOBIN)/stress $(PWD)/stress.test
+	@cd $(PKG); $(GOBIN)/stress $(PWD)/stress.test -test.run $(RUN)
 
 .PHONY: start-dev-env
 start-dev-env: ## Start testing containers and run server

--- a/pkg/scheduler/activation.go
+++ b/pkg/scheduler/activation.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2017 ScyllaDB
+
+package scheduler
+
+import (
+	"container/heap"
+	"time"
+)
+
+type activation struct {
+	time.Time
+	Key Key
+}
+
+// activationHeap implements heap.Interface.
+// The activations are sorted by time in ascending order.
+type activationHeap []activation
+
+var _ heap.Interface = (*activationHeap)(nil)
+
+func (h activationHeap) Len() int { return len(h) }
+
+func (h activationHeap) Less(i, j int) bool {
+	return h[i].UnixNano() < h[j].UnixNano()
+}
+
+func (h activationHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *activationHeap) Push(x interface{}) {
+	*h = append(*h, x.(activation))
+}
+
+func (h *activationHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	*h = old[0 : n-1]
+	return item
+}
+
+// activationQueue is a priority queue based on activationHeap.
+// There may be only a single activation for a given activation key.
+// On Push if key exists it is updated.
+type activationQueue struct {
+	h activationHeap
+}
+
+func newActivationQueue() *activationQueue {
+	return &activationQueue{
+		h: []activation{},
+	}
+}
+
+// Push returns true iff head was changed.
+func (q *activationQueue) Push(a activation) bool {
+	if idx := q.find(a.Key); idx >= 0 {
+		[]activation(q.h)[idx] = a
+		heap.Fix(&q.h, idx)
+	} else {
+		heap.Push(&q.h, a)
+	}
+	return q.h[0].Key == a.Key
+}
+
+func (q *activationQueue) Pop() (activation, bool) {
+	if len(q.h) == 0 {
+		return activation{}, false
+	}
+	return heap.Pop(&q.h).(activation), true
+}
+
+func (q *activationQueue) Top() (activation, bool) {
+	if len(q.h) == 0 {
+		return activation{}, false
+	}
+	return []activation(q.h)[0], true
+}
+
+// Remove returns true iff head if head was changed.
+func (q *activationQueue) Remove(key Key) bool {
+	idx := q.find(key)
+	if idx >= 0 {
+		heap.Remove(&q.h, idx)
+	}
+	return idx == 0
+}
+
+func (q *activationQueue) find(key Key) int {
+	for i, v := range q.h {
+		if v.Key == key {
+			return i
+		}
+	}
+	return -1
+}
+
+func (q *activationQueue) Size() int {
+	return len(q.h)
+}

--- a/pkg/scheduler/activation_test.go
+++ b/pkg/scheduler/activation_test.go
@@ -1,0 +1,104 @@
+// Copyright (C) 2017 ScyllaDB
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/scylladb/scylla-manager/pkg/util/uuid"
+)
+
+func makeTestActivation(sec int) activation {
+	return activation{
+		Time: unixTime(sec),
+		Key:  Key(uuid.MustRandom()),
+	}
+}
+
+func TestActivationQueue(t *testing.T) {
+	t.Run("push and pop", func(t *testing.T) {
+		q := newActivationQueue()
+		q.Push(makeTestActivation(2))
+		q.Push(makeTestActivation(1))
+		a0 := makeTestActivation(0)
+		q.Push(a0)
+		a3 := makeTestActivation(3)
+		a3.Key = a0.Key
+		q.Push(a3)
+
+		n := q.Size()
+		for i := 1; i < n; i++ {
+			a, ok := q.Pop()
+			if !ok {
+				t.Fatalf("Pop() = %v, %v, expected activation at %s", a, ok, unixTime(i))
+			}
+			if a.Time != unixTime(i) {
+				t.Fatalf("Pop() = %v, %v, expected activation at %s", a, ok, unixTime(i))
+			}
+		}
+	})
+
+	t.Run("top", func(t *testing.T) {
+		q := newActivationQueue()
+		q.Push(makeTestActivation(2))
+		q.Push(makeTestActivation(1))
+		q.Push(makeTestActivation(0))
+
+		n := q.Size()
+		for i := 0; i < n; i++ {
+			top, ok := q.Top()
+			if !ok {
+				t.Fatalf("Top() = %v, %v, expected ok to be true", top, ok)
+			}
+			q.Pop()
+		}
+	})
+
+	t.Run("top and pop", func(t *testing.T) {
+		q := newActivationQueue()
+
+		top, ok := q.Top()
+		if ok {
+			t.Fatalf("top() = %v, %v, expected ok to be false", top, ok)
+		}
+		pop, ok := q.Pop()
+		if ok {
+			t.Fatalf("pop() = %v, %v, expected ok to be false", top, ok)
+		}
+		if pop != top {
+			t.Fatalf("top() = %v, pop() = %v", top, pop)
+		}
+	})
+
+	t.Run("find", func(t *testing.T) {
+		q := newActivationQueue()
+		q.Push(makeTestActivation(2))
+		q.Push(makeTestActivation(1))
+		q.Push(makeTestActivation(0))
+
+		n := q.Size()
+		for i := 0; i < n; i++ {
+			if idx := q.find(q.h[i].Key); idx != i {
+				t.Fatalf("find() = %d, expected %d", idx, i)
+			}
+		}
+	})
+
+	t.Run("remove", func(t *testing.T) {
+		q := newActivationQueue()
+		a2 := makeTestActivation(2)
+		q.Push(a2)
+		a1 := makeTestActivation(1)
+		q.Push(a1)
+		a0 := makeTestActivation(0)
+		q.Push(a0)
+
+		if ok := q.Remove(a0.Key); !ok {
+			t.Fatalf("Remove()=%v, expected true", ok)
+		}
+
+		if a, _ := q.Pop(); a.Time != unixTime(1) {
+			t.Fatalf("Pop() = %v, expected activation at %s", a, unixTime(1))
+		}
+	})
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,0 +1,310 @@
+// Copyright (C) 2017 ScyllaDB
+
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/scylladb/go-log"
+	"github.com/scylladb/scylla-manager/pkg/util/uuid"
+)
+
+// Key is unique identifier of a task in scheduler.
+type Key uuid.UUID
+
+func (k Key) String() string {
+	return uuid.UUID(k).String()
+}
+
+// Properties specify task details and are passed to RunFunc.
+type Properties struct {
+	json.RawMessage
+	NoContinue bool
+}
+
+// RunFunc specifies interface for key execution.
+// When the provided context is cancelled function must return with
+// context.Cancelled error, or an error caused by this error.
+// Compatible functions can be passed to Scheduler constructor.
+type RunFunc func(ctx context.Context, key Key, properties Properties) error
+
+// Trigger provides the next activation date.
+// Implementations must return the same values for the same now parameter.
+// A zero time can be returned to indicate no more executions.
+type Trigger interface {
+	Next(now time.Time) time.Time
+}
+
+// Scheduler manages keys and triggers.
+// A key uniquely identifies a scheduler task.
+// There can be a single instance of a key scheduled or running at all times.
+// Scheduler gets the next activation time for a key from a trigger.
+// On key activation the RunFunc is called.
+type Scheduler struct {
+	now    func() time.Time
+	run    RunFunc
+	logger log.Logger
+	timer  *time.Timer
+
+	queue      *activationQueue
+	properties map[Key]Properties
+	trigger    map[Key]Trigger
+	running    map[Key]context.CancelFunc
+	mu         sync.Mutex
+
+	wakeupCh chan struct{}
+	wg       sync.WaitGroup
+}
+
+func NewScheduler(now func() time.Time, run RunFunc, logger log.Logger) *Scheduler {
+	return &Scheduler{
+		now:        now,
+		run:        run,
+		logger:     logger,
+		timer:      time.NewTimer(0),
+		queue:      newActivationQueue(),
+		properties: make(map[Key]Properties),
+		trigger:    make(map[Key]Trigger),
+		running:    make(map[Key]context.CancelFunc),
+		wakeupCh:   make(chan struct{}),
+	}
+}
+
+// Schedule updates properties and trigger of an existing key or add a new key.
+func (s *Scheduler) Schedule(ctx context.Context, key Key, properties Properties, trigger Trigger) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	next := trigger.Next(s.now())
+
+	s.logger.Info(ctx, "Schedule", "key", key, "next", next)
+
+	if next.IsZero() {
+		s.logger.Info(ctx, "No triggers, removing", "key", key)
+		s.unscheduleLocked(key)
+		return
+	}
+
+	s.properties[key] = properties
+	s.trigger[key] = trigger
+
+	// If running key will be scheduled when done in reschedule.
+	if _, running := s.running[key]; !running {
+		if s.queue.Push(activation{Key: key, Time: next}) {
+			s.wakeup()
+		}
+	}
+}
+
+func (s *Scheduler) reschedule(key Key) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cancel, ok := s.running[key]
+	if ok {
+		cancel()
+	}
+	delete(s.running, key)
+
+	t, ok := s.trigger[key]
+	if !ok {
+		return
+	}
+
+	next := t.Next(s.now())
+	if next.IsZero() {
+		s.unscheduleLocked(key)
+		return
+	}
+
+	if s.queue.Push(activation{Key: key, Time: next}) {
+		s.wakeup()
+	}
+}
+
+// Unschedule cancels schedule of a key. It does not stop an active run.
+func (s *Scheduler) Unschedule(ctx context.Context, key Key) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logger.Info(ctx, "Unschedule", "key", key)
+	s.unscheduleLocked(key)
+}
+
+func (s *Scheduler) unscheduleLocked(key Key) {
+	delete(s.properties, key)
+	delete(s.trigger, key)
+	if s.queue.Remove(key) {
+		s.wakeup()
+	}
+}
+
+// Trigger immediately runs a key.
+// If key is already running the call will have no effect.
+// Properties can be modified for this run with options.
+func (s *Scheduler) Trigger(ctx context.Context, key Key, opts ...func(p Properties) Properties) {
+	s.mu.Lock()
+	s.logger.Info(ctx, "Manual trigger", "key", key)
+
+	if _, running := s.running[key]; running {
+		s.logger.Info(ctx, "Manual trigger ignored - already running", "key", key)
+		s.mu.Unlock()
+		return
+	}
+
+	if s.queue.Remove(key) {
+		s.wakeup()
+	}
+	runCtx, cancel := context.WithCancel(context.Background())
+	s.running[key] = cancel
+	p := s.properties[key]
+	s.mu.Unlock()
+
+	for _, o := range opts {
+		p = o(p)
+	}
+
+	s.asyncRun(runCtx, key, p)
+}
+
+// Stop notifies RunFunc to stop by cancelling the context.
+func (s *Scheduler) Stop(ctx context.Context, key Key) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logger.Info(ctx, "Stop", "key", key)
+	if cancel, ok := s.running[key]; ok {
+		cancel()
+	}
+}
+
+// StopAll is equivalent to calling Stop for every running key.
+func (s *Scheduler) StopAll(ctx context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logger.Info(ctx, "Stop all")
+	for _, cancel := range s.running {
+		cancel()
+	}
+}
+
+// Start is the scheduler main loop.
+func (s *Scheduler) Start(ctx context.Context) {
+	s.logger.Info(ctx, "Scheduler started")
+
+	for {
+		var d time.Duration
+		s.mu.Lock()
+		top, ok := s.queue.Top()
+		s.mu.Unlock()
+		if !ok {
+			d = -1
+		} else {
+			d = s.activateIn(top)
+		}
+
+		if d < 0 {
+			s.logger.Debug(ctx, "Waiting...")
+		} else {
+			s.logger.Debug(ctx, "Waiting for key", "key", top.Key, "sleep", d)
+		}
+
+		if !s.sleep(ctx, d) {
+			if ctx.Err() != nil {
+				s.logger.Debug(ctx, "Context canceled")
+				break
+			}
+			continue
+		}
+
+		s.mu.Lock()
+		a, ok := s.queue.Pop()
+		if a != top {
+			if ok {
+				s.queue.Push(a)
+			}
+			s.mu.Unlock()
+			continue
+		}
+		p := s.properties[a.Key]
+		runCtx, cancel := context.WithCancel(context.Background())
+		s.running[a.Key] = cancel
+		s.mu.Unlock()
+
+		s.asyncRun(runCtx, a.Key, p)
+	}
+
+	s.logger.Info(ctx, "Scheduler stopped")
+}
+
+func (s *Scheduler) activateIn(a activation) time.Duration {
+	d := a.Sub(s.now())
+	if d < 0 {
+		d = 0
+	}
+	return d
+}
+
+// sleep waits for one of the following events: context is cancelled,
+// duration expires (if d >= 0) or wakeup function is called.
+// If d < 0 the timer is disabled.
+// Returns true iff timer expired.
+func (s *Scheduler) sleep(ctx context.Context, d time.Duration) bool {
+	if !s.timer.Stop() {
+		select {
+		case <-s.timer.C:
+		default:
+		}
+	}
+
+	if d == 0 {
+		return true
+	}
+
+	var timer <-chan time.Time
+	if d > 0 {
+		s.timer.Reset(d)
+		timer = s.timer.C
+	}
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-s.wakeupCh:
+		return false
+	case <-timer:
+		return true
+	}
+}
+
+func (s *Scheduler) wakeup() {
+	select {
+	case s.wakeupCh <- struct{}{}:
+	default:
+	}
+}
+
+func (s *Scheduler) asyncRun(ctx context.Context, key Key, p Properties) {
+	ctx = log.WithNewTraceID(ctx)
+	s.logger.Info(ctx, "Run", "key", key)
+
+	s.wg.Add(1)
+	go func(ctx context.Context, key Key, p Properties) {
+		defer s.wg.Done()
+
+		err := s.run(ctx, key, p)
+		if err != nil {
+			s.logger.Info(ctx, "Run failed", "key", key, "error", err)
+		} else {
+			s.logger.Info(ctx, "Run done", "key", key)
+		}
+
+		s.reschedule(key)
+	}(ctx, key, p)
+}
+
+// Wait joins all active runs.
+func (s *Scheduler) Wait() {
+	s.wg.Wait()
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,0 +1,386 @@
+// Copyright (C) 2017 ScyllaDB
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/scylladb/go-log"
+	"github.com/scylladb/scylla-manager/pkg/util/timeutc"
+	"github.com/scylladb/scylla-manager/pkg/util/uuid"
+	"go.uber.org/atomic"
+)
+
+const (
+	Timeout     = 1 * time.Second
+	StartOffset = 10 * time.Millisecond
+)
+
+func unixTime(sec int) time.Time {
+	return time.Unix(int64(sec), 0)
+}
+
+func relativeTime() func() time.Time {
+	start := timeutc.Now()
+	return func() time.Time {
+		return unixTime(0).Add(timeutc.Since(start))
+	}
+}
+
+func startAndWait(ctx context.Context, s *Scheduler) chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		s.Start(ctx)
+		close(ch)
+	}()
+	return ch
+}
+
+type fakeRunner struct {
+	c *atomic.Int64
+	C chan Key
+	F func(ctx context.Context, key Key, properties Properties) error
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{
+		c: atomic.NewInt64(0),
+		C: make(chan Key),
+	}
+}
+
+func (r *fakeRunner) Run(ctx context.Context, key Key, properties Properties) error {
+	r.c.Inc()
+	defer func() {
+		r.C <- key
+	}()
+	if r.F != nil {
+		return r.F(ctx, key, properties)
+	}
+	return nil
+}
+
+func (r *fakeRunner) WaitKeys(keys ...Key) chan struct{} {
+	ch := make(chan struct{})
+	go func() {
+		for i := 0; i < len(keys); i++ {
+			key := <-r.C
+			if key != keys[i] {
+				msg := fmt.Sprintf("Run key=%s, expected %s", key, keys[i])
+				panic(msg)
+			}
+		}
+		close(ch)
+	}()
+	return ch
+}
+
+func (r *fakeRunner) Count() int64 {
+	return r.c.Load()
+}
+
+func randomKey() Key {
+	return Key(uuid.MustRandom())
+}
+
+func randomKeys(n int) []Key {
+	keys := make([]Key, n)
+	for i := range keys {
+		keys[i] = randomKey()
+	}
+	return keys
+}
+
+func emptyProperties() Properties {
+	return Properties{}
+}
+
+type fakeTrigger struct {
+	a []time.Time
+}
+
+func newFakeTrigger(d ...time.Duration) fakeTrigger {
+	z := unixTime(0)
+	a := make([]time.Time, len(d))
+	for i := range d {
+		a[i] = z.Add(d[i])
+	}
+	return fakeTrigger{
+		a: a,
+	}
+}
+
+func (f fakeTrigger) Next(now time.Time) time.Time {
+	for _, t := range f.a {
+		if now.Before(t) {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
+func TestStopEmpty(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	f := newFakeRunner()
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+
+	time.AfterFunc(StartOffset, cancel)
+	select {
+	case <-startAndWait(ctx, s):
+	case <-time.After(Timeout):
+		t.Fatal("expected scheduler to be stopped")
+	}
+}
+
+func TestScheduleAfterStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	f := newFakeRunner()
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+
+	time.AfterFunc(StartOffset, func() {
+		cancel()
+		s.Schedule(ctx, randomKey(), emptyProperties(), newFakeTrigger(0))
+	})
+
+	select {
+	case <-startAndWait(ctx, s):
+	case <-time.After(Timeout):
+		t.Fatal("expected scheduler to be stopped")
+	}
+	if f.Count() != 0 {
+		t.Fatal("unexpected run")
+	}
+}
+
+func TestScheduleBeforeStart(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFakeRunner()
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+	s.Schedule(ctx, randomKey(), emptyProperties(), newFakeTrigger(100*time.Millisecond))
+
+	select {
+	case <-startAndWait(ctx, s):
+		t.Fatal("expected a run, scheduler exit")
+	case <-time.After(Timeout):
+		t.Fatal("expected a run, timeout")
+	case <-f.C:
+	}
+
+	if f.Count() != 1 {
+		t.Fatalf("Count()=%d, expected %d", f.Count(), 1)
+	}
+}
+
+func TestScheduleWhileRunning(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFakeRunner()
+	f.F = func(ctx context.Context, key Key, properties Properties) error {
+		time.Sleep(200 * time.Millisecond)
+		return nil
+	}
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+	k := randomKey()
+	s.Schedule(ctx, k, emptyProperties(), newFakeTrigger(50*time.Millisecond))
+
+	time.AfterFunc(100*time.Millisecond, func() {
+		s.Schedule(ctx, k, emptyProperties(), newFakeTrigger(300*time.Millisecond))
+	})
+
+	select {
+	case <-startAndWait(ctx, s):
+		t.Fatal("expected a run, scheduler exit")
+	case <-time.After(Timeout):
+		t.Fatal("expected a run, timeout")
+	case <-f.WaitKeys(k, k):
+	}
+}
+
+func TestStartSchedule(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFakeRunner()
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+
+	time.AfterFunc(StartOffset, func() {
+		s.Schedule(ctx, randomKey(), emptyProperties(), newFakeTrigger(100*time.Millisecond))
+	})
+
+	select {
+	case <-startAndWait(ctx, s):
+		t.Fatal("expected a run, scheduler exit")
+	case <-time.After(Timeout):
+		t.Fatal("expected a run, timeout")
+	case <-f.C:
+	}
+
+	if f.Count() != 1 {
+		t.Fatalf("Count()=%d, expected %d", f.Count(), 1)
+	}
+}
+
+func TestUnscheduleBeforeRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFakeRunner()
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+	k := randomKey()
+	s.Schedule(ctx, k, emptyProperties(), newFakeTrigger(500*time.Millisecond))
+
+	time.AfterFunc(StartOffset, func() {
+		s.Unschedule(ctx, k)
+	})
+
+	select {
+	case <-startAndWait(ctx, s):
+		t.Fatal("expected a run, scheduler exit")
+	case <-f.C:
+		t.Fatal("unexpected run")
+	case <-time.After(Timeout):
+	}
+}
+
+func TestUnschduleHead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFakeRunner()
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+	k := randomKeys(3)
+	s.Schedule(ctx, k[0], emptyProperties(), newFakeTrigger(500*time.Millisecond))
+	s.Schedule(ctx, k[1], emptyProperties(), newFakeTrigger(600*time.Millisecond))
+	s.Schedule(ctx, k[2], emptyProperties(), newFakeTrigger(700*time.Millisecond))
+
+	time.AfterFunc(StartOffset, func() {
+		s.Unschedule(ctx, k[0])
+	})
+
+	select {
+	case <-startAndWait(ctx, s):
+		t.Fatal("expected a run, scheduler exit")
+	case <-time.After(Timeout):
+		t.Fatal("expected a run, timeout")
+	case <-f.WaitKeys(k[1], k[2]):
+	}
+}
+
+func TestUnschduleTail(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFakeRunner()
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+	k := randomKeys(3)
+	s.Schedule(ctx, k[0], emptyProperties(), newFakeTrigger(500*time.Millisecond))
+	s.Schedule(ctx, k[1], emptyProperties(), newFakeTrigger(600*time.Millisecond))
+	s.Schedule(ctx, k[2], emptyProperties(), newFakeTrigger(700*time.Millisecond))
+
+	time.AfterFunc(StartOffset, func() {
+		s.Unschedule(ctx, k[1])
+	})
+
+	select {
+	case <-startAndWait(ctx, s):
+		t.Fatal("expected a run, scheduler exit")
+	case <-time.After(Timeout):
+		t.Fatal("expected a run, timeout")
+	case <-f.WaitKeys(k[0], k[2]):
+	}
+}
+
+func TestRescheduleHead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFakeRunner()
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+	k := randomKeys(3)
+	s.Schedule(ctx, k[0], emptyProperties(), newFakeTrigger(500*time.Millisecond))
+	s.Schedule(ctx, k[1], emptyProperties(), newFakeTrigger(600*time.Millisecond))
+	s.Schedule(ctx, k[2], emptyProperties(), newFakeTrigger(700*time.Millisecond))
+
+	time.AfterFunc(StartOffset, func() {
+		s.Schedule(ctx, k[0], emptyProperties(), newFakeTrigger(800*time.Millisecond))
+	})
+
+	select {
+	case <-startAndWait(ctx, s):
+		t.Fatal("expected a run, scheduler exit")
+	case <-time.After(Timeout):
+		t.Fatal("expected a run, timeout")
+	case <-f.WaitKeys(k[1], k[2], k[0]):
+	}
+}
+
+func TestRescheduleInterval(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFakeRunner()
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+	k := randomKeys(2)
+	s.Schedule(ctx, k[0], emptyProperties(), newFakeTrigger(100*time.Millisecond, 300*time.Millisecond, 400*time.Millisecond))
+	s.Schedule(ctx, k[1], emptyProperties(), newFakeTrigger(200*time.Millisecond))
+
+	select {
+	case <-startAndWait(ctx, s):
+		t.Fatal("expected a run, scheduler exit")
+	case <-time.After(Timeout):
+		t.Fatal("expected a run, timeout")
+	case <-f.WaitKeys(k[0], k[1], k[0], k[0]):
+	}
+}
+
+func TestTriggerHead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFakeRunner()
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+	k := randomKeys(3)
+	s.Schedule(ctx, k[0], emptyProperties(), newFakeTrigger(500*time.Millisecond))
+	s.Schedule(ctx, k[1], emptyProperties(), newFakeTrigger(600*time.Millisecond))
+	s.Schedule(ctx, k[2], emptyProperties(), newFakeTrigger(700*time.Millisecond))
+
+	time.AfterFunc(StartOffset, func() {
+		s.Trigger(ctx, k[0])
+	})
+
+	select {
+	case <-startAndWait(ctx, s):
+		t.Fatal("expected a run, scheduler exit")
+	case <-time.After(Timeout):
+		t.Fatal("expected a run, timeout")
+	case <-f.WaitKeys(k[0], k[0], k[1], k[2]):
+	}
+}
+
+func TestStop(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := newFakeRunner()
+	f.F = func(ctx context.Context, key Key, properties Properties) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	s := NewScheduler(relativeTime(), f.Run, log.NewDevelopment())
+	k := randomKeys(2)
+	s.Schedule(ctx, k[0], emptyProperties(), newFakeTrigger(100*time.Millisecond))
+	s.Schedule(ctx, k[1], emptyProperties(), newFakeTrigger(200*time.Millisecond))
+
+	time.AfterFunc(150*time.Millisecond, func() {
+		s.Stop(ctx, k[0])
+	})
+	time.AfterFunc(300*time.Millisecond, func() {
+		s.Stop(ctx, k[1])
+	})
+
+	select {
+	case <-startAndWait(ctx, s):
+		t.Fatal("expected a run, scheduler exit")
+	case <-time.After(Timeout):
+		t.Fatal("expected a run, timeout")
+	case <-f.WaitKeys(k[0], k[1]):
+	}
+}


### PR DESCRIPTION
The scheduler package is designed after Quartz project.
It borrows the idea of managing keys and a separation of task properties from the run queue.
Please find the mapping of Quartz core components to scheduler below

- [Job](https://www.quartz-scheduler.org/api/2.4.0-SNAPSHOT/org/quartz/Job.html) - RunFunc
- [JobKey](https://www.quartz-scheduler.org/api/2.4.0-SNAPSHOT/org/quartz/JobKey.html) - Key
- [JobDetail](https://www.quartz-scheduler.org/api/2.4.0-SNAPSHOT/org/quartz/JobDetail.html) - Properties
- [Trigger](https://www.quartz-scheduler.org/api/2.4.0-SNAPSHOT/org/quartz/Trigger.html) - Trigger

The interfaces are decluttered and translated to idiomatic Go.
Renames and customizations are done to better fit the current scheduler infrastructure (pkg/service/scheduler).

Please check Scheduler docs for details.