### PR TITLE
scyllaclient: expose config to config file

### DIFF
--- a/dist/etc/scylla-manager.yaml
+++ b/dist/etc/scylla-manager.yaml
@@ -133,3 +133,25 @@ http: 127.0.0.1:5080
 # Distribution of data among cores (shards) within a node.
 # Copy value from Scylla configuration file.
 #  murmur3_partitioner_ignore_msb_bits: 12
+
+# Connection configuration to Scylla Agent.
+#  agent_client:
+#
+# Timeouts configuration.
+#    timeout: 30s
+#    max_timeout: 1h
+#    list_timeout: 5m
+#
+# Connection backoff configuration.
+#    backoff:
+#      wait_min: 1s
+#      wait_max: 30s
+#      max_retries: 9
+#      multiplier: 2
+#      jitter: 0.2
+#    interactive_backoff:
+#      wait_min: 1s
+#      max_retries: 1
+#
+# Time window to measure average request time in host pool.
+#    pool_decay_duration: 30m

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -72,7 +72,7 @@ func (s *server) makeServices() error {
 	drawerStore := store.NewTableStore(s.session, table.Drawer)
 	secretsStore := store.NewTableStore(s.session, table.Secrets)
 
-	s.clusterSvc, err = cluster.NewService(s.session, metrics.NewClusterMetrics().MustRegister(), secretsStore, s.logger.Named("cluster"))
+	s.clusterSvc, err = cluster.NewService(s.session, metrics.NewClusterMetrics().MustRegister(), secretsStore, s.config.TimeoutConfig, s.logger.Named("cluster"))
 	if err != nil {
 		return errors.Wrapf(err, "cluster service")
 	}

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-manager/v3/pkg/config"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/healthcheck"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/repair"
@@ -42,20 +43,21 @@ type SSLConfig struct {
 
 // Config contains configuration structure for scylla manager.
 type Config struct {
-	HTTP        string             `yaml:"http"`
-	HTTPS       string             `yaml:"https"`
-	TLSVersion  config.TLSVersion  `yaml:"tls_version"`
-	TLSCertFile string             `yaml:"tls_cert_file"`
-	TLSKeyFile  string             `yaml:"tls_key_file"`
-	TLSCAFile   string             `yaml:"tls_ca_file"`
-	Prometheus  string             `yaml:"prometheus"`
-	Debug       string             `yaml:"debug"`
-	Logger      config.LogConfig   `yaml:"logger"`
-	Database    DBConfig           `yaml:"database"`
-	SSL         SSLConfig          `yaml:"ssl"`
-	Healthcheck healthcheck.Config `yaml:"healthcheck"`
-	Backup      backup.Config      `yaml:"backup"`
-	Repair      repair.Config      `yaml:"repair"`
+	HTTP          string                     `yaml:"http"`
+	HTTPS         string                     `yaml:"https"`
+	TLSVersion    config.TLSVersion          `yaml:"tls_version"`
+	TLSCertFile   string                     `yaml:"tls_cert_file"`
+	TLSKeyFile    string                     `yaml:"tls_key_file"`
+	TLSCAFile     string                     `yaml:"tls_ca_file"`
+	Prometheus    string                     `yaml:"prometheus"`
+	Debug         string                     `yaml:"debug"`
+	Logger        config.LogConfig           `yaml:"logger"`
+	Database      DBConfig                   `yaml:"database"`
+	SSL           SSLConfig                  `yaml:"ssl"`
+	Healthcheck   healthcheck.Config         `yaml:"healthcheck"`
+	Backup        backup.Config              `yaml:"backup"`
+	Repair        repair.Config              `yaml:"repair"`
+	TimeoutConfig scyllaclient.TimeoutConfig `yaml:"agent_client"`
 }
 
 func DefaultConfig() Config {
@@ -76,9 +78,10 @@ func DefaultConfig() Config {
 		SSL: SSLConfig{
 			Validate: true,
 		},
-		Healthcheck: healthcheck.DefaultConfig(),
-		Backup:      backup.DefaultConfig(),
-		Repair:      repair.DefaultConfig(),
+		Healthcheck:   healthcheck.DefaultConfig(),
+		Backup:        backup.DefaultConfig(),
+		Repair:        repair.DefaultConfig(),
+		TimeoutConfig: scyllaclient.DefaultTimeoutConfig(),
 	}
 }
 

--- a/pkg/config/server/server_test.go
+++ b/pkg/config/server/server_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/scylla-manager/v3/pkg/config"
 	"github.com/scylladb/scylla-manager/v3/pkg/config/server"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/healthcheck"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/repair"
@@ -85,6 +86,23 @@ func TestConfigModification(t *testing.T) {
 			GracefulStopTimeout:             60 * time.Second,
 			ForceRepairType:                 repair.TypeAuto,
 			Murmur3PartitionerIgnoreMSBBits: 12,
+		},
+		TimeoutConfig: scyllaclient.TimeoutConfig{
+			Timeout:     45 * time.Second,
+			MaxTimeout:  5 * time.Hour,
+			ListTimeout: 7 * time.Minute,
+			Backoff: scyllaclient.BackoffConfig{
+				WaitMin:    5 * time.Second,
+				WaitMax:    20 * time.Second,
+				MaxRetries: 12,
+				Multiplier: 8,
+				Jitter:     0.6,
+			},
+			InteractiveBackoff: scyllaclient.BackoffConfig{
+				WaitMin:    2 * time.Second,
+				MaxRetries: 4,
+			},
+			PoolDecayDuration: time.Hour,
 		},
 	}
 

--- a/pkg/config/server/testdata/scylla-manager.yaml
+++ b/pkg/config/server/testdata/scylla-manager.yaml
@@ -46,3 +46,18 @@ repair:
   long_polling_timeout_seconds: 5
   age_max: 12h
   graceful_stop_timeout: 60s
+
+agent_client:
+  timeout: 45s
+  max_timeout: 5h
+  list_timeout: 7m
+  backoff:
+    wait_min: 5s
+    wait_max: 20s
+    max_retries: 12
+    multiplier: 8
+    jitter: 0.6
+  interactive_backoff:
+    wait_min: 2s
+    max_retries: 4
+  pool_decay_duration: 1h

--- a/pkg/scyllaclient/config.go
+++ b/pkg/scyllaclient/config.go
@@ -12,53 +12,67 @@ import (
 
 // Config specifies the Client configuration.
 type Config struct {
+	TimeoutConfig
+	// Transport scheme HTTP or HTTPS.
+	Scheme string `yaml:"scheme"`
 	// Hosts specifies all the cluster hosts that for a pool of hosts for the
 	// client.
 	Hosts []string
 	// Port specifies the default Scylla Manager agent port.
 	Port string
-	// Transport scheme HTTP or HTTPS.
-	Scheme string
 	// AuthToken specifies the authentication token.
 	AuthToken string
-	// Timeout specifies time to complete a single request to Scylla REST API
-	// possibly including opening a TCP connection.
-	// The timeout may be increased exponentially on retry after a timeout error.
-	Timeout time.Duration
-	// MaxTimeout specifies the effective maximal timeout value after increasing Timeout on retry.
-	MaxTimeout time.Duration
-	// ListTimeout specifies maximum time to complete an iterative remote
-	// directory listing. The retrieval is performed in batches this timeout
-	// applies to the time it take to retrieve a single batch.
-	ListTimeout time.Duration
-	// Backoff specifies parameters of exponential backoff used when requests
-	// from Scylla Manager to Scylla Agent fail.
-	Backoff BackoffConfig
-	// InteractiveBackoff specifies backoff for interactive requests i.e.
-	// originating from API / sctool.
-	InteractiveBackoff BackoffConfig
-	// PoolDecayDuration specifies size of time window to measure average
-	// request time in Epsilon-Greedy host pool.
-	PoolDecayDuration time.Duration
-
 	// Transport allows for setting a custom round tripper to send HTTP
 	// requests over not standard connections i.e. over SSH tunnel.
 	Transport http.RoundTripper
 }
 
+// TimeoutConfig is the configuration of the connection exposed to users.
+type TimeoutConfig struct {
+	// Timeout specifies time to complete a single request to Scylla REST API
+	// possibly including opening a TCP connection.
+	// The timeout may be increased exponentially on retry after a timeout error.
+	Timeout time.Duration `yaml:"timeout"`
+	// MaxTimeout specifies the effective maximal timeout value after increasing Timeout on retry.
+	MaxTimeout time.Duration `yaml:"max_timeout"`
+	// ListTimeout specifies maximum time to complete an iterative remote
+	// directory listing. The retrieval is performed in batches this timeout
+	// applies to the time it take to retrieve a single batch.
+	ListTimeout time.Duration `yaml:"list_timeout"`
+	// Backoff specifies parameters of exponential backoff used when requests
+	// from Scylla Manager to Scylla Agent fail.
+	Backoff BackoffConfig `yaml:"backoff"`
+	// InteractiveBackoff specifies backoff for interactive requests i.e.
+	// originating from API / sctool.
+	InteractiveBackoff BackoffConfig `yaml:"interactive_backoff"`
+	// PoolDecayDuration specifies size of time window to measure average
+	// request time in Epsilon-Greedy host pool.
+	PoolDecayDuration time.Duration `yaml:"pool_decay_duration"`
+}
+
 // BackoffConfig specifies request exponential backoff parameters.
 type BackoffConfig struct {
-	WaitMin    time.Duration
-	WaitMax    time.Duration
-	MaxRetries uint64
-	Multiplier float64
-	Jitter     float64
+	WaitMin    time.Duration `yaml:"wait_min"`
+	WaitMax    time.Duration `yaml:"wait_max"`
+	MaxRetries uint64        `yaml:"max_retries"`
+	Multiplier float64       `yaml:"multiplier"`
+	Jitter     float64       `yaml:"jitter"`
 }
 
 func DefaultConfig() Config {
+	return DefaultConfigWithTimeout(DefaultTimeoutConfig())
+}
+
+func DefaultConfigWithTimeout(c TimeoutConfig) Config {
 	return Config{
-		Port:        "10001",
-		Scheme:      "https",
+		Scheme:        "https",
+		Port:          "10001",
+		TimeoutConfig: c,
+	}
+}
+
+func DefaultTimeoutConfig() TimeoutConfig {
+	return TimeoutConfig{
 		Timeout:     30 * time.Second,
 		MaxTimeout:  1 * time.Hour,
 		ListTimeout: 5 * time.Minute,


### PR DESCRIPTION
I created an additional struct containing only the user-configurable
parts of the client config, and embedded them within the config. This is
because fields like Hosts and Port are populated from the cluster and
they would just be overriden if exposed in the configuration.

fixes #3112