### PR TITLE
docs: update theme 1.2.1

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -1,0 +1,34 @@
+name: "Docs / Links"
+# For more information,
+# see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # At 00:00 on Sunday
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.4.1
+        with:
+          args: --verbose --exclude-mail --no-progress './**/*.md' './**/*.rst'
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Create Issue From File
+        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue

--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -1,6 +1,6 @@
 name: "Docs / Publish"
-# For more information, 
-# see https://sphinx-theme.scylladb.com/stable/github-pages.html#available-workflows
+# For more information,
+# see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
 on:
   push:
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v3
         with:
           python-version: 3.7
-      - name: Set up Poetry
-        run: curl -sSL https://install.python-poetry.org | python -
+      - name: Set up env
+        run: make -C docs setupenv
       - name: Build docs
         run: make -C docs multiversion
       - name: Deploy docs to GitHub Pages

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -1,6 +1,6 @@
 name: "Docs / Build PR"
-# For more information, 
-# see https://sphinx-theme.scylladb.com/stable/github-pages.html#available-workflows
+# For more information,
+# see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
 on:
   pull_request:
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v2.3.1
+        uses: actions/setup-python@v3
         with:
           python-version: 3.7
-      - name: Set up Poetry
-        run: curl -sSL https://install.python-poetry.org | python -
+      - name: Set up env
+        run: make -C docs setupenv
       - name: Build docs
         run: make -C docs test

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+http://someurl
+http://somewebsite
+http://host
+http://192.168.121.99
+http://66.102.7.147

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,5 +1,5 @@
 # You can set these variables from the command line.
-POETRY        := $(HOME)/.local/bin/poetry
+POETRY        := poetry
 SPHINXOPTS    :=
 SPHINXBUILD   := $(POETRY) run sphinx-build
 PAPER         :=
@@ -14,12 +14,18 @@ ALLSPHINXOPTS   := -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(
 I18NSPHINXOPTS  := $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) $(SOURCEDIR)
 TESTSPHINXOPTS  := $(ALLSPHINXOPTS) -W --keep-going
 
+# Windows variables
+ifeq ($(OS),Windows_NT)
+    POETRY := $(APPDATA)\Python\Scripts\poetry
+endif
+
 .PHONY: all
 all: dirhtml
 
-.PHONY: pristine
-pristine: clean
-	git clean -dfX
+# Setup commands
+.PHONY: setupenv
+setupenv:
+	pip install -q poetry
 
 .PHONY: setup
 setup:
@@ -27,14 +33,16 @@ setup:
 	$(POETRY) update
 	./_utils/pre-build.sh
 
+# Clean commands
+.PHONY: pristine
+pristine: clean
+	git clean -dfX
+
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR)/*
 
-.PHONY: preview
-preview: setup
-	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500
-
+# Build commands
 .PHONY: dirhtml
 dirhtml: setup
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
@@ -59,16 +67,6 @@ epub3: setup
 	@echo
 	@echo "Build finished. The epub3 file is in $(BUILDDIR)/epub3."
 
-.PHONY: dummy
-dummy: setup
-	$(SPHINXBUILD) -b dummy $(ALLSPHINXOPTS) $(BUILDDIR)/dummy
-	@echo
-	@echo "Build finished. Dummy builder generates no files."
-
-.PHONY: linkcheck
-linkcheck: setup
-	$(SPHINXBUILD) -b linkcheck $(SOURCEDIR) $(BUILDDIR)/linkcheck
-
 .PHONY: multiversion
 multiversion: setup
 	$(POETRY) run sphinx-multiversion source _build/dirhtml \
@@ -76,10 +74,19 @@ multiversion: setup
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
+# Preview commands
+.PHONY: preview
+preview: setup
+	$(POETRY) run sphinx-autobuild -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml --port 5500
 
 .PHONY: multiversionpreview
 multiversionpreview: multiversion
 	$(POETRY) run python -m http.server 5500 --directory $(BUILDDIR)/dirhtml
+
+# Test commands
+.PHONY: linkcheck
+linkcheck: setup
+	$(SPHINXBUILD) -b linkcheck $(SOURCEDIR) $(BUILDDIR)/linkcheck
 
 .PHONY: test
 test: setup

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -6,15 +6,15 @@ authors = ["ScyllaDB Documentation Contributors"]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-pyyaml = "^6.0"
+pyyaml = "6.0"
 pygments = "2.2.0"
-recommonmark = "^0.7.1"
-sphinx-scylladb-theme = "~1.1.0"
-sphinx-sitemap = "2.1.0"
-sphinx-autobuild = "^2021.3.14"
-Sphinx = "^4.3.2"
-sphinx-multiversion-scylla = "~0.2.10"
-"sphinxcontrib.datatemplates" = "^0.9.1"
+recommonmark = "0.7.1"
+sphinx-scylladb-theme = "~1.2.1"
+sphinx-sitemap = "2.2.0"
+sphinx-autobuild = "2021.3.14"
+Sphinx = "4.3.2"
+sphinx-multiversion-scylla = "~0.2.11"
+"sphinxcontrib.datatemplates" = "0.9.1"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,20 +4,35 @@ import sys
 from datetime import date
 
 from sphinx_scylladb_theme.utils import multiversion_regex_builder
+
+# -- Global variables
+
+# Build documentation for the following tags and branches
+TAGS = []
+BRANCHES = ['master', 'branch-2.2', 'branch-2.3', 'branch-2.4', 'branch-2.5', 'branch-2.6']
+# Set the latest version.
+LATEST_VERSION = 'branch-2.6'
+# Set which versions are not released yet.
+UNSTABLE_VERSIONS = ['master']
+# Set which versions are deprecated
+DEPRECATED_VERSIONS = ['']
+
 # -- General configuration ------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.todo',
-    'sphinx.ext.mathjax',
-    'sphinx.ext.githubpages',
-    'sphinx.ext.extlinks',
-    'sphinx_scylladb_theme',
-    'sphinx_multiversion',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.todo",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.extlinks",
+    "sphinx_sitemap",
+    "sphinx_scylladb_theme",
     'sphinxcontrib.datatemplates',
-    'recommonmark',
+    "sphinx_multiversion",
+    "recommonmark",
 ]
 
 # The suffix(es) of source filenames.
@@ -54,15 +69,13 @@ redirects_file = "_utils/redirections.yaml"
 
 # -- Options for multiversion --------------------------------------------
 
-# Whitelist pattern for tags (set to None to ignore all tags)
-TAGS = []
+# Whitelist pattern for tags
 smv_tag_whitelist = multiversion_regex_builder(TAGS)
-# Whitelist pattern for branches (set to None to ignore all branches)
-BRANCHES = ['master', 'branch-2.2', 'branch-2.3', 'branch-2.4', 'branch-2.5', 'branch-2.6']
+# Whitelist pattern for branches
 smv_branch_whitelist = multiversion_regex_builder(BRANCHES)
 # Defines which version is considered to be the latest stable version.
-# Must be listed in smv_tag_whitelist or smv_branch_whitelist.
-smv_latest_version = 'branch-2.6'
+smv_latest_version = LATEST_VERSION
+# Defines the new name for the latest version.
 smv_rename_latest_version = 'stable'
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r"^origin$"
@@ -71,7 +84,11 @@ smv_released_pattern = r'^tags/.*$'
 # Format for versioned output directories inside the build directory
 smv_outputdir_format = '{ref.name}'
 
-# -- Options for HTML output ----------------------------------------------
+# -- Options for sitemap extension ---------------------------------------
+
+sitemap_url_scheme = 'stable/{link}'
+
+# -- Options for HTML output ---------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
@@ -92,6 +109,8 @@ html_theme_options = {
     'hide_edit_this_page_button': 'false',
     'hide_version_dropdown': ['master'],
     'tag_substring_removed': 'scylla-manager-',
+    'versions_unstable': UNSTABLE_VERSIONS,
+    'versions_deprecated': DEPRECATED_VERSIONS,
 }
 
 # If not None, a 'Last updated on:' timestamp is inserted at every page


### PR DESCRIPTION
Related issue https://github.com/scylladb/sphinx-scylladb-theme/issues/395

ScyllaDB Sphinx Theme 1.2 is now released 🥳 

We’ve added automatic checks for broken links and introduced numerous UI updates.

You can read more about all notable changes [here](https://sphinx-theme.scylladb.com/stable/upgrade/CHANGELOG.html#march-2022).

## How to test this PR

1. Clone this PR. For more information, see [Cloning pull requests locally](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/checking-out-pull-requests-locally).

2. Enter the docs folder, and run:

```
make preview
````

4. Open http://127.0.0.1:5500/ with your favorite browser. The doc should render without errors, and the version should be Sphinx Theme version (see the footer) must be ``1.2.x``:

![image](https://user-images.githubusercontent.com/9107969/159508628-9da8fb3f-b1fa-45e2-a99e-d5f44a90bfaf.png)