### PR TITLE
Handle signals during migrate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,7 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - gci
     - contextcheck
     - cyclop
     - durationcheck

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ endif
 # Default package
 PKG := ./pkg/...
 
+SHELL := /bin/bash
 GIT_ROOT = $(shell git rev-parse --show-toplevel)
 GOBIN ?= $(shell pwd)/bin
 GOFILES = go list -f '{{range .GoFiles}}{{ $$.Dir }}/{{ . }} {{end}}{{range .TestGoFiles}}{{ $$.Dir }}/{{ . }} {{end}}' $(PKG)

--- a/pkg/cmd/scylla-manager/main.go
+++ b/pkg/cmd/scylla-manager/main.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"os"
+	"syscall"
 	"time"
 )
 
@@ -24,8 +24,8 @@ func main() {
 		// [1] https://github.com/systemd/systemd/issues/2913
 		time.Sleep(1100 * time.Millisecond)
 
-		os.Exit(1)
+		syscall.Exit(1)
 	}
 
-	os.Exit(0)
+	syscall.Exit(0)
 }


### PR DESCRIPTION
Fixes #3204 
Signal handling is moved before the migration starts.

Additional commit - change os.Exit to syscall.Exit (no need to log panic on closing server, it's actually expected)

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
