### PR TITLE
service/backup: improve error for nonexistent bucket

### DIFF
--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -252,6 +252,9 @@ func (s *Service) GetTarget(ctx context.Context, clusterID uuid.UUID, properties
 
 	// Validate locations access
 	if err := s.checkLocationsAvailableFromNodes(ctx, client, t.liveNodes, t.Location); err != nil {
+		if strings.Contains(err.Error(), "NoSuchBucket") {
+			return t, errors.New("specified bucket does not exist")
+		}
 		return t, errors.Wrap(err, "location is not accessible")
 	}
 

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -431,7 +431,7 @@ func TestGetTargetErrorIntegration(t *testing.T) {
 		{
 			Name:  "inaccessible location",
 			JSON:  `{"location": ["s3:foo", "dc1:s3:bar"]}`,
-			Error: "location is not accessible",
+			Error: "specified bucket does not exist",
 		},
 		{
 			Name:  "invalid rate limit dc",


### PR DESCRIPTION
error is now much more useful and succinct:
```
$ ./sctool backup -L "s3:fake-bucket"
Error: create backup target: specified bucket does not exist
Trace ID: 8KpElsLlRcaRjnW7y3ysJw (grep in scylla-manager logs)
```

fixes #3139 