### PR TITLE
service/backup: add retention days

### DIFF
--- a/docs/source/sctool/partials/sctool_backup.yaml
+++ b/docs/source/sctool/partials/sctool_backup.yaml
@@ -98,6 +98,10 @@ options:
   default_value: "7"
   usage: |
     The `number of backups` to store, once this number is reached, the next backup which comes in from this destination will initiate a purge of the oldest backup.
+- name: retention-days
+  usage: |
+    The number of days to retain a backup. All backups older than this will be purged.
+    Set to 0 for no limit (default 0)
 - name: retry-wait
   default_value: 10m
   usage: |

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -132,23 +132,6 @@ func (s *server) makeServices() error {
 	// This is a bit hacky way of providing selected information on other tasks
 	// such as locations, retention and passing it in context of a task run.
 
-	// Generate "retention_map" for backup task.
-	s.schedSvc.SetPropertiesDecorator(scheduler.BackupTask, func(ctx context.Context, clusterID, taskID uuid.UUID, properties json.RawMessage) (json.RawMessage, error) {
-		tasks, err := s.schedSvc.ListTasks(ctx, clusterID, scheduler.ListFilter{TaskType: []scheduler.TaskType{scheduler.BackupTask}, Deleted: true})
-		if err != nil {
-			return nil, err
-		}
-		retentionMap := make(map[uuid.UUID]backup.Retention)
-		for _, t := range tasks {
-			r, err := backup.ExtractRetention(properties)
-			if err != nil {
-				return nil, errors.Wrapf(err, "extract retention for task %s", t.ID)
-			}
-			retentionMap[t.ID] = r
-		}
-		return jsonutil.Set(properties, "retention_map", retentionMap), nil
-	})
-
 	// Get locations if not specified for validate backup task.
 	s.schedSvc.SetPropertiesDecorator(scheduler.ValidateBackupTask, func(ctx context.Context, clusterID, taskID uuid.UUID, properties json.RawMessage) (json.RawMessage, error) {
 		// If tasks contains locations return

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -132,6 +132,23 @@ func (s *server) makeServices() error {
 	// This is a bit hacky way of providing selected information on other tasks
 	// such as locations, retention and passing it in context of a task run.
 
+	// Generate "retention_map" for backup task.
+	s.schedSvc.SetPropertiesDecorator(scheduler.BackupTask, func(ctx context.Context, clusterID, taskID uuid.UUID, properties json.RawMessage) (json.RawMessage, error) {
+		tasks, err := s.schedSvc.ListTasks(ctx, clusterID, scheduler.ListFilter{TaskType: []scheduler.TaskType{scheduler.BackupTask}})
+		if err != nil {
+			return nil, err
+		}
+		retentionMap := make(backup.RetentionMap)
+		for _, t := range tasks {
+			r, err := backup.ExtractRetention(properties)
+			if err != nil {
+				return nil, errors.Wrapf(err, "extract retention for task %s", t.ID)
+			}
+			retentionMap[t.ID] = r
+		}
+		return jsonutil.Set(properties, "retention_map", retentionMap), nil
+	})
+
 	// Get locations if not specified for validate backup task.
 	s.schedSvc.SetPropertiesDecorator(scheduler.ValidateBackupTask, func(ctx context.Context, clusterID, taskID uuid.UUID, properties json.RawMessage) (json.RawMessage, error) {
 		// If tasks contains locations return

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -134,11 +134,11 @@ func (s *server) makeServices() error {
 
 	// Generate "retention_map" for backup task.
 	s.schedSvc.SetPropertiesDecorator(scheduler.BackupTask, func(ctx context.Context, clusterID, taskID uuid.UUID, properties json.RawMessage) (json.RawMessage, error) {
-		tasks, err := s.schedSvc.ListTasks(ctx, clusterID, scheduler.ListFilter{TaskType: []scheduler.TaskType{scheduler.BackupTask}})
+		tasks, err := s.schedSvc.ListTasks(ctx, clusterID, scheduler.ListFilter{TaskType: []scheduler.TaskType{scheduler.BackupTask}, Deleted: true})
 		if err != nil {
 			return nil, err
 		}
-		retentionMap := make(map[uuid.UUID]int)
+		retentionMap := make(map[uuid.UUID]backup.Retention)
 		for _, t := range tasks {
 			r, err := backup.ExtractRetention(properties)
 			if err != nil {
@@ -156,7 +156,7 @@ func (s *server) makeServices() error {
 			return properties, nil
 		}
 		// Extract locations from all tasks...
-		tasks, err := s.schedSvc.ListTasks(ctx, clusterID, scheduler.ListFilter{TaskType: []scheduler.TaskType{scheduler.BackupTask}})
+		tasks, err := s.schedSvc.ListTasks(ctx, clusterID, scheduler.ListFilter{TaskType: []scheduler.TaskType{scheduler.BackupTask}, Deleted: true})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/command/backup/cmd.go
+++ b/pkg/command/backup/cmd.go
@@ -30,6 +30,7 @@ type command struct {
 	location         []string
 	keyspace         []string
 	retention        int
+	retentionDays    int
 	rateLimit        []string
 	snapshotParallel []string
 	uploadParallel   []string
@@ -80,6 +81,7 @@ func (cmd *command) init() {
 	w.Datacenter(&cmd.dc)
 	w.Keyspace(&cmd.keyspace)
 	w.Unwrap().IntVar(&cmd.retention, "retention", 7, "")
+	w.Unwrap().IntVar(&cmd.retentionDays, "retention-days", 0, "")
 	w.Unwrap().StringSliceVar(&cmd.rateLimit, "rate-limit", nil, "")
 	w.Unwrap().StringSliceVar(&cmd.snapshotParallel, "snapshot-parallel", nil, "")
 	w.Unwrap().StringSliceVar(&cmd.uploadParallel, "upload-parallel", nil, "")
@@ -130,6 +132,10 @@ func (cmd *command) run(args []string) error {
 	}
 	if cmd.Flag("retention").Changed {
 		props["retention"] = cmd.retention
+		ok = true
+	}
+	if cmd.Flag("retention-days").Changed {
+		props["retention_days"] = cmd.retentionDays
 		ok = true
 	}
 	if cmd.Flag("rate-limit").Changed {

--- a/pkg/restapi/task.go
+++ b/pkg/restapi/task.go
@@ -90,6 +90,10 @@ func (h *taskHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 		filter scheduler.ListFilter
 		err    error
 	)
+
+	// Never expose deleted tasks over API
+	filter.Deleted = false
+
 	if s := r.FormValue("all"); s != "" {
 		filter.Disabled, err = strconv.ParseBool(s)
 		if err != nil {

--- a/pkg/schema/migrate/v3.0.0_integration_test.go
+++ b/pkg/schema/migrate/v3.0.0_integration_test.go
@@ -116,3 +116,61 @@ func TestRewriteHealthCheck30(t *testing.T) {
 
 	testCallback(t, migrate.CallComment, "rewriteHealthCheck30", prepare, validate)
 }
+
+func TestSetExistingTasksDeletedIntegration(t *testing.T) {
+	type Task struct {
+		ClusterID uuid.UUID
+		Type      string
+		ID        uuid.UUID
+		Name      string
+		Deleted   bool
+	}
+
+	clusterID := uuid.MustRandom()
+	input := []*Task{
+		{
+			ClusterID: clusterID,
+			Type:      "repair",
+			ID:        uuid.MustParse("6D77D539-1D10-4A40-98F2-4DE0865DE183"),
+		},
+		{
+			ClusterID: clusterID,
+			Type:      "backup",
+			ID:        uuid.MustParse("8042889C-6226-4FBA-BEAD-13C768FC2FC8"),
+		},
+	}
+
+	prepare := func(session gocqlx.Session) error {
+		q := qb.Insert("scheduler_task").Columns("cluster_id", "type", "id").Query(session)
+		for _, t := range input {
+			if err := q.BindStruct(t).Exec(); err != nil {
+				return err
+			}
+		}
+		q.Release()
+		return nil
+	}
+
+	validate := func(session gocqlx.Session) error {
+		q := qb.Select("scheduler_task").Where(qb.EqLit("deleted", "false")).AllowFiltering().Query(session)
+		defer q.Release()
+
+		var all []*Task
+		if err := q.Iter().Unsafe().Select(&all); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := context.Background()
+		for i, v := range all {
+			Logger.Debug(ctx, "Tasks", "pos", i, "task", v)
+		}
+
+		if len(all) != 2 {
+			t.Fatalf("Expected 2 not deleted, got %d", len(all))
+		}
+
+		return nil
+	}
+
+	testCallback(t, migrate.CallComment, "setExistingTasksDeleted", prepare, validate)
+}

--- a/pkg/schema/nopmigrate/nopmigrate.go
+++ b/pkg/schema/nopmigrate/nopmigrate.go
@@ -17,6 +17,7 @@ func nopCallback(ctx context.Context, session gocqlx.Session, ev migrate.Callbac
 
 func init() {
 	reg.Add(migrate.CallComment, "rewriteHealthCheck30", nopCallback)
+	reg.Add(migrate.CallComment, "setExistingTasksDeleted", nopCallback)
 }
 
 // Callback is a sibling of migrate.Callback that registers all mandatory callbacks as nop.

--- a/pkg/schema/table/table.go
+++ b/pkg/schema/table/table.go
@@ -179,6 +179,7 @@ var (
 		Name: "scheduler_task",
 		Columns: []string{
 			"cluster_id",
+			"deleted",
 			"enabled",
 			"error_count",
 			"id",

--- a/pkg/service/backup/purger.go
+++ b/pkg/service/backup/purger.go
@@ -16,38 +16,39 @@ import (
 	. "github.com/scylladb/scylla-manager/pkg/service/backup/backupspec"
 	"github.com/scylladb/scylla-manager/pkg/util/parallel"
 	"github.com/scylladb/scylla-manager/pkg/util/timeutc"
-	"github.com/scylladb/scylla-manager/pkg/util/uuid"
 	"go.uber.org/atomic"
 )
 
 // staleTags returns collection of snapshot tags for manifests that are "stale".
 // That is:
 // - temporary manifests,
+// - manifests over task days retention days policy,
 // - manifests over task retention policy,
 // - manifests older than threshold if retention policy is unknown.
-func staleTags(manifests []*ManifestInfo, policy map[uuid.UUID]int, threshold time.Time) *strset.Set {
+func staleTags(manifests []*ManifestInfo, policy RetentionFunc) *strset.Set {
 	tags := strset.New()
 
 	for taskID, taskManifests := range groupManifestsByTask(manifests) {
-		taskPolicy := policy[taskID]
+		taskPolicy := policy(taskID)
 		taskTags := strset.New()
 		for _, m := range taskManifests {
+			t, _ := SnapshotTagTime(m.SnapshotTag) // nolint: errcheck
+
 			switch {
 			case m.Temporary:
 				tags.Add(m.SnapshotTag)
-			case taskPolicy > 0:
+			// Tasks can have a Retention policy and a RetentionDays policy so fall through if tag is not too old
+			case taskPolicy.RetentionDays > 0 && t.Before(time.Now().AddDate(0, 0, -taskPolicy.RetentionDays)):
+				tags.Add(m.SnapshotTag)
+			case taskPolicy.Retention > 0:
 				taskTags.Add(m.SnapshotTag)
-			default:
-				t, _ := SnapshotTagTime(m.SnapshotTag) // nolint: errcheck
-				if t.Before(threshold) {
-					tags.Add(m.SnapshotTag)
-				}
 			}
 		}
-		if taskPolicy > 0 && taskTags.Size()-taskPolicy > 0 {
+
+		if taskPolicy.Retention > 0 && taskTags.Size()-taskPolicy.Retention > 0 {
 			l := taskTags.List()
 			sort.Strings(l)
-			tags.Add(l[:len(l)-taskPolicy]...)
+			tags.Add(l[:len(l)-taskPolicy.Retention]...)
 		}
 	}
 	return tags

--- a/pkg/service/backup/purger.go
+++ b/pkg/service/backup/purger.go
@@ -25,11 +25,11 @@ import (
 // - manifests over task days retention days policy,
 // - manifests over task retention policy,
 // - manifests older than threshold if retention policy is unknown.
-func staleTags(manifests []*ManifestInfo, policy retentionFunc) *strset.Set {
+func staleTags(manifests []*ManifestInfo, retentionMap RetentionMap) *strset.Set {
 	tags := strset.New()
 
 	for taskID, taskManifests := range groupManifestsByTask(manifests) {
-		taskPolicy := policy(taskID)
+		taskPolicy := GetRetention(taskID, retentionMap)
 		taskTags := strset.New()
 		for _, m := range taskManifests {
 			t, _ := SnapshotTagTime(m.SnapshotTag) // nolint: errcheck

--- a/pkg/service/backup/purger.go
+++ b/pkg/service/backup/purger.go
@@ -25,7 +25,7 @@ import (
 // - manifests over task days retention days policy,
 // - manifests over task retention policy,
 // - manifests older than threshold if retention policy is unknown.
-func staleTags(manifests []*ManifestInfo, policy RetentionFunc) *strset.Set {
+func staleTags(manifests []*ManifestInfo, policy retentionFunc) *strset.Set {
 	tags := strset.New()
 
 	for taskID, taskManifests := range groupManifestsByTask(manifests) {

--- a/pkg/service/backup/purger_test.go
+++ b/pkg/service/backup/purger_test.go
@@ -50,7 +50,7 @@ func TestStaleTags(t *testing.T) {
 	x.Temporary = true
 	manifests = append(manifests, x)
 
-	tags := staleTags(manifests, GetRetentionFrom(map[uuid.UUID]Retention{task0: {0, 3}, task1: {0, 2}}))
+	tags := staleTags(manifests, getRetentionFrom(map[uuid.UUID]retention{task0: {0, 3}, task1: {0, 2}}))
 
 	golden := []string{
 		"sm_19700101000000UTC",

--- a/pkg/service/backup/purger_test.go
+++ b/pkg/service/backup/purger_test.go
@@ -50,7 +50,7 @@ func TestStaleTags(t *testing.T) {
 	x.Temporary = true
 	manifests = append(manifests, x)
 
-	tags := staleTags(manifests, getRetentionFrom(map[uuid.UUID]retention{task0: {0, 3}, task1: {0, 2}}))
+	tags := staleTags(manifests, RetentionMap{task0: {0, 3}, task1: {0, 2}})
 
 	golden := []string{
 		"sm_19700101000000UTC",

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -385,7 +385,7 @@ func TestGetTargetIntegration(t *testing.T) {
 				t.Error(err)
 			}
 
-			if diff := cmp.Diff(golden, v, cmpopts.SortSlices(func(a, b string) bool { return a < b }), cmpopts.IgnoreUnexported(backup.Target{})); diff != "" {
+			if diff := cmp.Diff(golden, v, cmpopts.SortSlices(func(a, b string) bool { return a < b }), cmpopts.IgnoreUnexported(backup.Target{}), cmpopts.IgnoreFields(backup.Target{}, "GetRetention")); diff != "" {
 				t.Fatal(diff)
 			}
 		})
@@ -1412,6 +1412,7 @@ func TestPurgeIntegration(t *testing.T) {
 
 	task1 := h.taskID
 	task2 := uuid.MustRandom()
+	task3 := uuid.MustRandom()
 
 	Print("Given: retention policy 1")
 	target := backup.Target{
@@ -1423,10 +1424,11 @@ func TestPurgeIntegration(t *testing.T) {
 		DC:        []string{"dc1"},
 		Location:  []Location{location},
 		Retention: 1,
-		RetentionMap: map[uuid.UUID]int{
-			task1: 1,
-			task2: 1,
-		},
+		GetRetention: backup.GetRetentionFrom(map[uuid.UUID]backup.Retention{
+			task1: {7, 1},
+			task2: {7, 1},
+			task3: {2, 7},
+		}),
 	}
 	if err := h.service.InitTarget(ctx, h.clusterID, &target); err != nil {
 		t.Fatal(err)
@@ -1461,6 +1463,24 @@ func TestPurgeIntegration(t *testing.T) {
 		m.SnapshotTag = SnapshotTagAt(now.AddDate(0, 0, -2))
 		return true
 	})
+	Print("And: add 2 hour old manifest for task 3 - should NOT be removed")
+	h.tamperWithManifest(ctx, manifests[0], func(m ManifestInfoWithContent) bool {
+		m.TaskID = task3
+		m.SnapshotTag = SnapshotTagAt(now.Add(time.Hour * -2))
+		return true
+	})
+	Print("And: add 1 day old manifest for task 3 - should NOT be removed")
+	h.tamperWithManifest(ctx, manifests[0], func(m ManifestInfoWithContent) bool {
+		m.TaskID = task3
+		m.SnapshotTag = SnapshotTagAt(now.Add(time.Hour * -26))
+		return true
+	})
+	Print("And: add 3 day old manifest for task 3 - should be removed")
+	h.tamperWithManifest(ctx, manifests[0], func(m ManifestInfoWithContent) bool {
+		m.TaskID = task3
+		m.SnapshotTag = SnapshotTagAt(now.AddDate(0, 0, -3))
+		return true
+	})
 	Print("And: add manifest for removed old task - should be removed")
 	h.tamperWithManifest(ctx, manifests[0], func(m ManifestInfoWithContent) bool {
 		m.TaskID = uuid.MustRandom()
@@ -1481,10 +1501,10 @@ func TestPurgeIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	Print("Then: there should be 3 + 2 manifests")
+	Print("Then: there should be 3 + 4 manifests")
 	manifests, _, files := h.listS3Files()
-	if len(manifests) != 5 {
-		t.Fatalf("Expected 5 manifests (1 per each node) plus 2 generated, got %d %s", len(manifests), strings.Join(manifests, "\n"))
+	if len(manifests) != 7 {
+		t.Fatalf("Expected 7 manifests (1 per each node) plus 4 generated, got %d %s", len(manifests), strings.Join(manifests, "\n"))
 	}
 
 	Print("And: old sstable files are removed")

--- a/pkg/service/backup/worker_purge.go
+++ b/pkg/service/backup/worker_purge.go
@@ -13,7 +13,7 @@ import (
 	"github.com/scylladb/scylla-manager/pkg/util/timeutc"
 )
 
-func (w *worker) Purge(ctx context.Context, hosts []hostInfo, retention retentionFunc) (err error) {
+func (w *worker) Purge(ctx context.Context, hosts []hostInfo, retentionMap RetentionMap) (err error) {
 	w.Logger.Info(ctx, "Purging stale snapshots...")
 	defer func(start time.Time) {
 		if err != nil {
@@ -29,7 +29,7 @@ func (w *worker) Purge(ctx context.Context, hosts []hostInfo, retention retentio
 		return errors.Wrap(err, "list manifests")
 	}
 	// Get a list of stale tags
-	tags := staleTags(manifests, retention)
+	tags := staleTags(manifests, retentionMap)
 	// Get a nodeID manifests popping function
 	pop := popNodeIDManifestsForLocation(manifests)
 

--- a/pkg/service/backup/worker_purge.go
+++ b/pkg/service/backup/worker_purge.go
@@ -11,10 +11,9 @@ import (
 	. "github.com/scylladb/scylla-manager/pkg/service/backup/backupspec"
 	"github.com/scylladb/scylla-manager/pkg/util/parallel"
 	"github.com/scylladb/scylla-manager/pkg/util/timeutc"
-	"github.com/scylladb/scylla-manager/pkg/util/uuid"
 )
 
-func (w *worker) Purge(ctx context.Context, hosts []hostInfo, policy map[uuid.UUID]int) (err error) {
+func (w *worker) Purge(ctx context.Context, hosts []hostInfo, retention RetentionFunc) (err error) {
 	w.Logger.Info(ctx, "Purging stale snapshots...")
 	defer func(start time.Time) {
 		if err != nil {
@@ -30,7 +29,7 @@ func (w *worker) Purge(ctx context.Context, hosts []hostInfo, policy map[uuid.UU
 		return errors.Wrap(err, "list manifests")
 	}
 	// Get a list of stale tags
-	tags := staleTags(manifests, policy, timeutc.Now().AddDate(0, 0, -30))
+	tags := staleTags(manifests, retention)
 	// Get a nodeID manifests popping function
 	pop := popNodeIDManifestsForLocation(manifests)
 

--- a/pkg/service/backup/worker_purge.go
+++ b/pkg/service/backup/worker_purge.go
@@ -13,7 +13,7 @@ import (
 	"github.com/scylladb/scylla-manager/pkg/util/timeutc"
 )
 
-func (w *worker) Purge(ctx context.Context, hosts []hostInfo, retention RetentionFunc) (err error) {
+func (w *worker) Purge(ctx context.Context, hosts []hostInfo, retention retentionFunc) (err error) {
 	w.Logger.Info(ctx, "Purging stale snapshots...")
 	defer func(start time.Time) {
 		if err != nil {

--- a/pkg/service/scheduler/model.go
+++ b/pkg/service/scheduler/model.go
@@ -296,6 +296,7 @@ type Task struct {
 	Name       string          `json:"name"`
 	Tags       []string        `json:"tags,omitempty"`
 	Enabled    bool            `json:"enabled,omitempty"`
+	Deleted    bool            `json:"deleted,omitempty"`
 	Sched      Schedule        `json:"schedule,omitempty"`
 	Properties json.RawMessage `json:"properties,omitempty"`
 

--- a/pkg/service/scheduler/service.go
+++ b/pkg/service/scheduler/service.go
@@ -517,11 +517,11 @@ func (s *Service) findTaskByID(key scheduler.Key) (taskInfo, bool) {
 func (s *Service) DeleteTask(ctx context.Context, t *Task) error {
 	s.logger.Debug(ctx, "DeleteTask", "task", t)
 
-	q := table.SchedulerTask.DeleteQuery(s.session).BindMap(qb.M{
-		"cluster_id": t.ClusterID,
-		"type":       t.Type,
-		"id":         t.ID,
-	})
+	t.Deleted = true
+	t.Enabled = false
+
+	q := table.SchedulerTask.UpdateQuery(s.session, "deleted", "enabled").BindStruct(t)
+
 	if err := q.ExecRelease(); err != nil {
 		return err
 	}

--- a/pkg/service/scheduler/service.go
+++ b/pkg/service/scheduler/service.go
@@ -520,7 +520,10 @@ func (s *Service) DeleteTask(ctx context.Context, t *Task) error {
 	t.Deleted = true
 	t.Enabled = false
 
-	q := table.SchedulerTask.UpdateQuery(s.session, "deleted", "enabled").BindStruct(t)
+	// Remove the deleted task's name so that new tasks can use it
+	t.Name = ""
+
+	q := table.SchedulerTask.UpdateQuery(s.session, "deleted", "enabled", "name").BindStruct(t)
 
 	if err := q.ExecRelease(); err != nil {
 		return err

--- a/pkg/service/scheduler/service_list.go
+++ b/pkg/service/scheduler/service_list.go
@@ -25,6 +25,7 @@ type ListFilter struct {
 	TaskType []TaskType
 	Status   []Status
 	Disabled bool
+	Deleted  bool
 	Short    bool
 }
 
@@ -42,6 +43,10 @@ func (s *Service) ListTasks(ctx context.Context, clusterID uuid.UUID, filter Lis
 	}
 	if !filter.Disabled {
 		b.Where(qb.EqLit("enabled", "true"))
+		b.AllowFiltering()
+	}
+	if !filter.Deleted {
+		b.Where(qb.EqLit("deleted", "false"))
 		b.AllowFiltering()
 	}
 	if filter.Short {

--- a/schema/v3.0.0.cql
+++ b/schema/v3.0.0.cql
@@ -10,3 +10,6 @@ ALTER TABLE scheduler_task ADD success_count int;
 ALTER TABLE scheduler_task ADD error_count int;
 ALTER TABLE scheduler_task ADD last_success timestamp;
 ALTER TABLE scheduler_task ADD last_error timestamp;
+ALTER TABLE scheduler_task ADD deleted boolean;
+
+-- CALL setExistingTasksDeleted;


### PR DESCRIPTION
- Allows configuring retention days per backup task
- Purge now handles both removing snapshots over retention policy, and
  snapshots older than retention days
- Adds a "deleted" property to tasks so that retention policy is retained
  after the task is deleted

Previously the behavior of purge was:
- If retention policy exists (> 0) apply it
- If retention policy does not exist delete snapshot older than
  threshold

New behavior is:
- If retention days policy exists (> 0) apply it
- If retention policy exists (> 0) and snapshot was not deleted above apply it
- If neither retention or retention days policy exist delete snapshot
  older than threshold

Fixes #2923