### PR TITLE
testing: makefile, docker-compose, changed UID to CURRENT_UID

### DIFF
--- a/testing/Makefile
+++ b/testing/Makefile
@@ -35,7 +35,7 @@ else
 endif
 	@echo "==> Starting containers"
 	mkdir -p $(MINIO_DATA_DIR)
-	@. ./.env && UID=$(CURRENT_UID) GID=$(CURRENT_GID) $(COMPOSE) up -d
+	@. ./.env && CURRENT_UID=$(CURRENT_UID) CURRENT_GID=$(CURRENT_GID) $(COMPOSE) up -d
 	$(COMPOSE) exec -T --privileged dc1_node_1 sudo bash -c 'echo "fs.aio-max-nr = 1048579" > /etc/sysctl.d/50-scylla.conf'
 	$(COMPOSE) exec -T --privileged dc1_node_1 sudo sysctl -p /etc/sysctl.d/50-scylla.conf
 	@echo "==> Waiting for cluster"

--- a/testing/docker-compose.yaml
+++ b/testing/docker-compose.yaml
@@ -140,7 +140,7 @@ services:
   minio:
     image: minio/minio:${MINIO_VERSION}
     privileged: true
-    user: ${UID}:${GID}
+    user: ${CURRENT_UID}:${CURRENT_GID}
     command: server /data --console-address ":9001"
     environment:
       MINIO_REGION: ${MINIO_REGION}


### PR DESCRIPTION
UID is a readonly system variable, so it can't be assigned and passed to docker-compose file

