### PR TITLE
goreleaser:set arch in tar.gz file to match os

### DIFF
--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -69,6 +69,9 @@ archives:
       - license/LICENSE*
       - scripts
       - systemd
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
 
 nfpms:
   - id: server

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,5 +1,5 @@
 RELEASE      := 0.$(shell date +%Y%m%d).$(shell git describe --always)
-VERSION	     ?= 2.6-dev
+VERSION	     ?= 3.0-dev
 
 ifdef $$VERSION
 VERSION := $$VERSION


### PR DESCRIPTION
When running the command `uname -m` we get the machine arch type. Let's
align the reloc package filename to match it

