### PR TITLE
Allow disabling Small Table Threshold optimitzation

### DIFF
--- a/docs/source/sctool/partials/sctool_repair.yaml
+++ b/docs/source/sctool/partials/sctool_repair.yaml
@@ -117,7 +117,7 @@ options:
 - name: small-table-threshold
   default_value: 1G
   usage: |
-    Enables small table optimization for tables of size lower than given threshold, supported units [B, M, G, T].
+    Enables small table optimization for tables of size lower than given threshold, supported units [B, M, G, T]. Choose 0 followed by an unit to disable.
 - name: start-date
   shorthand: s
   usage: |

--- a/docs/source/sctool/partials/sctool_repair_update.yaml
+++ b/docs/source/sctool/partials/sctool_repair_update.yaml
@@ -116,7 +116,7 @@ options:
 - name: small-table-threshold
   default_value: 1G
   usage: |
-    Enables small table optimization for tables of size lower than given threshold, supported units [B, M, G, T].
+    Enables small table optimization for tables of size lower than given threshold, supported units [B, M, G, T]. Choose 0 followed by an unit to disable.
 - name: start-date
   shorthand: s
   usage: |

--- a/pkg/command/repair/res.yaml
+++ b/pkg/command/repair/res.yaml
@@ -29,7 +29,7 @@ parallel: |
   The formula to calculate is is as follows: number of nodes / RF, ex. for 6 node cluster with RF=3 the maximum parallelism is 2.
 
 small-table-threshold: |
-  Enables small table optimization for tables of size lower than given threshold, supported units [B, M, G, T].
+  Enables small table optimization for tables of size lower than given threshold, supported units [B, M, G, T]. Choose 0 followed by an unit to disable.
 
 dry-run: |
   Validates and displays repair information without actually scheduling the repair.

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -472,7 +472,7 @@ func (s *Service) optimizeSmallTables(ctx context.Context, client *scyllaclient.
 			key := u.Keyspace + "." + t
 			total := totalSize[key]
 
-			if total <= target.SmallTableThreshold {
+			if total < target.SmallTableThreshold {
 				s.logger.Debug(ctx, "Detected small table", "keyspace", u.Keyspace, "table", t, "size", total, "threshold", target.SmallTableThreshold)
 				g.markSmallTable(u.Keyspace, t)
 				smallTables = append(smallTables, key)


### PR DESCRIPTION
This commit corrects the logic in repair/service.go to ensure that only tables below a given unit (and not equal) are ignored during the smallTable optimization check. This simple one-liner now allows one to effectively disable the optimization altogether by setting it as 0B, for example.