### PR TITLE
managerclient: add host to repair progress details

### DIFF
--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -603,6 +603,8 @@ Progress:	{{ FormatRepairProgress .TokenRanges .Success .Error }}
 Intensity:	{{ .Intensity }}
 Parallel:	{{ .Parallel }}
 {{- end }}
+{{ if .Host }}Host:	{{ .Host }}
+{{ end -}}
 {{ if .Dcs }}Datacenters:	{{ range .Dcs }}
   - {{ . }}
 {{- end }}

--- a/pkg/schema/table/table.go
+++ b/pkg/schema/table/table.go
@@ -110,6 +110,7 @@ var (
 		Columns: []string{
 			"cluster_id",
 			"dc",
+			"host",
 			"id",
 			"prev_id",
 			"start_time",

--- a/pkg/service/repair/model.go
+++ b/pkg/service/repair/model.go
@@ -57,6 +57,7 @@ type Run struct {
 	ID        uuid.UUID
 
 	DC        []string
+	Host      string
 	PrevID    uuid.UUID
 	StartTime time.Time
 }
@@ -187,6 +188,7 @@ type TableProgress struct {
 type Progress struct {
 	progress
 	DC        []string        `json:"dcs"`
+	Host      string          `json:"host"`
 	Hosts     []HostProgress  `json:"hosts"`
 	Tables    []TableProgress `json:"tables"`
 	Intensity float64         `json:"intensity"`

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -227,6 +227,7 @@ func (s *Service) Repair(ctx context.Context, clusterID, taskID, runID uuid.UUID
 		TaskID:    taskID,
 		ID:        runID,
 		DC:        target.DC,
+		Host:      target.Host,
 		StartTime: timeutc.Now().UTC(),
 	}
 	if err := s.putRun(run); err != nil {
@@ -743,6 +744,7 @@ func (s *Service) GetProgress(ctx context.Context, clusterID, taskID, runID uuid
 		return p, err
 	}
 	p.DC = run.DC
+	p.Host = run.Host
 
 	return p, nil
 }

--- a/schema/v3.0.0.cql
+++ b/schema/v3.0.0.cql
@@ -13,3 +13,5 @@ ALTER TABLE scheduler_task ADD last_error timestamp;
 ALTER TABLE scheduler_task ADD deleted boolean;
 
 -- CALL setExistingTasksDeleted;
+
+ALTER TABLE repair_run ADD host text;

--- a/swagger/gen/scylla-manager/models/repair_progress.go
+++ b/swagger/gen/scylla-manager/models/repair_progress.go
@@ -32,6 +32,9 @@ type RepairProgress struct {
 	// error
 	Error int64 `json:"error,omitempty"`
 
+	// host
+	Host string `json:"host,omitempty"`
+
 	// hosts
 	Hosts []*RepairProgressHostsItems0 `json:"hosts"`
 

--- a/swagger/scylla-manager.json
+++ b/swagger/scylla-manager.json
@@ -175,6 +175,9 @@
             "type": "string"
           }
         },
+        "host": {
+          "type": "string"
+        },
         "intensity": {
           "type": "number"
         },


### PR DESCRIPTION
Previously if a specific host was specified for a repair that was not
reported in the repair progress and not tracked with a repair run.

Added host to the repair_run table and return that info via the API and
render in the progress output when available.

fixes #3067