### PR TITLE
scyllaclient: t/o per batch on RcloneListDirIter

### DIFF
--- a/pkg/scyllaclient/config.go
+++ b/pkg/scyllaclient/config.go
@@ -27,9 +27,9 @@ type Config struct {
 	Timeout time.Duration
 	// MaxTimeout specifies the effective maximal timeout value after increasing Timeout on retry.
 	MaxTimeout time.Duration
-	// ListTimeout specifies maximum time to complete a remote directory listing.
-	// The listing can be recursive, if the number of files is significant such
-	// listing can easily take a couple of hours.
+	// ListTimeout specifies maximum time to complete an iterative remote
+	// directory listing. The retrieval is performed in batches this timeout
+	// applies to the time it take to retrieve a single batch.
 	ListTimeout time.Duration
 	// Backoff specifies parameters of exponential backoff used when requests
 	// from Scylla Manager to Scylla Agent fail.
@@ -61,7 +61,7 @@ func DefaultConfig() Config {
 		Scheme:      "https",
 		Timeout:     15 * time.Second,
 		MaxTimeout:  1 * time.Hour,
-		ListTimeout: 12 * time.Hour,
+		ListTimeout: 5 * time.Minute,
 		Backoff: BackoffConfig{
 			WaitMin:    1 * time.Second,
 			WaitMax:    30 * time.Second,

--- a/pkg/scyllaclient/context.go
+++ b/pkg/scyllaclient/context.go
@@ -15,6 +15,7 @@ const (
 	ctxInteractive ctxt = iota
 	ctxHost
 	ctxNoRetry
+	ctxNoTimeout
 	ctxCustomTimeout
 	ctxShouldRetryHandler
 )
@@ -44,6 +45,12 @@ func isForceHost(ctx context.Context) bool {
 // noRetry disables retries.
 func noRetry(ctx context.Context) context.Context {
 	return context.WithValue(ctx, ctxNoRetry, true)
+}
+
+// noTimeout disables timeouts - if in doubt do not use it.
+// This should only be used by functions that handle timeouts internally.
+func noTimeout(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxNoTimeout, true)
 }
 
 // customTimeout allows to pass a custom timeout to timeout middleware.

--- a/pkg/scyllaclient/timeout.go
+++ b/pkg/scyllaclient/timeout.go
@@ -29,6 +29,10 @@ func (b body) Close() error {
 // timeout sets request context timeout for individual requests.
 func timeout(next http.RoundTripper, timeout time.Duration) http.RoundTripper {
 	return httpx.RoundTripperFunc(func(req *http.Request) (resp *http.Response, err error) {
+		if _, ok := req.Context().Value(ctxNoTimeout).(bool); ok {
+			return next.RoundTrip(req)
+		}
+
 		d, ok := hasCustomTimeout(req.Context())
 		if !ok {
 			d = timeout

--- a/pkg/service/backup/list.go
+++ b/pkg/service/backup/list.go
@@ -50,21 +50,21 @@ func listManifests(ctx context.Context, client *scyllaclient.Client, host string
 		FilesOnly: true,
 		Recurse:   true,
 	}
-	items, err := client.RcloneListDir(ctx, host, location.RemotePath(baseDir), &opts)
+
+	var manifests []*ManifestInfo
+	err := client.RcloneListDirIter(ctx, host, location.RemotePath(baseDir), &opts, func(f *scyllaclient.RcloneListDirItem) {
+		p := path.Join(baseDir, f.Path)
+		m := &ManifestInfo{}
+		if err := m.ParsePath(p); err != nil {
+			return
+		}
+		m.Location = location
+		manifests = append(manifests, m)
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	var manifests []*ManifestInfo
-	for _, item := range items {
-		p := path.Join(baseDir, item.Path)
-		m := &ManifestInfo{}
-		if err := m.ParsePath(p); err != nil {
-			continue
-		}
-		m.Location = location
-		manifests = append(manifests, m)
-	}
 	return manifests, nil
 }
 


### PR DESCRIPTION
Instead of passing a context into the HTTP request with a 12 hour
timeout, we now set a 5 minute timeout but only enforce it per batch of
files. This is done by waiting for the next JSON decode from the HTTP
request body and selecting between that and a 5 minute timeout each time
we process a new batch, cancelling the context if the timeout is reached.

Had some trouble coming up with a decent way to get this working since we can't really put it in the context, as it needs to be started fresh every time we get something new over the line. Let me know if any feedback on an alternate way to approach this.

Relates to #3039