### PR TITLE
service/backup: forEachManifest no longer loads Index into memory

### DIFF
--- a/pkg/service/backup/list.go
+++ b/pkg/service/backup/list.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
-	"github.com/scylladb/scylla-manager/v3/pkg/util/inexlist/ksfilter"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 )
 
@@ -164,19 +163,6 @@ func filterManifests(manifests []*ManifestInfo, filter ListFilter) []*ManifestIn
 		}
 	}
 	return out
-}
-
-func filterManifestIndex(c *ManifestContentWithIndex, ksf *ksfilter.Filter) {
-	if len(ksf.Filters()) == 0 {
-		return
-	}
-	var index []FilesMeta
-	for _, u := range c.Index {
-		if ksf.Check(u.Keyspace, u.Table) {
-			index = append(index, u)
-		}
-	}
-	c.Index = index
 }
 
 func groupManifestsByNode(manifests []*ManifestInfo) map[string][]*ManifestInfo {


### PR DESCRIPTION
Iterating over Index should be done using ForEachIndexIter or ForEachIndexIterFiles.

Commit 4dc88bebb68c549a010ff3e66fa7891fa0c39346 introduced a new way of processing Index file that consumes less memory. Normal iteration over Index has been replaced with either ForEachIndexIter or ForEachIndexFiles (especially in all uses of ForEachManifest method).

Unfortunately, ForEachManifest hasn't been changed so it still loads the whole index to memory, only for ForEachIndexIter to load it again (I guess someone forgot to delete this part).