### PR TITLE
rclone: update rclone dependency to reduce logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,6 @@ require (
 
 replace (
 	github.com/gocql/gocql => github.com/scylladb/gocql v1.5.1-0.20210906110332-fb22d64efc33
-	github.com/rclone/rclone => github.com/scylladb/rclone v1.54.1-0.20210923101756-ca38103352d9
+	github.com/rclone/rclone => github.com/scylladb/rclone v1.54.1-0.20220302094033-0bf74ef6c54b
 	google.golang.org/api v0.34.0 => github.com/scylladb/google-api-go-client v0.34.0-patched
 )

--- a/go.sum
+++ b/go.sum
@@ -678,10 +678,8 @@ github.com/scylladb/gocqlx/v2 v2.4.0 h1:XkmIf3F++iP8jWCqZuabcF5Vw2bqD7VRpyTVmPFQ
 github.com/scylladb/gocqlx/v2 v2.4.0/go.mod h1:rb1rAYGkQjkUrpBgsEovkULiX8ik0QQSwdIs+YrgKbs=
 github.com/scylladb/google-api-go-client v0.34.0-patched h1:ojZBnyKm2/HbRuERamBCmH1ariPTj6mqG53y0wQIkik=
 github.com/scylladb/google-api-go-client v0.34.0-patched/go.mod h1:/XrVsuzM0rZmrsbjJutiuftIzeuTQcEeaYcSk/mQ1dg=
-github.com/scylladb/rclone v1.54.0-patched h1:GLfmm0Ck5q5eRVC79GzT91RgdN1RNSkgquoVkXYFWQo=
-github.com/scylladb/rclone v1.54.0-patched/go.mod h1:tOEyuX+gEnD02u07wwvDmyFmWCDZsHmI5tw1zU+WcB8=
-github.com/scylladb/rclone v1.54.1-0.20210923101756-ca38103352d9 h1:F5JcSjMMRxjRvGn1QqUqbwWZFystEp3OpMNugnnUqSs=
-github.com/scylladb/rclone v1.54.1-0.20210923101756-ca38103352d9/go.mod h1:tOEyuX+gEnD02u07wwvDmyFmWCDZsHmI5tw1zU+WcB8=
+github.com/scylladb/rclone v1.54.1-0.20220302094033-0bf74ef6c54b h1:5gRZKFEIkw9RSNCo1hcHY+7Na0tuJwgROnPirxCOEwU=
+github.com/scylladb/rclone v1.54.1-0.20220302094033-0bf74ef6c54b/go.mod h1:tOEyuX+gEnD02u07wwvDmyFmWCDZsHmI5tw1zU+WcB8=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4 h1:8qmTC5ByIXO3GP/IzBkxcZ/99VITvnIETDhdFz/om7A=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/vendor/github.com/rclone/rclone/fs/operations/operations.go
+++ b/vendor/github.com/rclone/rclone/fs/operations/operations.go
@@ -519,9 +519,9 @@ func Copy(ctx context.Context, f fs.Fs, dst fs.Object, remote string, src fs.Obj
 		}
 	}
 	if newDst != nil && src.String() != newDst.String() {
-		fs.Infof(src, "%s to: %s", actionTaken, newDst.String())
+		fs.Debugf(src, "%s to: %s", actionTaken, newDst.String())
 	} else {
-		fs.Infof(src, actionTaken)
+		fs.Debugf(src, actionTaken)
 	}
 	return newDst, err
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -227,7 +227,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/rclone/rclone v1.51.0 => github.com/scylladb/rclone v1.54.1-0.20210923101756-ca38103352d9
+# github.com/rclone/rclone v1.51.0 => github.com/scylladb/rclone v1.54.1-0.20220302094033-0bf74ef6c54b
 ## explicit
 github.com/rclone/rclone/backend/azureblob
 github.com/rclone/rclone/backend/crypt
@@ -541,4 +541,4 @@ gopkg.in/inf.v0
 ## explicit
 gopkg.in/yaml.v2
 # github.com/gocql/gocql => github.com/scylladb/gocql v1.5.1-0.20210906110332-fb22d64efc33
-# github.com/rclone/rclone => github.com/scylladb/rclone v1.54.1-0.20210923101756-ca38103352d9
+# github.com/rclone/rclone => github.com/scylladb/rclone v1.54.1-0.20220302094033-0bf74ef6c54b


### PR DESCRIPTION
- Latest patched version of rclone reduces file copy logs to DEBUG level

fixes #3041
