### PR TITLE
managerclient: don't limit status column

### DIFF
--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -477,7 +477,6 @@ type TaskRunSlice []*TaskRun
 // Render renders TaskRunSlice in a tabular format.
 func (tr TaskRunSlice) Render(w io.Writer) error {
 	t := table.New("ID", "Start time", "Duration", "Status")
-	t.LimitColumnLength(3)
 	for _, r := range tr {
 		s := r.Status
 		if r.Cause != "" {


### PR DESCRIPTION
As far as I can tell this limit really didn't bring any benefit to begin
with. Every status is almost as short as the table header "Status"
anyway and the other columns in the table are much longer and more
likely to cause the lines to wrap. There is also only a 1-2 width window
where this could actually be beneficial, and in other cases it leads to
every status showing as "…" which can cause confusion.

fixes #3065