### PR TITLE
Full range repair

### DIFF
--- a/pkg/service/cluster/service_integration_test.go
+++ b/pkg/service/cluster/service_integration_test.go
@@ -30,7 +30,6 @@ func TestServiceStorageIntegration(t *testing.T) {
 	session := CreateSession(t)
 
 	secretsStore := store.NewTableStore(session, table.Secrets)
-	// TimeoutConfig: scyllaclient.DefaultTimeoutConfig(),
 
 	s, err := cluster.NewService(session, metrics.NewClusterMetrics(), secretsStore, scyllaclient.DefaultTimeoutConfig(), log.NewDevelopment())
 	if err != nil {

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1204,6 +1204,15 @@ func TestServiceRepairIntegration(t *testing.T) {
 		if repairCalled != 1 {
 			t.Fatalf("Expected repair in one shot got %d", repairCalled)
 		}
+
+		p, err := h.service.GetProgress(context.Background(), h.clusterID, h.taskID, h.runID)
+		if err != nil {
+			h.t.Fatal(err)
+		}
+
+		if p.TokenRanges != 1 {
+			t.Fatalf("Expected all tokens in one range, got %d ranges", p.TokenRanges)
+		}
 	})
 
 	t.Run("repair status context timeout", func(t *testing.T) {


### PR DESCRIPTION
service/repair: join ranges when fully replicated small table

Run repairs on full ranges when tables are below small table threshold
and fully replicated.

fixes #3128