### PR TITLE
cmd/agent: require auth-token to start

### DIFF
--- a/pkg/cmd/agent/root.go
+++ b/pkg/cmd/agent/root.go
@@ -60,6 +60,11 @@ var rootCmd = &cobra.Command{
 			logger.Sync() // nolint
 		}()
 
+		// Validate auth-token.
+		if c.AuthToken == "" {
+			return errors.New("configuration file must specify auth-token")
+		}
+
 		// Start server
 		s := newServer(c, logger)
 		if err := s.init(ctx); err != nil {


### PR DESCRIPTION
Fixes #2806
