### PR TITLE
service/{backup,service}: provide ETA in progress

### DIFF
--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -658,6 +658,9 @@ Duration:	{{ FormatDuration .StartTime .EndTime }}
 {{- end }}
 {{- with .Progress }}
 Progress:	{{ FormatRepairProgress .TokenRanges .Success .Error }}
+{{- if (isZero $.Run.EndTime) }}
+Time Remaining: {{ FormatSecondsAsETA .TimeRemaining }}
+{{- end -}}
 {{- if isRunning }}
 Intensity:	{{ .Intensity }}
 Parallel:	{{ .Parallel }}
@@ -679,6 +682,7 @@ func (rp RepairProgress) addHeader(w io.Writer) error {
 		"isRunning":            rp.isRunning,
 		"FormatTime":           FormatTime,
 		"FormatDuration":       FormatDuration,
+		"FormatSecondsAsETA":   FormatSecondsAsETA,
 		"FormatError":          FormatError,
 		"FormatRepairProgress": FormatRepairProgress,
 	}).Parse(repairProgressTemplate))
@@ -896,7 +900,11 @@ End time:	{{ FormatTime .EndTime }}
 {{- end }}
 Duration:	{{ FormatDuration .StartTime .EndTime }}
 {{ end -}}
-{{ with .Progress }}Progress:	{{ if ne .Size 0 }}{{ FormatUploadProgress .Size .Uploaded .Skipped .Failed }}{{else}}-{{ end }}
+{{ with .Progress -}}
+Progress:	{{ if ne .Size 0 }}{{ FormatUploadProgress .Size .Uploaded .Skipped .Failed }}{{else}}-{{ end }}
+{{- if (isZero $.Run.EndTime) }}
+Time Remaining: {{ FormatSecondsAsETA .TimeRemaining }}
+{{- end -}}
 {{- if ne .SnapshotTag "" }}
 Snapshot Tag:	{{ .SnapshotTag }}
 {{- end }}
@@ -919,6 +927,7 @@ func (bp BackupProgress) addHeader(w io.Writer) error {
 		"isZero":               isZero,
 		"FormatTime":           FormatTime,
 		"FormatDuration":       FormatDuration,
+		"FormatSecondsAsETA":   FormatSecondsAsETA,
 		"FormatError":          FormatError,
 		"FormatUploadProgress": FormatUploadProgress,
 		"status":               bp.status,

--- a/pkg/managerclient/utils.go
+++ b/pkg/managerclient/utils.go
@@ -129,6 +129,22 @@ func FormatTime(t strfmt.DateTime) string {
 	return time.Time(t).Local().Format(rfc822WithSec)
 }
 
+// FormatSecondsAsETA formats the supplied number of seconds in `3h2m1s` format.
+// Returns 1s if t == 0 because it is used for calculating ETAs.
+// Returns "Unknown" if < 0 because we don't have historical data.
+func FormatSecondsAsETA(t int64) string {
+	if t == 0 {
+		return "1s"
+	}
+
+	if t < 0 {
+		return "Unknown"
+	}
+
+	d := time.Duration(t * time.Second.Nanoseconds())
+	return d.String()
+}
+
 // FormatTimePointer see FormatTime.
 func FormatTimePointer(t *strfmt.DateTime) string {
 	var tf strfmt.DateTime

--- a/pkg/service/backup/model.go
+++ b/pkg/service/backup/model.go
@@ -140,12 +140,13 @@ func (p *RunProgress) IsUploaded() bool {
 }
 
 type progress struct {
-	Size        int64      `json:"size"`
-	Uploaded    int64      `json:"uploaded"`
-	Skipped     int64      `json:"skipped"`
-	Failed      int64      `json:"failed"`
-	StartedAt   *time.Time `json:"started_at"`
-	CompletedAt *time.Time `json:"completed_at"`
+	Size          int64      `json:"size"`
+	Uploaded      int64      `json:"uploaded"`
+	Skipped       int64      `json:"skipped"`
+	Failed        int64      `json:"failed"`
+	StartedAt     *time.Time `json:"started_at"`
+	CompletedAt   *time.Time `json:"completed_at"`
+	TimeRemaining int64      `json:"time_remaining"`
 }
 
 // Progress groups uploading progress for all backed up hosts.

--- a/pkg/service/repair/model.go
+++ b/pkg/service/repair/model.go
@@ -143,12 +143,13 @@ func (rs *RunState) UpdatePositions(job jobResult) {
 // progress holds generic progress data, it's a base type for other progress
 // structs.
 type progress struct {
-	TokenRanges int64      `json:"token_ranges"`
-	Success     int64      `json:"success"`
-	Error       int64      `json:"error"`
-	StartedAt   *time.Time `json:"started_at"`
-	CompletedAt *time.Time `json:"completed_at"`
-	Duration    int64      `json:"duration_ms"`
+	TokenRanges   int64      `json:"token_ranges"`
+	Success       int64      `json:"success"`
+	Error         int64      `json:"error"`
+	StartedAt     *time.Time `json:"started_at"`
+	CompletedAt   *time.Time `json:"completed_at"`
+	Duration      int64      `json:"duration_ms"`
+	TimeRemaining int64      `json:"time_remaining"`
 }
 
 // ProgressPercentage returns repair progress percentage based on token ranges.

--- a/swagger/gen/scylla-manager/models/backup_progress.go
+++ b/swagger/gen/scylla-manager/models/backup_progress.go
@@ -48,6 +48,9 @@ type BackupProgress struct {
 	// Format: date-time
 	StartedAt *strfmt.DateTime `json:"started_at,omitempty"`
 
+	// time remaining
+	TimeRemaining int64 `json:"time_remaining,omitempty"`
+
 	// uploaded
 	Uploaded int64 `json:"uploaded,omitempty"`
 }

--- a/swagger/gen/scylla-manager/models/repair_progress.go
+++ b/swagger/gen/scylla-manager/models/repair_progress.go
@@ -54,6 +54,9 @@ type RepairProgress struct {
 	// tables
 	Tables []*TableRepairProgress `json:"tables"`
 
+	// time remaining
+	TimeRemaining int64 `json:"time_remaining,omitempty"`
+
 	// token ranges
 	TokenRanges int64 `json:"token_ranges,omitempty"`
 }

--- a/swagger/scylla-manager.json
+++ b/swagger/scylla-manager.json
@@ -166,6 +166,9 @@
           "format": "date-time",
           "x-nullable": true
         },
+        "time_remaining": {
+          "type": "integer"
+        },
         "duration_ms": {
           "type": "integer"
         },
@@ -737,6 +740,9 @@
           "type": "integer"
         },
         "failed": {
+          "type": "integer"
+        },
+        "time_remaining": {
           "type": "integer"
         },
         "started_at": {


### PR DESCRIPTION
Using the historical data for a given task, calculate an ETA when a user
requests task progress.

For repairs this is based on # of token ranges remaining, and how
quickly they were historically repaired.

For backups this is based on bytes remaining to upload and how quickly
they historically uploaded.

Fixes #3137