### PR TITLE
service/backup: allow underscores in backup paths

### DIFF
--- a/pkg/service/backup/backupspec/location.go
+++ b/pkg/service/backup/backupspec/location.go
@@ -83,7 +83,7 @@ var ErrInvalid = errors.Errorf("invalid location, the format is [dc:]<provider>:
 // Providers require that resource names are DNS compliant.
 // The following is a super simplified DNS (plus provider prefix)
 // matching regexp.
-var pattern = regexp.MustCompile(`^(([a-zA-Z0-9\-\_\.]+):)?([a-z0-9]+):([a-z0-9\-\.\/]+)$`)
+var pattern = regexp.MustCompile(`^(([a-zA-Z0-9\-\_\.]+):)?([a-z0-9]+):([a-z0-9\-\.\/\_]+)$`)
 
 // NewLocation first checks if location string conforms to valid pattern.
 // It then returns the location split into three components dc, remote, and


### PR DESCRIPTION
Fixes underscores in backup paths not being accepted

```
Command: 'sudo sctool backup -c b25d296b-52ea-4e01-9c7c-5761b00aaaa9 --location s3:manager-backup-tests-us-east-1/path_testing/ '

Exit code: 1

Stdout:



Stderr:

Error: malformed request: evaluate properties: extract retention for task b31aadce-b2f2-4432-8562-ab258361082d: invalid location "s3:manager-backup-tests-us-east-1/path_testing/", the format is [dc:]<provider>:<path> ex. s3:my-bucket, the path must be DNS compliant
Trace ID: CBTa_n9hQE2dCA-SWvNKvw (grep in scylla-manager logs)
```