### PR TITLE
scyllaclient: metrics, support 'memory_total_memory' as gauge

### DIFF
--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -760,7 +760,12 @@ func (c *Client) TotalMemory(ctx context.Context, host string) (int64, error) {
 
 	var totalMemory int64
 	for _, m := range metrics[metricName].Metric {
-		totalMemory += int64(*m.Counter.Value)
+		switch {
+		case m.Counter != nil:
+			totalMemory += int64(*m.Counter.Value)
+		case m.Gauge != nil:
+			totalMemory += int64(*m.Gauge.Value)
+		}
 	}
 
 	return totalMemory, nil

--- a/pkg/scyllaclient/client_scylla_test.go
+++ b/pkg/scyllaclient/client_scylla_test.go
@@ -204,6 +204,21 @@ func TestClientShardCount(t *testing.T) {
 	}
 }
 
+func TestClientTotalMemory(t *testing.T) {
+	t.Parallel()
+
+	client, closeServer := scyllaclienttest.NewFakeScyllaServer(t, "testdata/scylla_metrics/metrics")
+	defer closeServer()
+
+	v, err := client.TotalMemory(context.Background(), scyllaclienttest.TestHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 31138512896 {
+		t.Fatal(v)
+	}
+}
+
 func TestClientDescribeRing(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Supports:
- Counter (old)
_ Gauge (new)

Fixes #2961
