### PR TITLE
service/backup: split manifest load and deletion

### DIFF
--- a/docs/source/sctool/partials/sctool_backup.yaml
+++ b/docs/source/sctool/partials/sctool_backup.yaml
@@ -76,6 +76,8 @@ options:
     The '<dc>' parameter is optional it allows to specify location for a datacenter in a multi-dc setting, it must match Scylla nodes datacenter.
     The supported storage '<provider>'s are 'azure', 'gcs', 's3'.
     The 'name' parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
+- name: manifest-parallelism
+  default_value: "1"
 - name: name
   usage: |
     Task name that can be used insead of ID.

--- a/docs/source/sctool/partials/sctool_backup_delete.yaml
+++ b/docs/source/sctool/partials/sctool_backup_delete.yaml
@@ -21,6 +21,10 @@ options:
     The '<dc>' parameter is optional it allows to specify location for a datacenter in a multi-dc setting, it must match Scylla nodes datacenter.
     The supported storage '<provider>'s are 'azure', 'gcs', 's3'.
     The 'name' parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
+- name: purge-parallel
+  default_value: "1"
+  usage: |
+    The number of manifests to load in parallel (0 for no limit).
 - name: snapshot-tag
   shorthand: T
   default_value: '[]'

--- a/docs/source/sctool/partials/sctool_backup_update.yaml
+++ b/docs/source/sctool/partials/sctool_backup_update.yaml
@@ -77,6 +77,8 @@ options:
     The '<dc>' parameter is optional it allows to specify location for a datacenter in a multi-dc setting, it must match Scylla nodes datacenter.
     The supported storage '<provider>'s are 'azure', 'gcs', 's3'.
     The 'name' parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
+- name: manifest-parallelism
+  default_value: "1"
 - name: name
   usage: |
     Task name that can be used insead of ID.

--- a/pkg/command/backup/backupdelete/cmd.go
+++ b/pkg/command/backup/backupdelete/cmd.go
@@ -21,9 +21,10 @@ type command struct {
 	cobra.Command
 	client *managerclient.Client
 
-	cluster     string
-	location    []string
-	snapshotTag []string
+	cluster       string
+	location      []string
+	snapshotTag   []string
+	purgeParallel int64
 }
 
 func NewCommand(client *managerclient.Client) *cobra.Command {
@@ -47,6 +48,7 @@ func (cmd *command) init() {
 	w.Cluster(&cmd.cluster)
 	w.Location(&cmd.location)
 	w.Unwrap().StringSliceVarP(&cmd.snapshotTag, "snapshot-tag", "T", nil, "")
+	w.Unwrap().Int64VarP(&cmd.purgeParallel, "purge-parallel", "p", 1, "The number of manifests to load in parallel (0 for no limit).")
 }
 
 func (cmd *command) run() error {
@@ -56,5 +58,5 @@ func (cmd *command) run() error {
 			fmt.Fprintf(cmd.OutOrStderr(), "NOTICE: this may take a while, we are reading metadata from backup location(s)\n")
 		}
 	})
-	return cmd.client.DeleteSnapshot(cmd.Context(), cmd.cluster, cmd.location, cmd.snapshotTag)
+	return cmd.client.DeleteSnapshot(cmd.Context(), cmd.cluster, cmd.location, cmd.snapshotTag, cmd.purgeParallel)
 }

--- a/pkg/command/backup/cmd.go
+++ b/pkg/command/backup/cmd.go
@@ -37,6 +37,7 @@ type command struct {
 	dryRun           bool
 	showTables       bool
 	purgeOnly        bool
+	purgeParallel    int
 }
 
 func NewCommand(client *managerclient.Client) *cobra.Command {
@@ -82,6 +83,7 @@ func (cmd *command) init() {
 	w.Keyspace(&cmd.keyspace)
 	w.Unwrap().IntVar(&cmd.retention, "retention", 7, "")
 	w.Unwrap().IntVar(&cmd.retentionDays, "retention-days", 0, "")
+	w.Unwrap().IntVar(&cmd.purgeParallel, "purge-parallel", 1, "")
 	w.Unwrap().StringSliceVar(&cmd.rateLimit, "rate-limit", nil, "")
 	w.Unwrap().StringSliceVar(&cmd.snapshotParallel, "snapshot-parallel", nil, "")
 	w.Unwrap().StringSliceVar(&cmd.uploadParallel, "upload-parallel", nil, "")
@@ -152,6 +154,10 @@ func (cmd *command) run(args []string) error {
 	}
 	if cmd.Flag("purge-only").Changed {
 		props["purge_only"] = cmd.purgeOnly
+		ok = true
+	}
+	if cmd.Flag("purge-parallel").Changed {
+		props["purge-parallel"] = cmd.purgeParallel
 		ok = true
 	}
 

--- a/pkg/command/backup/res.yaml
+++ b/pkg/command/backup/res.yaml
@@ -34,3 +34,8 @@ show-tables: |
 
 purge-only: |
   Run the backup cleanup only.
+
+purge-parallel: |
+  The number of hosts to read manifests from in parallel.
+  The reading of manifests can be a memory-intensive process so this limit can be raised if sufficient memory is available to the host.
+  Set to 0 for no limit.

--- a/pkg/managerclient/client.go
+++ b/pkg/managerclient/client.go
@@ -560,12 +560,13 @@ func (c Client) ListBackupFiles(ctx context.Context, clusterID string,
 
 // DeleteSnapshot deletes backup snapshot with all data associated with it.
 func (c Client) DeleteSnapshot(ctx context.Context, clusterID string,
-	locations []string, snapshotTags []string) error {
+	locations []string, snapshotTags []string, purgeParallel int64) error {
 	p := &operations.DeleteClusterClusterIDBackupsParams{
-		Context:      ctx,
-		ClusterID:    clusterID,
-		Locations:    locations,
-		SnapshotTags: snapshotTags,
+		Context:       ctx,
+		ClusterID:     clusterID,
+		Locations:     locations,
+		SnapshotTags:  snapshotTags,
+		PurgeParallel: purgeParallel,
 	}
 
 	_, err := c.operations.DeleteClusterClusterIDBackups(p) // nolint: errcheck

--- a/pkg/restapi/mock_backupservice_test.go
+++ b/pkg/restapi/mock_backupservice_test.go
@@ -39,17 +39,17 @@ func (m *MockBackupService) EXPECT() *MockBackupServiceMockRecorder {
 }
 
 // DeleteSnapshot mocks base method.
-func (m *MockBackupService) DeleteSnapshot(arg0 context.Context, arg1 uuid.UUID, arg2 []backupspec.Location, arg3 []string) error {
+func (m *MockBackupService) DeleteSnapshot(arg0 context.Context, arg1 uuid.UUID, arg2 []backupspec.Location, arg3 []string, arg4 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSnapshot", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "DeleteSnapshot", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteSnapshot indicates an expected call of DeleteSnapshot.
-func (mr *MockBackupServiceMockRecorder) DeleteSnapshot(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockBackupServiceMockRecorder) DeleteSnapshot(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSnapshot", reflect.TypeOf((*MockBackupService)(nil).DeleteSnapshot), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSnapshot", reflect.TypeOf((*MockBackupService)(nil).DeleteSnapshot), arg0, arg1, arg2, arg3, arg4)
 }
 
 // ExtractLocations mocks base method.

--- a/pkg/restapi/services.go
+++ b/pkg/restapi/services.go
@@ -57,7 +57,7 @@ type BackupService interface {
 	List(ctx context.Context, clusterID uuid.UUID, locations []backupspec.Location, filter backup.ListFilter) ([]backup.ListItem, error)
 	ListFiles(ctx context.Context, clusterID uuid.UUID, locations []backupspec.Location, filter backup.ListFilter) ([]backupspec.FilesInfo, error)
 	GetProgress(ctx context.Context, clusterID, taskID, runID uuid.UUID) (backup.Progress, error)
-	DeleteSnapshot(ctx context.Context, clusterID uuid.UUID, locations []backupspec.Location, snapshotTags []string) error
+	DeleteSnapshot(ctx context.Context, clusterID uuid.UUID, locations []backupspec.Location, snapshotTags []string, parallelism int) error
 	GetValidationTarget(_ context.Context, clusterID uuid.UUID, properties json.RawMessage) (backup.ValidationTarget, error)
 	GetValidationProgress(ctx context.Context, clusterID, taskID, runID uuid.UUID) ([]backup.ValidationHostProgress, error)
 }

--- a/pkg/service/backup/model.go
+++ b/pkg/service/backup/model.go
@@ -50,6 +50,7 @@ type Target struct {
 	UploadParallel   []DCLimit    `json:"upload_parallel,omitempty"`
 	Continue         bool         `json:"continue,omitempty"`
 	PurgeOnly        bool         `json:"purge_only,omitempty"`
+	PurgeParallel    int          `json:"purge_parallel"`
 
 	// LiveNodes caches node status for GetTarget GetTargetSize calls.
 	liveNodes scyllaclient.NodeStatusInfoSlice `json:"-"`
@@ -238,6 +239,7 @@ type taskProperties struct {
 	UploadParallel   []DCLimit    `json:"upload_parallel"`
 	Continue         bool         `json:"continue"`
 	PurgeOnly        bool         `json:"purge_only"`
+	PurgeParallel    int          `json:"purge-parallel"`
 }
 
 func defaultTaskProperties() taskProperties {
@@ -245,6 +247,7 @@ func defaultTaskProperties() taskProperties {
 		Retention:     3,
 		RetentionDays: 0,
 		Continue:      true,
+		PurgeParallel: 1,
 	}
 }
 

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -1684,7 +1684,7 @@ func TestDeleteSnapshotIntegration(t *testing.T) {
 		t.Fatalf("Expected to have single snapshot in the first task, got %d", firstTaskTags.Size())
 	}
 
-	if err := h.service.DeleteSnapshot(ctx, h.clusterID, []Location{h.location}, []string{firstTaskTags.Pop()}); err != nil {
+	if err := h.service.DeleteSnapshot(ctx, h.clusterID, []Location{h.location}, []string{firstTaskTags.Pop()}, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1706,7 +1706,7 @@ func TestDeleteSnapshotIntegration(t *testing.T) {
 		t.Fatalf("Expected have single snapshot in second task, got %d", secondTaskTags.Size())
 	}
 
-	if err := h.service.DeleteSnapshot(ctx, h.clusterID, []Location{h.location}, []string{secondTaskTags.Pop()}); err != nil {
+	if err := h.service.DeleteSnapshot(ctx, h.clusterID, []Location{h.location}, []string{secondTaskTags.Pop()}, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/service/backup/testdata/get_target/continue.golden.json
+++ b/pkg/service/backup/testdata/get_target/continue.golden.json
@@ -3,20 +3,20 @@
     {
       "keyspace": "system_auth",
       "tables": [
-        "roles",
-        "role_permissions",
         "role_attributes",
-        "role_members"
+        "role_members",
+        "roles",
+        "role_permissions"
       ],
       "all_tables": true
     },
     {
       "keyspace": "system_distributed",
       "tables": [
-        "view_build_status",
+        "cdc_generation_timestamps",
         "service_levels",
-        "cdc_streams_descriptions_v2",
-        "cdc_generation_timestamps"
+        "view_build_status",
+        "cdc_streams_descriptions_v2"
       ],
       "all_tables": true
     },
@@ -31,8 +31,8 @@
       "keyspace": "system_traces",
       "tables": [
         "sessions",
-        "node_slow_log_time_idx",
         "sessions_time_idx",
+        "node_slow_log_time_idx",
         "events",
         "node_slow_log"
       ],
@@ -44,9 +44,9 @@
         "computed_columns",
         "views",
         "functions",
+        "indexes",
         "scylla_tables",
         "triggers",
-        "indexes",
         "dropped_columns",
         "columns",
         "aggregates",
@@ -66,7 +66,9 @@
     "s3:backuptest-get-target"
   ],
   "retention": 3,
+  "retention_days": 0,
   "rate_limit": [
     "100"
-  ]
+  ],
+  "purge_parallel": 1
 }

--- a/pkg/service/backup/testdata/get_target/dc_locations.golden.json
+++ b/pkg/service/backup/testdata/get_target/dc_locations.golden.json
@@ -3,10 +3,10 @@
     {
       "keyspace": "system_auth",
       "tables": [
-        "roles",
-        "role_permissions",
         "role_attributes",
-        "role_members"
+        "role_members",
+        "roles",
+        "role_permissions"
       ],
       "all_tables": true
     },
@@ -31,9 +31,9 @@
       "keyspace": "system_traces",
       "tables": [
         "sessions",
-        "node_slow_log_time_idx",
         "sessions_time_idx",
         "events",
+        "node_slow_log_time_idx",
         "node_slow_log"
       ],
       "all_tables": true
@@ -41,19 +41,19 @@
     {
       "keyspace": "system_schema",
       "tables": [
-        "computed_columns",
-        "views",
+        "types",
         "functions",
+        "view_virtual_columns",
         "scylla_tables",
-        "triggers",
         "indexes",
-        "dropped_columns",
-        "columns",
+        "triggers",
+        "tables",
+        "views",
+        "computed_columns",
         "aggregates",
         "keyspaces",
-        "tables",
-        "types",
-        "view_virtual_columns"
+        "columns",
+        "dropped_columns"
       ],
       "all_tables": true
     }
@@ -67,8 +67,10 @@
     "dc1:s3:backuptest-get-target"
   ],
   "retention": 3,
+  "retention_days": 0,
   "rate_limit": [
     "100"
   ],
-  "continue": true
+  "continue": true,
+  "purge_parallel": 1
 }

--- a/pkg/service/backup/testdata/get_target/dc_no_rate_limit.golden.json
+++ b/pkg/service/backup/testdata/get_target/dc_no_rate_limit.golden.json
@@ -3,20 +3,20 @@
     {
       "keyspace": "system_auth",
       "tables": [
-        "roles",
-        "role_permissions",
         "role_attributes",
-        "role_members"
+        "role_members",
+        "roles",
+        "role_permissions"
       ],
       "all_tables": true
     },
     {
       "keyspace": "system_distributed",
       "tables": [
-        "cdc_generation_timestamps",
         "cdc_streams_descriptions_v2",
-        "service_levels",
-        "view_build_status"
+        "view_build_status",
+        "cdc_generation_timestamps",
+        "service_levels"
       ],
       "all_tables": true
     },
@@ -31,10 +31,10 @@
       "keyspace": "system_traces",
       "tables": [
         "node_slow_log_time_idx",
-        "node_slow_log",
+        "sessions",
         "events",
         "sessions_time_idx",
-        "sessions"
+        "node_slow_log"
       ],
       "all_tables": true
     },
@@ -49,11 +49,11 @@
         "columns",
         "keyspaces",
         "aggregates",
-        "computed_columns",
         "views",
-        "indexes",
+        "computed_columns",
         "functions",
-        "triggers"
+        "triggers",
+        "indexes"
       ],
       "all_tables": true
     }
@@ -66,8 +66,10 @@
     "s3:backuptest-get-target"
   ],
   "retention": 3,
+  "retention_days": 0,
   "rate_limit": [
     "0"
   ],
-  "continue": true
+  "continue": true,
+  "purge_parallel": 1
 }

--- a/pkg/service/backup/testdata/get_target/dc_rate_limit.golden.json
+++ b/pkg/service/backup/testdata/get_target/dc_rate_limit.golden.json
@@ -5,8 +5,8 @@
       "tables": [
         "roles",
         "role_permissions",
-        "role_attributes",
-        "role_members"
+        "role_members",
+        "role_attributes"
       ],
       "all_tables": true
     },
@@ -30,10 +30,10 @@
     {
       "keyspace": "system_traces",
       "tables": [
-        "sessions_time_idx",
         "sessions",
-        "node_slow_log_time_idx",
+        "sessions_time_idx",
         "events",
+        "node_slow_log_time_idx",
         "node_slow_log"
       ],
       "all_tables": true
@@ -41,19 +41,19 @@
     {
       "keyspace": "system_schema",
       "tables": [
-        "computed_columns",
-        "views",
-        "functions",
-        "scylla_tables",
-        "triggers",
-        "indexes",
-        "dropped_columns",
-        "columns",
-        "aggregates",
-        "keyspaces",
         "tables",
         "types",
-        "view_virtual_columns"
+        "view_virtual_columns",
+        "views",
+        "computed_columns",
+        "indexes",
+        "functions",
+        "triggers",
+        "scylla_tables",
+        "columns",
+        "dropped_columns",
+        "aggregates",
+        "keyspaces"
       ],
       "all_tables": true
     }
@@ -66,9 +66,11 @@
     "s3:backuptest-get-target"
   ],
   "retention": 3,
+  "retention_days": 0,
   "rate_limit": [
     "1000",
     "dc1:100"
   ],
-  "continue": true
+  "continue": true,
+  "purge_parallel": 1
 }

--- a/pkg/service/backup/testdata/get_target/dc_snapshot_parallel.golden.json
+++ b/pkg/service/backup/testdata/get_target/dc_snapshot_parallel.golden.json
@@ -3,10 +3,10 @@
     {
       "keyspace": "system_auth",
       "tables": [
-        "roles",
+        "role_members",
         "role_permissions",
         "role_attributes",
-        "role_members"
+        "roles"
       ],
       "all_tables": true
     },
@@ -30,10 +30,10 @@
     {
       "keyspace": "system_traces",
       "tables": [
-        "sessions",
-        "sessions_time_idx",
         "node_slow_log_time_idx",
+        "sessions",
         "events",
+        "sessions_time_idx",
         "node_slow_log"
       ],
       "all_tables": true
@@ -41,19 +41,19 @@
     {
       "keyspace": "system_schema",
       "tables": [
-        "views",
-        "computed_columns",
+        "types",
         "functions",
-        "triggers",
+        "view_virtual_columns",
         "scylla_tables",
         "indexes",
-        "dropped_columns",
-        "columns",
+        "triggers",
+        "tables",
+        "views",
+        "computed_columns",
         "aggregates",
         "keyspaces",
-        "tables",
-        "types",
-        "view_virtual_columns"
+        "columns",
+        "dropped_columns"
       ],
       "all_tables": true
     }
@@ -66,6 +66,7 @@
     "s3:backuptest-get-target"
   ],
   "retention": 3,
+  "retention_days": 0,
   "rate_limit": [
     "100"
   ],
@@ -73,5 +74,6 @@
     "10",
     "dc1:20"
   ],
-  "continue": true
+  "continue": true,
+  "purge_parallel": 1
 }

--- a/pkg/service/backup/testdata/get_target/dc_upload_parallel.golden.json
+++ b/pkg/service/backup/testdata/get_target/dc_upload_parallel.golden.json
@@ -3,10 +3,10 @@
     {
       "keyspace": "system_auth",
       "tables": [
-        "role_attributes",
-        "role_members",
         "roles",
-        "role_permissions"
+        "role_permissions",
+        "role_attributes",
+        "role_members"
       ],
       "all_tables": true
     },
@@ -30,10 +30,10 @@
     {
       "keyspace": "system_traces",
       "tables": [
-        "sessions_time_idx",
-        "sessions",
         "node_slow_log_time_idx",
+        "sessions",
         "events",
+        "sessions_time_idx",
         "node_slow_log"
       ],
       "all_tables": true
@@ -41,19 +41,19 @@
     {
       "keyspace": "system_schema",
       "tables": [
+        "scylla_tables",
+        "tables",
+        "types",
+        "view_virtual_columns",
+        "dropped_columns",
+        "columns",
+        "keyspaces",
+        "aggregates",
         "views",
         "computed_columns",
         "functions",
         "triggers",
-        "scylla_tables",
-        "indexes",
-        "dropped_columns",
-        "columns",
-        "aggregates",
-        "keyspaces",
-        "tables",
-        "types",
-        "view_virtual_columns"
+        "indexes"
       ],
       "all_tables": true
     }
@@ -66,6 +66,7 @@
     "s3:backuptest-get-target"
   ],
   "retention": 3,
+  "retention_days": 0,
   "rate_limit": [
     "100"
   ],
@@ -73,5 +74,6 @@
     "10",
     "dc1:20"
   ],
-  "continue": true
+  "continue": true,
+  "purge_parallel": 1
 }

--- a/pkg/service/backup/testdata/get_target/everything.golden.json
+++ b/pkg/service/backup/testdata/get_target/everything.golden.json
@@ -13,10 +13,10 @@
     {
       "keyspace": "system_distributed",
       "tables": [
-        "view_build_status",
-        "service_levels",
+        "cdc_generation_timestamps",
         "cdc_streams_descriptions_v2",
-        "cdc_generation_timestamps"
+        "service_levels",
+        "view_build_status"
       ],
       "all_tables": true
     },
@@ -30,30 +30,30 @@
     {
       "keyspace": "system_traces",
       "tables": [
-        "node_slow_log_time_idx",
-        "node_slow_log",
-        "events",
+        "sessions",
         "sessions_time_idx",
-        "sessions"
+        "node_slow_log_time_idx",
+        "events",
+        "node_slow_log"
       ],
       "all_tables": true
     },
     {
       "keyspace": "system_schema",
       "tables": [
-        "computed_columns",
-        "views",
-        "functions",
         "scylla_tables",
-        "triggers",
-        "indexes",
-        "dropped_columns",
-        "columns",
-        "aggregates",
-        "keyspaces",
         "tables",
         "types",
-        "view_virtual_columns"
+        "view_virtual_columns",
+        "dropped_columns",
+        "columns",
+        "keyspaces",
+        "aggregates",
+        "views",
+        "computed_columns",
+        "functions",
+        "triggers",
+        "indexes"
       ],
       "all_tables": true
     }
@@ -66,8 +66,10 @@
     "s3:backuptest-get-target"
   ],
   "retention": 3,
+  "retention_days": 0,
   "rate_limit": [
     "100"
   ],
-  "continue": true
+  "continue": true,
+  "purge_parallel": 1
 }

--- a/pkg/service/backup/testdata/get_target/filter_dc.golden.json
+++ b/pkg/service/backup/testdata/get_target/filter_dc.golden.json
@@ -3,8 +3,8 @@
     {
       "keyspace": "system_auth",
       "tables": [
-        "role_attributes",
         "role_members",
+        "role_attributes",
         "roles",
         "role_permissions"
       ],
@@ -13,10 +13,10 @@
     {
       "keyspace": "system_distributed",
       "tables": [
-        "cdc_generation_timestamps",
+        "view_build_status",
         "cdc_streams_descriptions_v2",
-        "service_levels",
-        "view_build_status"
+        "cdc_generation_timestamps",
+        "service_levels"
       ],
       "all_tables": true
     },
@@ -33,27 +33,27 @@
         "node_slow_log_time_idx",
         "node_slow_log",
         "events",
-        "sessions_time_idx",
-        "sessions"
+        "sessions",
+        "sessions_time_idx"
       ],
       "all_tables": true
     },
     {
       "keyspace": "system_schema",
       "tables": [
-        "scylla_tables",
         "tables",
         "types",
         "view_virtual_columns",
-        "dropped_columns",
-        "columns",
-        "keyspaces",
-        "aggregates",
-        "computed_columns",
         "views",
+        "computed_columns",
         "indexes",
         "functions",
-        "triggers"
+        "triggers",
+        "scylla_tables",
+        "columns",
+        "dropped_columns",
+        "aggregates",
+        "keyspaces"
       ],
       "all_tables": true
     }
@@ -65,8 +65,10 @@
     "s3:backuptest-get-target"
   ],
   "retention": 3,
+  "retention_days": 0,
   "rate_limit": [
     "100"
   ],
-  "continue": true
+  "continue": true,
+  "purge_parallel": 1
 }

--- a/pkg/service/backup/testdata/get_target/filter_keyspaces.golden.json
+++ b/pkg/service/backup/testdata/get_target/filter_keyspaces.golden.json
@@ -13,19 +13,19 @@
     {
       "keyspace": "system_schema",
       "tables": [
-        "scylla_tables",
-        "tables",
         "types",
-        "view_virtual_columns",
-        "dropped_columns",
-        "columns",
-        "keyspaces",
-        "aggregates",
-        "computed_columns",
-        "views",
-        "indexes",
         "functions",
-        "triggers"
+        "view_virtual_columns",
+        "scylla_tables",
+        "indexes",
+        "triggers",
+        "tables",
+        "views",
+        "computed_columns",
+        "aggregates",
+        "keyspaces",
+        "columns",
+        "dropped_columns"
       ],
       "all_tables": true
     }
@@ -38,8 +38,10 @@
     "s3:backuptest-get-target"
   ],
   "retention": 3,
+  "retention_days": 0,
   "rate_limit": [
     "100"
   ],
-  "continue": true
+  "continue": true,
+  "purge_parallel": 1
 }

--- a/swagger/Makefile
+++ b/swagger/Makefile
@@ -1,6 +1,6 @@
 all: gen/agent gen/scylla-manager gen/scylla/v1 gen/scylla/v2
 
-CLIENT := swagger generate client
+CLIENT := ../bin/swagger generate client
 
 gen/agent: agent.json
 	@rm -Rf $@ && mkdir -p $@

--- a/swagger/gen/scylla-manager/client/operations/delete_cluster_cluster_id_backups_parameters.go
+++ b/swagger/gen/scylla-manager/client/operations/delete_cluster_cluster_id_backups_parameters.go
@@ -65,6 +65,8 @@ type DeleteClusterClusterIDBackupsParams struct {
 	ClusterID string
 	/*Locations*/
 	Locations []string
+	/*PurgeParallel*/
+	PurgeParallel int64
 	/*SnapshotTags*/
 	SnapshotTags []string
 
@@ -128,6 +130,17 @@ func (o *DeleteClusterClusterIDBackupsParams) SetLocations(locations []string) {
 	o.Locations = locations
 }
 
+// WithPurgeParallel adds the purgeParallel to the delete cluster cluster ID backups params
+func (o *DeleteClusterClusterIDBackupsParams) WithPurgeParallel(purgeParallel int64) *DeleteClusterClusterIDBackupsParams {
+	o.SetPurgeParallel(purgeParallel)
+	return o
+}
+
+// SetPurgeParallel adds the purgeParallel to the delete cluster cluster ID backups params
+func (o *DeleteClusterClusterIDBackupsParams) SetPurgeParallel(purgeParallel int64) {
+	o.PurgeParallel = purgeParallel
+}
+
 // WithSnapshotTags adds the snapshotTags to the delete cluster cluster ID backups params
 func (o *DeleteClusterClusterIDBackupsParams) WithSnapshotTags(snapshotTags []string) *DeleteClusterClusterIDBackupsParams {
 	o.SetSnapshotTags(snapshotTags)
@@ -158,6 +171,15 @@ func (o *DeleteClusterClusterIDBackupsParams) WriteToRequest(r runtime.ClientReq
 	// query array param locations
 	if err := r.SetQueryParam("locations", joinedLocations...); err != nil {
 		return err
+	}
+
+	// query param purge_parallel
+	qrPurgeParallel := o.PurgeParallel
+	qPurgeParallel := swag.FormatInt64(qrPurgeParallel)
+	if qPurgeParallel != "" {
+		if err := r.SetQueryParam("purge_parallel", qPurgeParallel); err != nil {
+			return err
+		}
 	}
 
 	valuesSnapshotTags := o.SnapshotTags


### PR DESCRIPTION
Loading all manifests in parallel can be memory-intensive. This splits
the loading of manifests and the actual file deletion in the purge step.
This way by default manifests are loaded only one at a time, but a
configurable parallelism can be provided if memory is not as constrained
and they can be loaded in parallel again.

fixes #3113