### PR TITLE
dist: goreleaser, remove empty_folders directive

### DIFF
--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -91,8 +91,6 @@ nfpms:
       - rpm
     bindir: /usr/bin
 
-    empty_folders:
-      - /var/lib/scylla-manager
     contents:
       - src: etc/scylla-manager.yaml
         dst: /etc/scylla-manager/scylla-manager.yaml
@@ -186,8 +184,6 @@ nfpms:
       - rpm
     bindir: /usr/bin
 
-    empty_folders:
-      - /var/lib/scylla-manager
     contents:
       - src: etc/scylla-manager-agent.yaml
         dst: /etc/scylla-manager-agent/scylla-manager-agent.yaml


### PR DESCRIPTION
This is not needed and in Centos it overwrites already existing directory with wrong user and permissions.

The below snippet from rpm installation debug logs happens after the preinstall scriplet.

```
D: create     040755  1 (   0,   0)     0 /var/lib/scylla-manager
```

It does not affect Ubuntu.

Fixes #3032

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
