### PR TITLE
service/scheduler: schedule one off tasks on resume

### DIFF
--- a/pkg/service/scheduler/service_suspend.go
+++ b/pkg/service/scheduler/service_suspend.go
@@ -226,6 +226,9 @@ func (s *Service) Resume(ctx context.Context, clusterID uuid.UUID, startTasks bo
 	}
 	if err := s.forEachClusterTask(clusterID, func(t *Task) error {
 		r := running.Has(t.ID.Bytes16())
+		if needsOneShotRun(t) {
+			r = true
+		}
 		if t.Type == SuspendTask {
 			r = false
 		}


### PR DESCRIPTION
If a task is created with a window but not any type of schedule it
should begin execution when the window begins. In the case where the
scheduler is suspended or stopped before the execution that was never
happening. This makes sure we check if a task created in that way gets
scheduled on a resume if the task has never run.

fixes #3083
