### PR TITLE
dist/.goreleaser: remove "agent" from tar file

### DIFF
--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -63,7 +63,7 @@ builds:
       - -X github.com/scylladb/scylla-manager/pkg.version={{ .Version }}
 
 archives:
-  - name_template: "{{ .ProjectName }}-agent_{{ .Version }}.{{ .Os }}_{{ .Arch }}"
+  - name_template: "{{ .ProjectName }}_{{ .Version }}.{{ .Os }}_{{ .Arch }}"
     files:
       - etc
       - license/LICENSE*


### PR DESCRIPTION
In scylla-manager tar file, we have both the client and agent, Let's remove the `agent` mention so it will less confusing
reported by @ShlomiBalalis