### PR TITLE
service/repair: disable small tables optimisation if --small-table-threshold is set to 0

### DIFF
--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -437,6 +437,10 @@ func (s *Service) killAllRepairs(ctx context.Context, client *scyllaclient.Clien
 }
 
 func (s *Service) optimizeSmallTables(ctx context.Context, client *scyllaclient.Client, target Target, g *generator) error {
+	if target.SmallTableThreshold == 0 {
+		return nil
+	}
+
 	repairHosts := g.Hosts()
 
 	// Get report for Host, Keyspace, Table tuples


### PR DESCRIPTION
Fixes #2945
