### PR TITLE
doc: remove outdated refrences to the Manager section in the ScyllaDB docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,6 @@
-==============
-Scylla Manager
-==============
+=================
+ScyllaDB Manager
+=================
 
 .. toctree::
    :hidden:
@@ -24,40 +24,40 @@ Scylla Manager
 
 .. image:: images/header.png
 
-Slack channel
+Slack Channel
 =============
 
-If you have any troubles or questions regarding Scylla Manager contact us on `Scylla Manager Slack channel <https://scylladb-users.slack.com/archives/C01ERVBPWLU>`_.
+If you have any troubles or questions regarding ScyllaDB Manager contact us on `ScyllaDB Manager Slack channel <https://scylladb-users.slack.com/archives/C01ERVBPWLU>`_.
 
 Introduction
 ============
 
-Scylla Manager automates database operations.
-With Scylla Manager you can schedule tasks such as backups and repairs, check cluster status, and more.
-Scylla Manager can manage multiple Scylla clusters and run cluster-wide tasks in a controlled and predictable way.
-It is available for Scylla Enterprise customers and Scylla Open Source users.
-With Scylla Open Source, Scylla Manager is limited to 5 nodes.
-See the Scylla Manager Proprietary Software `License Agreement <https://www.scylladb.com/scylla-manager-software-license-agreement/>`_ for details.
+ScyllaDB Manager automates database operations.
+With ScyllaDB Manager you can schedule tasks such as backups and repairs, check cluster status, and more.
+ScyllaDB Manager can manage multiple ScyllaDB clusters and run cluster-wide tasks in a controlled and predictable way.
+It is available for ScyllaDB Enterprise customers and ScyllaDB Open Source users.
+With ScyllaDB Open Source, ScyllaDB Manager is limited to 5 nodes.
+See the ScyllaDB Manager Proprietary Software `License Agreement <https://www.scylladb.com/scylla-manager-software-license-agreement/>`_ for details.
 
 
-Scylla Manager consists of three components:
+ScyllaDB Manager consists of three components:
 
 * Server - a daemon that exposes a REST API
 * sctool - a command-line interface (CLI) for interacting with the Server
-* Agent - a daemon, installed on each Scylla node, the Server communicates with the Agent over HTTPS
+* Agent - a daemon, installed on each ScyllaDB node, the Server communicates with the Agent over HTTPS
 
-The Server persists its data to a Scylla cluster which can run locally, or can run on an external cluster.
-Optionally, but recommended, you can add Scylla Monitoring Stack to enable reporting of Scylla Manager metrics and alerts.
-Scylla Manager comes with its own Scylla Monitoring Dashboard.
-The diagram below presents a view on Scylla Manager managing multiple Scylla Clusters.
-Scylla Manager Server has two connections with each Scylla node:
+The Server persists its data to a ScyllaDB cluster which can run locally, or can run on an external cluster.
+Optionally, but recommended, you can add ScyllaDB Monitoring Stack to enable reporting of ScyllaDB Manager metrics and alerts.
+ScyllaDB Manager comes with its own ScyllaDB Monitoring Dashboard.
+The diagram below presents a view on ScyllaDB Manager managing multiple ScyllaDB Clusters.
+ScyllaDB Manager Server has two connections with each ScyllaDB node:
 
-* REST API connection - used to access Scylla API and Scylla Manager Agent
-* (Optional) CQL connection - used for the Scylla :ref:`Health Check <scylla-health-check>`
+* REST API connection - used to access ScyllaDB API and ScyllaDB Manager Agent
+* (Optional) CQL connection - used for the ScyllaDB :ref:`Health Check <scylla-health-check>`
 
 .. image:: images/architecture.jpg
 
 Installation
 ============
 
-To proceed with installation go to :doc:`Install Scylla Manager <install-scylla-manager>`.
+To proceed with installation go to :doc:`Install ScyllaDB Manager <install-scylla-manager>`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,6 @@ Scylla Manager
    swagger/index
    scylla-monitoring
    troubleshooting
-   older-versions
    Slack <https://scylladb-users.slack.com/archives/C01ERVBPWLU>
 
 .. image:: images/header.png

--- a/docs/source/install-scylla-manager-agent.rst
+++ b/docs/source/install-scylla-manager-agent.rst
@@ -1,8 +1,8 @@
 .. _install-agent:
 
-============================
-Install Scylla Manager Agent
-============================
+==============================
+Install ScyllaDB Manager Agent
+==============================
 
 Scylla Manager Agent is a daemon, that needs to be **installed and started on each Scylla node**.
 Scylla Manager Server communicates with nodes in the managed Scylla clusters via the Agents.
@@ -92,8 +92,8 @@ Unauthenticated requests are rejected.
 
    .. note:: Use the same token on all the nodes in a cluster
 
-Start Scylla Manager Agent service
-==================================
+Start ScyllaDB Manager Agent service
+=====================================
 
 **Procedure**
 

--- a/docs/source/install-scylla-manager.rst
+++ b/docs/source/install-scylla-manager.rst
@@ -1,8 +1,8 @@
 .. _install-manager:
 
-======================
-Install Scylla Manager
-======================
+=========================
+Install ScyllaDB Manager
+=========================
 
 .. contents::
    :depth: 2
@@ -146,8 +146,8 @@ Alternatively, you can just open a new terminal.
 
    source /etc/bash_completion.d/sctool.bash
 
-Start Scylla Manager service
-============================
+Start ScyllaDB Manager service
+===============================
 
 Scylla Manager integrates with ``systemd`` and can be started and stopped using ``systemctl`` command. 
 

--- a/docs/source/older-versions.rst
+++ b/docs/source/older-versions.rst
@@ -1,6 +1,0 @@
-==============
-Older Versions
-==============
-
-- `Scylla Manager 2.1 <https://docs.scylladb.com/operating-scylla/manager/2.1>`_
-- `Scylla Manager 2.0 <https://docs.scylladb.com/operating-scylla/manager/2.0>`_

--- a/docs/source/scylla-monitoring.rst
+++ b/docs/source/scylla-monitoring.rst
@@ -1,19 +1,19 @@
-=================
-Scylla Monitoring
-=================
+====================
+ScyllaDB Monitoring
+====================
 
-Scylla Manager as Service Discovery for Scylla Monitoring
-=========================================================
+ScyllaDB Manager as Service Discovery for ScyllaDB Monitoring
+===============================================================
 
 Scylla Manager provides Consul's Service Catalog API that is used by Prometheus to dynamically get scrape targets.
-Scylla Monitoring uses this mechanism to discover all clusters and nodes under Scylla Manager.
-More information can be found in `Scylla Monitoring docs <https://scylladb.github.io/scylla-monitoring>`_.
+ScyllaDB Monitoring uses this mechanism to discover all clusters and nodes under ScyllaDB Manager.
+More information can be found in `ScyllaDB Monitoring docs <https://scylladb.github.io/scylla-monitoring>`_.
 
-Scylla Manager Dashboard
-========================
+ScyllaDB Manager Dashboard
+============================
 
-Scylla Manager has its own dashboard in Scylla Monitoring.
-It can be used to track progress of Scylla Manager tasks.
+ScyllaDB Manager has its own dashboard in ScyllaDB Monitoring.
+It can be used to track progress of ScyllaDB Manager tasks.
 
 ..
    TODO Add screenshot

--- a/docs/source/scylla-monitoring.rst
+++ b/docs/source/scylla-monitoring.rst
@@ -7,7 +7,7 @@ ScyllaDB Manager as Service Discovery for ScyllaDB Monitoring
 
 Scylla Manager provides Consul's Service Catalog API that is used by Prometheus to dynamically get scrape targets.
 ScyllaDB Monitoring uses this mechanism to discover all clusters and nodes under ScyllaDB Manager.
-More information can be found in `ScyllaDB Monitoring docs <https://scylladb.github.io/scylla-monitoring>`_.
+More information can be found in `ScyllaDB Monitoring docs <https://monitoring.docs.scylladb.com>`_.
 
 ScyllaDB Manager Dashboard
 ============================

--- a/docs/source/upgrade/index.rst
+++ b/docs/source/upgrade/index.rst
@@ -1,6 +1,6 @@
-=======================
-Scylla Manager Upgrade 
-=======================
+==========================
+ScyllaDB Manager Upgrade 
+==========================
 
 This document describes the upgrade process beween two versions of Scylla Manager.
 
@@ -50,8 +50,8 @@ Or on versions 3.0 and higher using:
 
 None of the listed tasks should have status in RUNNING.
 
-Stop the Scylla Manager Server 
--------------------------------
+Stop the ScyllaDB Manager Server 
+----------------------------------
 
 **On the Manager Server** instruct Systemd to stop the server process:
 
@@ -67,7 +67,7 @@ Ensure that it is stopped with:
 
 It should have a status of *“Active: inactive (dead)”*.
 
-Stop the Scylla Manager Agent on all nodes
+Stop the ScyllaDB Manager Agent on all nodes
 ------------------------------------------------
 
 **On each scylla node** in the cluster run:
@@ -84,8 +84,8 @@ Ensure that it is stopped with:
 
 It should have a status of *“Active: inactive (dead)”*.
 
-Upgrade the Scylla Manager Server and Client 
----------------------------------------------
+Upgrade the ScyllaDB Manager Server and Client 
+------------------------------------------------
 
 **Before you Begin**
 
@@ -129,7 +129,7 @@ Debian, Ubuntu:
 
 .. note:: When using apt-get, if a previous version of the Scylla Manager package had a modified configuration file, you will be asked what to do with this file during the installation process. In order to keep both files for reconciliation (covered later in the procedure), select the "keep your currently-installed version" option when prompted. 
 
-Upgrade the Scylla Manager Agent on all nodes
+Upgrade the ScyllaDB Manager Agent on all nodes
 ------------------------------------------------------
 
 **On each scylla node** instruct package manager to update the agent:
@@ -224,7 +224,7 @@ For Ubuntu:
     mv scylla-manager-agent.yaml scylla-manager-agent.yaml.old
     mv scylla-manager-agent.yaml.dpkg-dist scylla-manager-agent.yaml
 
-Start the Scylla Manager Agent on all nodes
+Start the ScyllaDB Manager Agent on all nodes
 -------------------------------------------------
 
 **On each scylla node** instruct Systemd to start the agent process:
@@ -241,8 +241,8 @@ Ensure that it is running with:
 
 It should have a status of *“Active: active (running)”*.
 
-Start the Scylla Manager Server 
---------------------------------
+Start the ScyllaDB Manager Server 
+-----------------------------------
 
 **On the Manager Server** instruct Systemd to start the server process:
 
@@ -298,8 +298,8 @@ Rollback procedure contains the same steps as upgrade but with downgrading the c
 Rollback steps
 ==============
 
-Stop all Scylla Manager tasks (or wait for them to finish)
-----------------------------------------------------------
+Stop all ScyllaDB Manager tasks (or wait for them to finish)
+--------------------------------------------------------------
 
 **On the Manager Server** check current status of the manager tasks:
 
@@ -309,8 +309,8 @@ Stop all Scylla Manager tasks (or wait for them to finish)
 
 None of the listed tasks should have status in RUNNING.
 
-Stop the Scylla Manager Server 
--------------------------------
+Stop the ScyllaDB Manager Server 
+-----------------------------------
 
 **On the Manager Server** instruct Systemd to stop the server process:
 
@@ -326,7 +326,7 @@ Ensure that it is stopped with:
 
 It should have a status of *“Active: inactive (dead)”*.
 
-Stop the Scylla Manager Agent on all nodes
+Stop the ScyllaDB Manager Agent on all nodes
 ------------------------------------------------
 
 **On each scylla node** in the cluster run:
@@ -343,8 +343,8 @@ Ensure that it is stopped with:
 
 It should have a status of *“Active: inactive (dead)”*.
 
-Downgrade the Scylla Manager Server and Client 
------------------------------------------------
+Downgrade the ScyllaDB Manager Server and Client 
+----------------------------------------------------
 
 **On the Manager Server** instruct package manager to downgrade server and the client:
 
@@ -360,7 +360,7 @@ Debian, Ubuntu:
 
     sudo apt-get install scylla-manager-server=2.x scylla-manager-client=2.x -y
 
-Downgrade the Scylla Manager Agent on all nodes
+Downgrade the ScyllaDB Manager Agent on all nodes
 --------------------------------------------------------
 
 **On each scylla node** instruct package manager to downgrade the agent:
@@ -403,7 +403,7 @@ The procedure is the same for the Scylla Manager Agent (on all nodes):
     mv scylla-manager-agent.yaml scylla-manager-agent.yaml.new
     mv scylla-manager-agent.yaml.old scylla-manager-agent.yaml
 
-Start the Scylla Manager Agent on all nodes
+Start the ScyllaDB Manager Agent on all nodes
 -------------------------------------------------
 
 On all nodes instruct Systemd to start the agent process:
@@ -420,7 +420,7 @@ Ensure that it is running with:
 
 It should have a status of *“Active: active (running)”*.
 
-Start the Scylla Manager Server
+Start the ScyllaDB Manager Server
 -------------------------------------
 
 **On the Manager Server** instruct Systemd to start the server process:


### PR DESCRIPTION
The Manger section in the ScyllaDB docs has been removed; see https://github.com/scylladb/scylladb/pull/11162. 

This PR removes or replaces the links to that section.

In addition, I've replaced "Scylla" with "ScyllaDB" on key pages to be in sync with other resources.