### PR TITLE
docs: split tasks commands

### DIFF
--- a/docs/source/sctool/index.rst
+++ b/docs/source/sctool/index.rst
@@ -10,10 +10,14 @@ CLI sctool
 
    global-flags-and-variables
    completion
-   cluster
    backup
+   cluster
+   info
+   progress
    repair
+   start
    status
+   stop
    suspend-resume
    task
    version

--- a/docs/source/sctool/info.rst
+++ b/docs/source/sctool/info.rst
@@ -1,0 +1,10 @@
+Info
+----
+
+.. _task-info:
+
+info
+====
+
+.. datatemplate:yaml:: partials/sctool_info.yaml
+   :template: command.tmpl

--- a/docs/source/sctool/progress.rst
+++ b/docs/source/sctool/progress.rst
@@ -1,0 +1,10 @@
+Progress
+--------
+
+.. _task-progress:
+
+progress
+========
+
+.. datatemplate:yaml:: partials/sctool_progress.yaml
+   :template: command.tmpl

--- a/docs/source/sctool/start.rst
+++ b/docs/source/sctool/start.rst
@@ -1,0 +1,10 @@
+Start
+-----
+
+.. _task-start:
+
+start
+=====
+
+.. datatemplate:yaml:: partials/sctool_start.yaml
+   :template: command.tmpl

--- a/docs/source/sctool/stop.rst
+++ b/docs/source/sctool/stop.rst
@@ -1,0 +1,10 @@
+Stop
+----
+
+.. _task-stop:
+
+stop
+====
+
+.. datatemplate:yaml:: partials/sctool_stop.yaml
+   :template: command.tmpl

--- a/docs/source/sctool/task.rst
+++ b/docs/source/sctool/task.rst
@@ -1,9 +1,7 @@
 .. _task-commands:
 
-Task
-----
-
-The task command set allows you to schedule, start, stop and modify tasks.
+Tasks
+-----
 
 .. _task-list:
 
@@ -11,28 +9,4 @@ tasks
 =====
 
 .. datatemplate:yaml:: partials/sctool_tasks.yaml
-   :template: command.tmpl
-
-.. _task-stop:
-
-stop
-====
-
-.. datatemplate:yaml:: partials/sctool_stop.yaml
-   :template: command.tmpl
-
-.. _task-progress:
-
-progress
-========
-
-.. datatemplate:yaml:: partials/sctool_progress.yaml
-   :template: command.tmpl
-
-.. _task-info:
-
-info
-====
-
-.. datatemplate:yaml:: partials/sctool_info.yaml
    :template: command.tmpl


### PR DESCRIPTION
Closes https://github.com/scylladb/scylla-manager/issues/3008

Adds ``tasks start`` commands and splits the ``task`` module in separate pages.