### PR TITLE
ci: align release tag pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - 'scylla-manager-**'
+      - 'v**'
 
 jobs:
   release:


### PR DESCRIPTION
Following #3097 the tag pattern should align to v.x.y.z

