### PR TITLE
scyllaclient retry custom request

### DIFF
--- a/pkg/scyllaclient/client.go
+++ b/pkg/scyllaclient/client.go
@@ -112,8 +112,8 @@ func NewClient(config Config, logger log.Logger) (*Client, error) {
 	scyllaRuntime.Debug = false
 	agentRuntime.Debug = false
 
-	scyllaOps := scyllaOperations.New(retryable(scyllaRuntime, config, logger), strfmt.Default)
-	agentOps := agentOperations.New(retryable(agentRuntime, config, logger), strfmt.Default)
+	scyllaOps := scyllaOperations.New(retryable(scyllaRuntime, newRetryConfig(config), logger), strfmt.Default)
+	agentOps := agentOperations.New(retryable(agentRuntime, newRetryConfig(config), logger), strfmt.Default)
 
 	return &Client{
 		config:    config,

--- a/pkg/scyllaclient/client.go
+++ b/pkg/scyllaclient/client.go
@@ -70,7 +70,7 @@ type Client struct {
 
 	scyllaOps scyllaOperations.ClientService
 	agentOps  agentOperations.ClientService
-	transport http.RoundTripper
+	client    *http.Client
 
 	mu      sync.RWMutex
 	dcCache map[string]string
@@ -99,13 +99,13 @@ func NewClient(config Config, logger log.Logger) (*Client, error) {
 	transport = auth.AddToken(transport, config.AuthToken)
 	transport = fixContentType(transport)
 
-	c := &http.Client{Transport: transport}
+	client := &http.Client{Transport: transport}
 
 	scyllaRuntime := api.NewWithClient(
-		scyllaClient.DefaultHost, scyllaClient.DefaultBasePath, []string{config.Scheme}, c,
+		scyllaClient.DefaultHost, scyllaClient.DefaultBasePath, []string{config.Scheme}, client,
 	)
 	agentRuntime := api.NewWithClient(
-		agentClient.DefaultHost, agentClient.DefaultBasePath, []string{config.Scheme}, c,
+		agentClient.DefaultHost, agentClient.DefaultBasePath, []string{config.Scheme}, client,
 	)
 
 	// Debug can be turned on by SWAGGER_DEBUG or DEBUG env variable
@@ -120,7 +120,7 @@ func NewClient(config Config, logger log.Logger) (*Client, error) {
 		logger:    logger,
 		scyllaOps: scyllaOps,
 		agentOps:  agentOps,
-		transport: transport,
+		client:    client,
 		dcCache:   make(map[string]string),
 	}, nil
 }

--- a/pkg/scyllaclient/client_rclone.go
+++ b/pkg/scyllaclient/client_rclone.go
@@ -335,7 +335,7 @@ func (c *Client) RcloneOpen(ctx context.Context, host, remotePath string) (io.Re
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.transport.RoundTrip(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "round trip")
 	}
@@ -417,7 +417,7 @@ func (c *Client) RcloneListDirIter(ctx context.Context, host, remotePath string,
 	}
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := c.transport.RoundTrip(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "round trip")
 	}
@@ -498,7 +498,7 @@ func (c *Client) RclonePut(ctx context.Context, host, remotePath string, body *b
 	req.Header.Add("Content-Type", "application/octet-stream")
 	req.Header.Add("Content-Length", fmt.Sprint(body.Len()))
 
-	resp, err := c.transport.RoundTrip(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return errors.Wrap(err, "round trip")
 	}

--- a/pkg/scyllaclient/client_rclone.go
+++ b/pkg/scyllaclient/client_rclone.go
@@ -474,7 +474,7 @@ func (c *Client) RcloneCheckPermissions(ctx context.Context, host, remotePath st
 }
 
 // RclonePut uploads file with provided content under remotePath.
-func (c *Client) RclonePut(ctx context.Context, host, remotePath string, content io.Reader, size int64) error {
+func (c *Client) RclonePut(ctx context.Context, host, remotePath string, body *bytes.Buffer) error {
 	fs, remote, err := rcloneSplitRemotePath(remotePath)
 	if err != nil {
 		return err
@@ -485,7 +485,7 @@ func (c *Client) RclonePut(ctx context.Context, host, remotePath string, content
 	const urlPath = agentClient.DefaultBasePath + "/rclone/operations/put"
 
 	u := c.newURL(host, urlPath)
-	req, err := http.NewRequestWithContext(forceHost(ctx, host), http.MethodPost, u.String(), content)
+	req, err := http.NewRequestWithContext(forceHost(ctx, host), http.MethodPost, u.String(), body)
 	if err != nil {
 		return err
 	}
@@ -496,7 +496,7 @@ func (c *Client) RclonePut(ctx context.Context, host, remotePath string, content
 	req.URL.RawQuery = q.Encode()
 
 	req.Header.Add("Content-Type", "application/octet-stream")
-	req.Header.Add("Content-Length", fmt.Sprint(size))
+	req.Header.Add("Content-Length", fmt.Sprint(body.Len()))
 
 	resp, err := c.transport.RoundTrip(req)
 	if err != nil {

--- a/pkg/scyllaclient/client_rclone.go
+++ b/pkg/scyllaclient/client_rclone.go
@@ -335,15 +335,10 @@ func (c *Client) RcloneOpen(ctx context.Context, host, remotePath string) (io.Re
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do("OperationsCat", req)
 	if err != nil {
-		return nil, errors.Wrap(err, "round trip")
+		return nil, err
 	}
-	if resp.StatusCode != http.StatusOK {
-		defer resp.Body.Close()
-		return nil, makeAgentError(resp)
-	}
-
 	return resp.Body, nil
 }
 
@@ -395,6 +390,7 @@ func (c *Client) RcloneListDir(ctx context.Context, host, remotePath string, opt
 // Resulting item path is relative to the remote path.
 func (c *Client) RcloneListDirIter(ctx context.Context, host, remotePath string, opts *RcloneListDirOpts, f func(item *RcloneListDirItem)) error {
 	ctx = customTimeout(ctx, c.config.ListTimeout)
+	ctx = noRetry(ctx)
 
 	// Due to OpenAPI limitations we manually construct and sent the request
 	// object to stream process the response body.
@@ -417,15 +413,11 @@ func (c *Client) RcloneListDirIter(ctx context.Context, host, remotePath string,
 	}
 	req.Header.Add("Content-Type", "application/json")
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do("OperationsList", req)
 	if err != nil {
-		return errors.Wrap(err, "round trip")
+		return err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return makeAgentError(resp)
-	}
 
 	dec := json.NewDecoder(resp.Body)
 
@@ -494,20 +486,16 @@ func (c *Client) RclonePut(ctx context.Context, host, remotePath string, body *b
 	q.Add("fs", fs)
 	q.Add("remote", remote)
 	req.URL.RawQuery = q.Encode()
-
 	req.Header.Add("Content-Type", "application/octet-stream")
-	req.Header.Add("Content-Length", fmt.Sprint(body.Len()))
 
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do("OperationsPut", req)
 	if err != nil {
-		return errors.Wrap(err, "round trip")
+		return err
 	}
 	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return makeAgentError(resp)
+	if _, err := io.CopyN(io.Discard, resp.Body, resp.ContentLength); err != nil {
+		return err
 	}
-
 	return nil
 }
 

--- a/pkg/scyllaclient/client_rclone_test.go
+++ b/pkg/scyllaclient/client_rclone_test.go
@@ -435,7 +435,7 @@ func TestRcloneMoveFile(t *testing.T) {
 	ctx := context.Background()
 
 	// Put "a"
-	if err := client.RclonePut(ctx, scyllaclienttest.TestHost, "tmp:move/a", bytes.NewBufferString("a"), 1); err != nil {
+	if err := client.RclonePut(ctx, scyllaclienttest.TestHost, "tmp:move/a", bytes.NewBufferString("a")); err != nil {
 		t.Fatal("RclonePut() error", err)
 	}
 	// Move "b"
@@ -468,7 +468,7 @@ func TestRclonePut(t *testing.T) {
 
 	putString := func(s string) error {
 		b := bytes.NewBufferString(s)
-		err := client.RclonePut(ctx, scyllaclienttest.TestHost, "tmp:put/a", b, int64(b.Len()))
+		err := client.RclonePut(ctx, scyllaclienttest.TestHost, "tmp:put/a", b)
 		if err != nil {
 			t.Logf("RclonePut(%s) error = %s", s, err)
 		}

--- a/pkg/scyllaclient/client_rclone_test.go
+++ b/pkg/scyllaclient/client_rclone_test.go
@@ -119,8 +119,8 @@ func TestRcloneCat(t *testing.T) {
 			if err != nil {
 				errMsg = err.Error()
 			}
-			if test.Error != errMsg {
-				t.Fatalf("RcloneCat() error %s expected %s", test.Error, errMsg)
+			if !strings.Contains(errMsg, test.Error) {
+				t.Fatalf("RcloneCat() error %s expected %s", errMsg, test.Error)
 			}
 			if diff := cmp.Diff(content, test.Golden); diff != "" {
 				t.Fatal(content, diff)

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -310,7 +310,7 @@ func (c *Client) metrics(ctx context.Context, host, name string) (map[string]*pr
 		r.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.transport.RoundTrip(r)
+	resp, err := c.client.Do(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -310,11 +310,10 @@ func (c *Client) metrics(ctx context.Context, host, name string) (map[string]*pr
 		r.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.client.Do(r)
+	resp, err := c.client.Do("Metrics", r)
 	if err != nil {
 		return nil, err
 	}
-
 	defer resp.Body.Close()
 
 	return prom.ParseText(resp.Body)

--- a/pkg/scyllaclient/retry_test.go
+++ b/pkg/scyllaclient/retry_test.go
@@ -3,6 +3,7 @@
 package scyllaclient_test
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"strings"
@@ -20,7 +21,38 @@ func fastRetry(config *scyllaclient.Config) {
 	config.Backoff.WaitMin = 50 * time.Millisecond
 }
 
-func TestRetrySingleHost(t *testing.T) {
+func TestRetryRest(t *testing.T) {
+	s := repairTestSuite{
+		invokeClient: func(ctx context.Context, host string, client *scyllaclient.Client) error {
+			return client.RclonePut(ctx, host, "s3://foo/bar", bytes.NewBufferString("bar"))
+		},
+	}
+	s.Run(t)
+}
+
+func TestRetrySwagger(t *testing.T) {
+	s := repairTestSuite{
+		invokeClient: func(ctx context.Context, host string, client *scyllaclient.Client) error {
+			_, err := client.NodeInfo(ctx, host)
+			return err
+		},
+	}
+	s.Run(t)
+}
+
+type repairTestSuite struct {
+	invokeClient func(context.Context, string, *scyllaclient.Client) error
+}
+
+func (s repairTestSuite) Run(t *testing.T) {
+	t.Run("TestRetrySingleHost", s.TestRetrySingleHost)
+	t.Run("TestNoRetry", s.TestNoRetry)
+	t.Run("TestRetryCancelContext", s.TestRetryCancelContext)
+	t.Run("TestRetryShouldRetryHandler", s.TestRetryShouldRetryHandler)
+	t.Run("TestRetryTimeout", s.TestRetryTimeout)
+}
+
+func (s repairTestSuite) TestRetrySingleHost(t *testing.T) {
 	t.Parallel()
 
 	t.Run("error", func(t *testing.T) {
@@ -28,12 +60,12 @@ func TestRetrySingleHost(t *testing.T) {
 		defer closeServer()
 		client := scyllaclienttest.MakeClient(t, host, port, fastRetry)
 
-		_, err := client.NodeInfo(context.Background(), host)
+		err := s.invokeClient(context.Background(), host, client)
 		if err == nil {
-			t.Fatalf("NodeInfo() expected error")
+			t.Fatalf("invokeClient() expected error")
 		}
 		if !strings.Contains(err.Error(), "giving up after 4 attempts") {
-			t.Fatalf("NodeInfo() error = %s, expected giving up after 4 attempts", err.Error())
+			t.Fatalf("invokeClient() error = %s, expected giving up after 4 attempts", err.Error())
 		}
 	})
 
@@ -42,9 +74,156 @@ func TestRetrySingleHost(t *testing.T) {
 		defer closeServer()
 		client := scyllaclienttest.MakeClient(t, host, port, fastRetry)
 
-		_, err := client.NodeInfo(context.Background(), host)
+		err := s.invokeClient(context.Background(), host, client)
 		if err != nil {
-			t.Fatal("NodeInfo() error", err)
+			t.Fatal("invokeClient() error", err)
+		}
+	})
+}
+
+func (s repairTestSuite) TestNoRetry(t *testing.T) {
+	t.Parallel()
+
+	host, port, closeServer := scyllaclienttest.MakeServer(t, scyllaclienttest.RespondStatus(t, 999, 200))
+	defer closeServer()
+	client := scyllaclienttest.MakeClient(t, host, port, fastRetry)
+
+	ctx := scyllaclient.NoRetry(context.Background())
+	err := s.invokeClient(ctx, host, client)
+	if err == nil {
+		t.Fatalf("invokeClient() expected error")
+	}
+}
+
+func (s repairTestSuite) TestRetryCancelContext(t *testing.T) {
+	t.Parallel()
+
+	table := []struct {
+		Name    string
+		Handler http.Handler
+	}{
+		{
+			Name:    "Repeat",
+			Handler: scyllaclienttest.RespondStatus(t, 999, 999, 999, 200),
+		},
+		{
+			Name:    "Wait",
+			Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) { time.Sleep(time.Second) }),
+		},
+	}
+
+	for i := range table {
+		test := table[i]
+
+		t.Run(test.Name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			time.AfterFunc(50*time.Millisecond, cancel)
+
+			host, port, closeServer := scyllaclienttest.MakeServer(t, test.Handler)
+			defer closeServer()
+			client := scyllaclienttest.MakeClient(t, host, port, fastRetry)
+
+			err := s.invokeClient(ctx, host, client)
+			t.Log("invokeClient() error", err)
+
+			if err == nil {
+				t.Fatalf("invokeClient() expected error")
+			}
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("invokeClient() error=%s, expected context.Canceled", err)
+			}
+		})
+	}
+}
+
+func (s repairTestSuite) TestRetryShouldRetryHandler(t *testing.T) {
+	t.Parallel()
+
+	table := []struct {
+		Name               string
+		Handler            http.Handler
+		ShouldRetryHandler func(err error) *bool
+		Error              string
+	}{
+		{
+			Name:    "Always retry",
+			Handler: scyllaclienttest.RespondStatus(t, 400, 400, 400, 400),
+			ShouldRetryHandler: func(err error) *bool {
+				return pointer.BoolPtr(true)
+			},
+			Error: "giving up after 4 attempts: agent [HTTP 400]",
+		},
+		{
+			Name:    "Never retry",
+			Handler: scyllaclienttest.RespondStatus(t, 999, 999, 999, 999),
+			ShouldRetryHandler: func(err error) *bool {
+				return pointer.BoolPtr(false)
+			},
+			Error: "agent [HTTP 999]",
+		},
+		{
+			Name:    "Fallback",
+			Handler: scyllaclienttest.RespondStatus(t, 999, 400, 400, 400, 400),
+			ShouldRetryHandler: func(err error) *bool {
+				return nil
+			},
+			Error: "giving up after 2 attempts: agent [HTTP 400]",
+		},
+	}
+
+	for i := range table {
+		test := table[i]
+
+		t.Run(test.Name, func(t *testing.T) {
+			host, port, closeServer := scyllaclienttest.MakeServer(t, test.Handler)
+			defer closeServer()
+			client := scyllaclienttest.MakeClient(t, host, port, fastRetry)
+
+			ctx := scyllaclient.WithShouldRetryHandler(context.Background(), test.ShouldRetryHandler)
+			err := s.invokeClient(ctx, host, client)
+			t.Log("invokeClient() error", err)
+
+			if err == nil || test.Error == "" {
+				t.Error("Expected error")
+			}
+			if !strings.Contains(err.Error(), test.Error) {
+				t.Errorf("Wrong error %s, expected %s", err, test.Error)
+			}
+		})
+	}
+}
+
+func (s repairTestSuite) TestRetryTimeout(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		time.Sleep(75 * time.Millisecond)
+	})
+
+	shortTimeout := func(config *scyllaclient.Config) {
+		config.Timeout = 30 * time.Millisecond
+	}
+
+	host, port, closeServer := scyllaclienttest.MakeServer(t, handler)
+	defer closeServer()
+	client := scyllaclienttest.MakeClient(t, host, port, fastRetry, shortTimeout)
+
+	t.Run("simple", func(t *testing.T) {
+		err := s.invokeClient(context.Background(), host, client)
+		if err != nil {
+			t.Fatal("invokeClient() error", err)
+		}
+	})
+	t.Run("interactive", func(t *testing.T) {
+		err := s.invokeClient(scyllaclient.Interactive(context.Background()), host, client)
+		if err == nil {
+			t.Fatal("invokeClient() expected error")
+		}
+	})
+	t.Run("custom timeout", func(t *testing.T) {
+		err := s.invokeClient(scyllaclient.CustomTimeout(context.Background(), 5*time.Millisecond), host, client)
+		if err != nil {
+			t.Fatal("invokeClient() error", err)
 		}
 	})
 }
@@ -110,153 +289,6 @@ func TestRetryHostPool(t *testing.T) {
 		_, err := client.ClusterName(context.Background())
 		if err != nil {
 			t.Fatal("ClusterName() error", err)
-		}
-	})
-}
-
-func TestNoRetry(t *testing.T) {
-	t.Parallel()
-
-	host, port, closeServer := scyllaclienttest.MakeServer(t, scyllaclienttest.RespondStatus(t, 999, 200))
-	defer closeServer()
-	client := scyllaclienttest.MakeClient(t, host, port, fastRetry)
-
-	ctx := scyllaclient.NoRetry(context.Background())
-	_, err := client.NodeInfo(ctx, host)
-	if err == nil {
-		t.Fatalf("NodeInfo() expected error")
-	}
-}
-
-func TestRetryCancelContext(t *testing.T) {
-	t.Parallel()
-
-	table := []struct {
-		Name    string
-		Handler http.Handler
-	}{
-		{
-			Name:    "Repeat",
-			Handler: scyllaclienttest.RespondStatus(t, 999, 999, 999, 200),
-		},
-		{
-			Name:    "Wait",
-			Handler: http.HandlerFunc(func(http.ResponseWriter, *http.Request) { time.Sleep(time.Second) }),
-		},
-	}
-
-	for i := range table {
-		test := table[i]
-
-		t.Run(test.Name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			time.AfterFunc(50*time.Millisecond, cancel)
-
-			host, port, closeServer := scyllaclienttest.MakeServer(t, test.Handler)
-			defer closeServer()
-			client := scyllaclienttest.MakeClient(t, host, port, fastRetry)
-
-			_, err := client.NodeInfo(ctx, host)
-			t.Log("NodeInfo() error", err)
-
-			if err == nil {
-				t.Fatalf("NodeInfo() expected error")
-			}
-			if !errors.Is(err, context.Canceled) {
-				t.Fatalf("NodeInfo() error=%s, expected context.Canceled", err)
-			}
-		})
-	}
-}
-
-func TestRetryShouldRetryHandler(t *testing.T) {
-	t.Parallel()
-
-	table := []struct {
-		Name               string
-		Handler            http.Handler
-		ShouldRetryHandler func(err error) *bool
-		Error              string
-	}{
-		{
-			Name:    "Always retry",
-			Handler: scyllaclienttest.RespondStatus(t, 400, 400, 400, 400),
-			ShouldRetryHandler: func(err error) *bool {
-				return pointer.BoolPtr(true)
-			},
-			Error: "giving up after 4 attempts: agent [HTTP 400]",
-		},
-		{
-			Name:    "Never retry",
-			Handler: scyllaclienttest.RespondStatus(t, 999, 999, 999, 999),
-			ShouldRetryHandler: func(err error) *bool {
-				return pointer.BoolPtr(false)
-			},
-			Error: "agent [HTTP 999]",
-		},
-		{
-			Name:    "Fallback",
-			Handler: scyllaclienttest.RespondStatus(t, 999, 400, 400, 400, 400),
-			ShouldRetryHandler: func(err error) *bool {
-				return nil
-			},
-			Error: "giving up after 2 attempts: agent [HTTP 400]",
-		},
-	}
-
-	for i := range table {
-		test := table[i]
-
-		t.Run(test.Name, func(t *testing.T) {
-			host, port, closeServer := scyllaclienttest.MakeServer(t, test.Handler)
-			defer closeServer()
-			client := scyllaclienttest.MakeClient(t, host, port, fastRetry)
-
-			ctx := scyllaclient.WithShouldRetryHandler(context.Background(), test.ShouldRetryHandler)
-			_, err := client.NodeInfo(ctx, host)
-			t.Log("NodeInfo() error", err)
-
-			if err == nil || test.Error == "" {
-				t.Error("Expected error")
-			}
-			if !strings.Contains(err.Error(), test.Error) {
-				t.Errorf("Wrong error %s, expected %s", err, test.Error)
-			}
-		})
-	}
-}
-
-func TestRetryTimeout(t *testing.T) {
-	t.Parallel()
-
-	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-		time.Sleep(75 * time.Millisecond)
-	})
-
-	shortTimeout := func(config *scyllaclient.Config) {
-		config.Timeout = 30 * time.Millisecond
-	}
-
-	host, port, closeServer := scyllaclienttest.MakeServer(t, handler)
-	defer closeServer()
-	client := scyllaclienttest.MakeClient(t, host, port, fastRetry, shortTimeout)
-
-	t.Run("simple", func(t *testing.T) {
-		_, err := client.NodeInfo(context.Background(), host)
-		if err != nil {
-			t.Fatal("NodeInfo() error", err)
-		}
-	})
-	t.Run("interactive", func(t *testing.T) {
-		_, err := client.NodeInfo(scyllaclient.Interactive(context.Background()), host)
-		if err == nil {
-			t.Fatal("NodeInfo() expected error")
-		}
-	})
-	t.Run("custom timeout", func(t *testing.T) {
-		_, err := client.NodeInfo(scyllaclient.CustomTimeout(context.Background(), 5*time.Millisecond), host)
-		if err != nil {
-			t.Fatal("NodeInfo() error", err)
 		}
 	})
 }

--- a/pkg/scyllaclient/scyllaclienttest/client.go
+++ b/pkg/scyllaclient/scyllaclienttest/client.go
@@ -15,13 +15,12 @@ const TestHost = "127.0.0.1"
 // ClientOption allows to modify configuration in MakeClient.
 type ClientOption func(*scyllaclient.Config)
 
-// MakeClient creates a Client for testing. Typically host and port are set
-// based on MakeServer result.
+// MakeClient creates a Client for testing.
+// Typically, host and port are set based on MakeServer result.
 func MakeClient(t *testing.T, host, port string, opts ...ClientOption) *scyllaclient.Client {
 	t.Helper()
 
-	config := scyllaclient.DefaultConfig()
-	config.Hosts = []string{host}
+	config := scyllaclient.TestConfig([]string{host}, "")
 	config.Port = port
 	config.Scheme = "http"
 

--- a/pkg/scyllaclient/status.go
+++ b/pkg/scyllaclient/status.go
@@ -68,6 +68,12 @@ type agentError struct {
 }
 
 func makeAgentError(resp *http.Response) error {
+	if resp.StatusCode/100 == 2 {
+		return nil
+	}
+
+	defer resp.Body.Close()
+
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, "read body")

--- a/pkg/scyllaclient/status_test.go
+++ b/pkg/scyllaclient/status_test.go
@@ -100,3 +100,23 @@ func TestAgentError(t *testing.T) {
 		t.Fatalf("Error = %s not matching expected pattern", ae)
 	}
 }
+
+func TestAgentErrorStatusCode2XX(t *testing.T) {
+	p := agentModels.ErrorResponse{
+		Status:  200,
+		Message: "test",
+	}
+	b, err := p.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(b)),
+	}
+
+	if err := makeAgentError(resp); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -272,7 +272,7 @@ func (h *backupTestHelper) tamperWithManifest(ctx context.Context, manifestsPath
 	if err = m.Write(buf); err != nil {
 		h.t.Fatal(err)
 	}
-	if err := h.client.RclonePut(ctx, ManagedClusterHost(), h.location.RemotePath(m.Path()), buf, int64(buf.Len())); err != nil {
+	if err := h.client.RclonePut(ctx, ManagedClusterHost(), h.location.RemotePath(m.Path()), buf); err != nil {
 		h.t.Fatal(err)
 	}
 }
@@ -280,7 +280,7 @@ func (h *backupTestHelper) tamperWithManifest(ctx context.Context, manifestsPath
 func (h *backupTestHelper) touchFile(ctx context.Context, dir, file, content string) {
 	h.t.Helper()
 	buf := bytes.NewBufferString(content)
-	if err := h.client.RclonePut(ctx, ManagedClusterHost(), h.location.RemotePath(path.Join(dir, file)), buf, int64(buf.Len())); err != nil {
+	if err := h.client.RclonePut(ctx, ManagedClusterHost(), h.location.RemotePath(path.Join(dir, file)), buf); err != nil {
 		h.t.Fatal(err)
 	}
 }

--- a/pkg/service/backup/worker_manifest.go
+++ b/pkg/service/backup/worker_manifest.go
@@ -112,7 +112,7 @@ func (w *worker) uploadHostManifest(ctx context.Context, h hostInfo, m ManifestI
 
 	// Upload compressed manifest
 	dst := h.Location.RemotePath(m.Path())
-	return w.Client.RclonePut(ctx, h.IP, dst, buf, int64(buf.Len()))
+	return w.Client.RclonePut(ctx, h.IP, dst, buf)
 }
 
 func (w *worker) MoveManifest(ctx context.Context, hosts []hostInfo) (err error) {

--- a/pkg/service/backup/worker_schema.go
+++ b/pkg/service/backup/worker_schema.go
@@ -3,7 +3,6 @@
 package backup
 
 import (
-	"bytes"
 	"context"
 	"time"
 
@@ -110,6 +109,6 @@ func (w *worker) UploadSchema(ctx context.Context, hosts []hostInfo) (stepError 
 
 	return hostsInParallel(hostPerLocation, parallel.NoLimit, func(h hostInfo) error {
 		dst := h.Location.RemotePath(RemoteSchemaFile(w.ClusterID, w.TaskID, w.SnapshotTag))
-		return w.Client.RclonePut(ctx, h.IP, dst, bytes.NewReader(w.Schema.Bytes()), int64(w.Schema.Len()))
+		return w.Client.RclonePut(ctx, h.IP, dst, w.Schema)
 	})
 }


### PR DESCRIPTION
This extends the swagger retry code to work with hand created http requests.