### PR TITLE
Fix version command `sctool version` output

### DIFF
--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
       - -trimpath
     ldflags:
       - -extldflags '-static'
-      - -X github.com/scylladb/scylla-manager/pkg.version={{ .Version }}
+      - -X github.com/scylladb/scylla-manager/v3/pkg.version={{ .Version }}
 
   - id: client
     dir: ../pkg
@@ -43,7 +43,7 @@ builds:
       - -trimpath
     ldflags:
       - -extldflags '-static'
-      - -X github.com/scylladb/scylla-manager/pkg.version={{ .Version }}
+      - -X github.com/scylladb/scylla-manager/v3/pkg.version={{ .Version }}
 
   - id: agent
     dir: ../pkg
@@ -60,7 +60,7 @@ builds:
       - -trimpath
     ldflags:
       - -extldflags '-static'
-      - -X github.com/scylladb/scylla-manager/pkg.version={{ .Version }}
+      - -X github.com/scylladb/scylla-manager/v3/pkg.version={{ .Version }}
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Version }}.{{ .Os }}_{{ .Arch }}"


### PR DESCRIPTION
Since 68c99a6c7ede5db83db1f423b1bc71b435a85f11, the output of
`sctool version` is:

```
Client version: Snapshot
Server version: Snapshot
```

it was breaking the dtest run since it was merged

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
