### PR TITLE
scheduler/window: Account for DST changes

### DIFF
--- a/pkg/scheduler/trigger/cron_test.go
+++ b/pkg/scheduler/trigger/cron_test.go
@@ -27,7 +27,9 @@ func TestCronInDifferentLocations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	now := timeutc.Now()
+	// Must use a date where EST and CET locations are actually 6 hours apart.
+	// A few weeks a year they are 5 or 7 due to DST.
+	now := time.Date(2022, 1, 15, 12, 05, 01, 0, time.UTC)
 
 	n0 := c.Next(now.In(l0))
 	n1 := c.Next(now.In(l1))

--- a/pkg/scheduler/window.go
+++ b/pkg/scheduler/window.go
@@ -96,7 +96,11 @@ func (i WeekdayTime) Next(now time.Time) time.Time {
 	if w < 0 || w == 0 && now.Sub(t) > i.Time {
 		w += 7
 	}
-	return t.Add(time.Duration(w)*day + i.Time)
+
+	d := t.Add(time.Duration(w) * day)
+
+	return time.Date(d.Year(), d.Month(), d.Day(), int(i.Time.Hours()), int(i.Time.Minutes())%60,
+		int(i.Time.Seconds())%60, int(i.Time.Nanoseconds())%1e9, t.Location())
 }
 
 type slot struct {

--- a/pkg/scheduler/window_test.go
+++ b/pkg/scheduler/window_test.go
@@ -19,6 +19,8 @@ func TestWeekdayTimeNext(t *testing.T) {
 		h = time.Hour
 	)
 
+	aus, _ := time.LoadLocation("Australia/Sydney")
+
 	table := []struct {
 		Name        string
 		WeekdayTime WeekdayTime
@@ -69,6 +71,15 @@ func TestWeekdayTimeNext(t *testing.T) {
 			},
 			Now:    time.Date(2020, 2, 23, 15, 59, 0, 0, time.UTC),
 			Golden: time.Date(2020, 2, 29, 4, 5, 0, 0, time.UTC),
+		},
+		{
+			Name: "daylight savings time",
+			WeekdayTime: WeekdayTime{
+				Weekday: time.Sunday,
+				Time:    21*h + 5*m,
+			},
+			Now:    time.Date(2022, 4, 2, 23, 59, 0, 0, aus),
+			Golden: time.Date(2022, 4, 3, 21, 5, 0, 0, aus),
 		},
 	}
 


### PR DESCRIPTION
Previously we were calculating execution times by simply adding a
`time.Duration` to 00:00 on the execution day. Most of the time this
works, however on days where DST begins or ends it does not. For
example 21:00 is not always 21 hours after 00:00, sometimes it can
be 20 or 22 hours after.

In order to account for this we are now creating a new time using the
hours from duration and the location instead of simply adding it.

Also fixed an issue with a test that does not account for DST changes,
sometimes EST and CET are not 6 hours apart but instead 5 or 7 because
the clocks change on different dates.

fixes #3082