### PR TITLE
service/backup: integration test, fix TestPurgeTemporaryManifestsIntegration

### DIFF
--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -1601,6 +1601,9 @@ func TestPurgeTemporaryManifestsIntegration(t *testing.T) {
 	})
 
 	Print("And: run backup again")
+	// wait at least 1 sec to avoid having same snapshot ID as in previous backup run
+	time.Sleep(time.Second)
+
 	if err := h.service.Backup(ctx, h.clusterID, h.taskID, h.runID, target); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Simple fix for randomly failing TestPurgeTemporaryManifestsIntegration.
SnapshotID is generated out of timestamp with to one second precision.

It happened sometimes that two backups done in TestPurgeTemporaryManifestsIntegration had same snapshotID and test was failing due to that.

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
