### PR TITLE
repair fallback to shard-aware (legacy) mode when intensity < 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ start-dev-env: .testing-up deploy-agent build-cli run-server
 
 .PHONY: .testing-up
 .testing-up:
-	@make -C testing build down up create-tables
+	@make -C testing build down up
 
 .PHONY: dev-env-status
 dev-env-status:  ## Checks status of docker containers and cluster nodes

--- a/pkg/service/repair/config.go
+++ b/pkg/service/repair/config.go
@@ -15,11 +15,11 @@ type Type string
 
 const (
 	// TypeAuto auto detects repair algo.
-	TypeAuto = "auto"
+	TypeAuto Type = "auto"
 	// TypeRowLevel row level repair.
-	TypeRowLevel = "row_level"
+	TypeRowLevel Type = "row_level"
 	// TypeLegacy legacy repair type.
-	TypeLegacy = "legacy"
+	TypeLegacy Type = "legacy"
 )
 
 // Config specifies the repair service configuration.
@@ -28,7 +28,7 @@ type Config struct {
 	LongPollingTimeoutSeconds       int           `yaml:"long_polling_timeout_seconds"`
 	AgeMax                          time.Duration `yaml:"age_max"`
 	GracefulStopTimeout             time.Duration `yaml:"graceful_stop_timeout"`
-	ForceRepairType                 string        `yaml:"force_repair_type"`
+	ForceRepairType                 Type          `yaml:"force_repair_type"`
 	Murmur3PartitionerIgnoreMSBBits int           `yaml:"murmur3_partitioner_ignore_msb_bits"`
 }
 

--- a/pkg/service/repair/controller.go
+++ b/pkg/service/repair/controller.go
@@ -241,10 +241,14 @@ func (c *rowLevelRepairController) block(hosts []string, ranges int) {
 }
 
 func (c *rowLevelRepairController) allowance(hosts []string, intensity float64) allowance {
-	return allowance{
+	a := allowance{
 		Replicas: hosts,
 		Ranges:   c.rangesForIntensity(hosts, intensity),
 	}
+	if intensity < 1 {
+		a.ShardsPercent = intensity
+	}
+	return a
 }
 
 func (c *rowLevelRepairController) rangesForIntensity(hosts []string, intensity float64) (ranges int) {

--- a/pkg/service/repair/controller_test.go
+++ b/pkg/service/repair/controller_test.go
@@ -234,12 +234,16 @@ func TestRowLevelRepairController(t *testing.T) {
 		unblockAll()
 
 		s.intensityHandler.SetIntensity(ctx, 0.5)
-		for i := 0; i < controllerTestDefaultRangesLimit/2; i++ {
-			if ok, a := ctl.TryBlock([]string{"a", "b", "c"}); !ok {
-				t.Fatal("TryBlock() failed to block")
-			} else {
-				queue = append(queue, a)
+		if ok, a := ctl.TryBlock([]string{"a", "b", "c"}); !ok {
+			t.Fatal("TryBlock() failed to block")
+		} else {
+			if a.Ranges != controllerTestDefaultRangesLimit {
+				t.Fatalf("TryBlock()=%v, expected %d ranges", a, controllerTestDefaultRangesLimit)
 			}
+			if a.ShardsPercent != 0.5 {
+				t.Fatalf("TryBlock()=%v, expected %f shards percent", a, 0.5)
+			}
+			queue = append(queue, a)
 		}
 		if ok, _ := ctl.TryBlock([]string{"a", "b", "c"}); ok {
 			t.Fatal("TryBlock() unexpected success")

--- a/pkg/service/repair/worker_test.go
+++ b/pkg/service/repair/worker_test.go
@@ -33,7 +33,6 @@ func TestWorkerRun(t *testing.T) {
 		longPollingTimeoutSeconds = 2
 		partitioner               = dht.NewMurmur3Partitioner(2, 12)
 		hostPartitioner           = map[string]*dht.Murmur3Partitioner{"h1": partitioner, "h2": partitioner}
-		emptyHostPartitioner      = make(map[string]*dht.Murmur3Partitioner)
 		run                       = &Run{ID: uuid.NewTime(), TaskID: uuid.NewTime()}
 	)
 
@@ -45,7 +44,7 @@ func TestWorkerRun(t *testing.T) {
 		}
 		hrt.SetInterceptor(repairInterceptor(true, ranges, 2))
 
-		w := newWorker(run, in, out, c, newNopProgressManager(), emptyHostPartitioner, scyllaFeatures(false, true), pollInterval, longPollingTimeoutSeconds, logger)
+		w := newWorker(run, in, out, c, newNopProgressManager(), hostPartitioner, scyllaFeatures(true, true), TypeRowLevel, pollInterval, longPollingTimeoutSeconds, logger)
 
 		go func() {
 			if err := w.Run(ctx); err != nil {
@@ -99,7 +98,7 @@ func TestWorkerRun(t *testing.T) {
 		}
 		hrt.SetInterceptor(repairInterceptor(false, ranges, 2))
 
-		w := newWorker(run, in, out, c, newNopProgressManager(), emptyHostPartitioner, scyllaFeatures(false, false), pollInterval, longPollingTimeoutSeconds, logger)
+		w := newWorker(run, in, out, c, newNopProgressManager(), hostPartitioner, scyllaFeatures(true, false), TypeRowLevel, pollInterval, longPollingTimeoutSeconds, logger)
 
 		go func() {
 			if err := w.Run(ctx); err != nil {
@@ -108,7 +107,7 @@ func TestWorkerRun(t *testing.T) {
 		}()
 
 		go func() {
-			for i := 0; i < 2; i++ {
+			for i := 1; i <= 2; i++ {
 				in <- job{
 					Host: fmt.Sprintf("h%d", i),
 					Ranges: []*tableTokenRange{
@@ -153,7 +152,7 @@ func TestWorkerRun(t *testing.T) {
 		}
 		hrt.SetInterceptor(repairInterceptor(true, ranges, 2))
 
-		w := newWorker(run, in, out, c, newNopProgressManager(), hostPartitioner, scyllaFeatures(false, false), pollInterval, longPollingTimeoutSeconds, logger)
+		w := newWorker(run, in, out, c, newNopProgressManager(), hostPartitioner, scyllaFeatures(false, false), TypeLegacy, pollInterval, longPollingTimeoutSeconds, logger)
 
 		go func() {
 			if err := w.Run(ctx); err != nil {
@@ -207,7 +206,7 @@ func TestWorkerRun(t *testing.T) {
 		}
 		hrt.SetInterceptor(repairInterceptor(true, ranges, 2))
 
-		w := newWorker(run, in, out, c, newNopProgressManager(), emptyHostPartitioner, scyllaFeatures(false, true), pollInterval, longPollingTimeoutSeconds, logger)
+		w := newWorker(run, in, out, c, newNopProgressManager(), hostPartitioner, scyllaFeatures(true, true), TypeRowLevel, pollInterval, longPollingTimeoutSeconds, logger)
 
 		go func() {
 			if err := w.Run(ctx); err != nil {


### PR DESCRIPTION
When running in row-level repair mode intensity < 1 specifies that there would be less token ranges repaired at the same time but all the shards will need to work in order to repair the token range.
This patch adds auto fallback to legacy mode when intensity < 1.

Fixes #2913