### PR TITLE
rclone: use server mod time by default

### DIFF
--- a/pkg/config/agent/testdata/auth_token_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/auth_token_overwrite.golden.yaml
@@ -79,7 +79,7 @@ rclone:
   stats_file_name_length: 45
   ask_password: true
   password_command: []
-  use_server_mod_time: false
+  use_server_mod_time: true
   max_transfer: -1
   max_duration: 0s
   cutoff_mode: 0

--- a/pkg/config/agent/testdata/basic.golden.yaml
+++ b/pkg/config/agent/testdata/basic.golden.yaml
@@ -79,7 +79,7 @@ rclone:
   stats_file_name_length: 45
   ask_password: true
   password_command: []
-  use_server_mod_time: false
+  use_server_mod_time: true
   max_transfer: -1
   max_duration: 0s
   cutoff_mode: 0

--- a/pkg/config/agent/testdata/debug_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/debug_overwrite.golden.yaml
@@ -79,7 +79,7 @@ rclone:
   stats_file_name_length: 45
   ask_password: true
   password_command: []
-  use_server_mod_time: false
+  use_server_mod_time: true
   max_transfer: -1
   max_duration: 0s
   cutoff_mode: 0

--- a/pkg/config/agent/testdata/https_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/https_overwrite.golden.yaml
@@ -79,7 +79,7 @@ rclone:
   stats_file_name_length: 45
   ask_password: true
   password_command: []
-  use_server_mod_time: false
+  use_server_mod_time: true
   max_transfer: -1
   max_duration: 0s
   cutoff_mode: 0

--- a/pkg/config/agent/testdata/prometheus_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/prometheus_overwrite.golden.yaml
@@ -79,7 +79,7 @@ rclone:
   stats_file_name_length: 45
   ask_password: true
   password_command: []
-  use_server_mod_time: false
+  use_server_mod_time: true
   max_transfer: -1
   max_duration: 0s
   cutoff_mode: 0

--- a/pkg/config/agent/testdata/scylla_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/scylla_overwrite.golden.yaml
@@ -79,7 +79,7 @@ rclone:
   stats_file_name_length: 45
   ask_password: true
   password_command: []
-  use_server_mod_time: false
+  use_server_mod_time: true
   max_transfer: -1
   max_duration: 0s
   cutoff_mode: 0

--- a/pkg/config/agent/testdata/structs_empty.golden.yaml
+++ b/pkg/config/agent/testdata/structs_empty.golden.yaml
@@ -79,7 +79,7 @@ rclone:
   stats_file_name_length: 45
   ask_password: true
   password_command: []
-  use_server_mod_time: false
+  use_server_mod_time: true
   max_transfer: -1
   max_duration: 0s
   cutoff_mode: 0

--- a/pkg/rclone/options.go
+++ b/pkg/rclone/options.go
@@ -30,7 +30,7 @@ const (
 // GlobalOptions is an alias for rclone fs.ConfigInfo.
 type GlobalOptions = fs.ConfigInfo
 
-// DefaultGlobalOptions returns rclong fs.ConfigInfo initialized with default
+// DefaultGlobalOptions returns rclone fs.ConfigInfo initialized with default
 // values.
 func DefaultGlobalOptions() GlobalOptions {
 	c := fs.NewConfig()
@@ -50,6 +50,8 @@ func DefaultGlobalOptions() GlobalOptions {
 	c.NoTraverse = true
 	// Explicitly disable deletes as enabling them turns off NoTraverse.
 	c.DeleteMode = fs.DeleteModeOff
+	// Use modification time from server ListObjects request.
+	c.UseServerModTime = true
 
 	// The number of checkers to run in parallel.
 	// Checkers do the equality checking of files (local vs. backup location)


### PR DESCRIPTION
This prevents rclone from performing a HEAD request for each file when
listing objects.

fixes #3046