### PR TITLE
command/info: add cause flag and limit error field

### DIFF
--- a/docs/source/sctool/partials/sctool_info.yaml
+++ b/docs/source/sctool/partials/sctool_info.yaml
@@ -5,6 +5,10 @@ description: |
   If there is one task of the given type the '<id|name>' argument is not needed.
 usage: sctool info --cluster <id|name> [flags] <type>[/<id|name>]
 options:
+- name: cause
+  default_value: "false"
+  usage: |
+    Prints the cause of a failed task.
 - name: cluster
   shorthand: c
   usage: |

--- a/pkg/command/info/cmd.go
+++ b/pkg/command/info/cmd.go
@@ -21,6 +21,7 @@ type command struct {
 
 	cluster string
 	limit   int
+	cause   bool
 }
 
 func NewCommand(client *managerclient.Client) *cobra.Command {
@@ -46,6 +47,7 @@ func (cmd *command) init() {
 	w := flag.Wrap(cmd.Flags())
 	w.Cluster(&cmd.cluster)
 	w.Unwrap().IntVar(&cmd.limit, "limit", 10, "")
+	w.Unwrap().BoolVar(&cmd.cause, "cause", false, "")
 }
 
 func (cmd *command) run(args []string) error {
@@ -78,5 +80,5 @@ func (cmd *command) run(args []string) error {
 		return nil
 	}
 
-	return runs.Render(w)
+	return runs.Render(w, cmd.cause)
 }

--- a/pkg/command/info/res.yaml
+++ b/pkg/command/info/res.yaml
@@ -8,3 +8,6 @@ long: |
 
 limit: |
   Limits the number of returned results.
+
+cause: |
+  Prints the cause of a failed task.

--- a/pkg/command/legacy/task/taskhistory/cmd.go
+++ b/pkg/command/legacy/task/taskhistory/cmd.go
@@ -58,5 +58,5 @@ func (cmd *command) run(args []string) error {
 		return err
 	}
 
-	return runs.Render(cmd.OutOrStdout())
+	return runs.Render(cmd.OutOrStdout(), true)
 }

--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -475,11 +475,12 @@ type TaskRun = models.TaskRun
 type TaskRunSlice []*TaskRun
 
 // Render renders TaskRunSlice in a tabular format.
-func (tr TaskRunSlice) Render(w io.Writer) error {
+func (tr TaskRunSlice) Render(w io.Writer, printCause bool) error {
 	t := table.New("ID", "Start time", "Duration", "Status")
 	for _, r := range tr {
 		s := r.Status
-		if r.Cause != "" {
+		if printCause && r.Cause != "" {
+			t.LimitColumnLength(3)
 			s += " " + r.Cause
 		}
 		t.AddRow(r.ID, FormatTime(r.StartTime), FormatDuration(r.StartTime, r.EndTime), s)


### PR DESCRIPTION
Default to not printing cause of errors, and if we do print them add a
limit to the field.

Legacy command always prints cause.

Fixes #3140