### PR TITLE
docs: link checker skip vendor dir

### DIFF
--- a/.github/workflows/docs-links.yaml
+++ b/.github/workflows/docs-links.yaml
@@ -21,7 +21,7 @@ jobs:
         id: lychee
         uses: lycheeverse/lychee-action@v1.4.1
         with:
-          args: --verbose --exclude-mail --no-progress './**/*.md' './**/*.rst'
+          args: --verbose --exclude-mail --no-progress './docs/**/*.md' './docs/**/*.rst'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 


### PR DESCRIPTION
Related issue https://github.com/scylladb/scylla-manager/issues/3121

Only check for broken links within the docs folder.