### PR TITLE
util: Add support for backoff dependency version 4.1.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.35.17
-	github.com/cenkalti/backoff/v4 v4.0.0
+	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/go-chi/chi/v5 v5.0.0
 	github.com/go-chi/render v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/calebcase/tmpfile v1.0.2 h1:1AGuhKiUu4J6wxz6lxuF6ck3f8G2kaV6KSEny0RGC
 github.com/calebcase/tmpfile v1.0.2/go.mod h1:iErLeG/iqJr8LaQ/gYRv4GXdqssi3jg4iSzvrA06/lw=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
-github.com/cenkalti/backoff/v4 v4.0.0 h1:6VeaLF9aI+MAUQ95106HwWzYZgJJpZ4stumjj6RFYAU=
-github.com/cenkalti/backoff/v4 v4.0.0/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
+github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
+github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -25,7 +25,7 @@ func WithNotify(ctx context.Context, op Operation, b Backoff, n Notify) error {
 
 // Permanent wraps the given err in a *backoff.PermanentError.
 // This error interrupts further retries and causes retrying mechanism.
-func Permanent(err error) *backoff.PermanentError {
+func Permanent(err error) error {
 	return backoff.Permanent(err)
 }
 

--- a/vendor/github.com/cenkalti/backoff/v4/.gitignore
+++ b/vendor/github.com/cenkalti/backoff/v4/.gitignore
@@ -20,3 +20,6 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# IDEs
+.idea/

--- a/vendor/github.com/cenkalti/backoff/v4/.travis.yml
+++ b/vendor/github.com/cenkalti/backoff/v4/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.12
+  - 1.13
   - 1.x
   - tip
 before_install:

--- a/vendor/github.com/cenkalti/backoff/v4/README.md
+++ b/vendor/github.com/cenkalti/backoff/v4/README.md
@@ -11,8 +11,7 @@ The retries exponentially increase and stop increasing when a certain threshold 
 
 Import path is `github.com/cenkalti/backoff/v4`. Please note the version part at the end.
 
-godoc.org does not support modules yet,
-so you can use https://godoc.org/gopkg.in/cenkalti/backoff.v4 to view the documentation.
+Use https://pkg.go.dev/github.com/cenkalti/backoff/v4 to view the documentation.
 
 ## Contributing
 
@@ -20,7 +19,7 @@ so you can use https://godoc.org/gopkg.in/cenkalti/backoff.v4 to view the docume
 * Please don't send a PR without opening an issue and discussing it first.
 * If proposed change is not a common use case, I will probably not accept it.
 
-[godoc]: https://godoc.org/github.com/cenkalti/backoff
+[godoc]: https://pkg.go.dev/github.com/cenkalti/backoff/v4
 [godoc image]: https://godoc.org/github.com/cenkalti/backoff?status.png
 [travis]: https://travis-ci.org/cenkalti/backoff
 [travis image]: https://travis-ci.org/cenkalti/backoff.png?branch=master
@@ -30,4 +29,4 @@ so you can use https://godoc.org/gopkg.in/cenkalti/backoff.v4 to view the docume
 [google-http-java-client]: https://github.com/google/google-http-java-client/blob/da1aa993e90285ec18579f1553339b00e19b3ab5/google-http-client/src/main/java/com/google/api/client/util/ExponentialBackOff.java
 [exponential backoff wiki]: http://en.wikipedia.org/wiki/Exponential_backoff
 
-[advanced example]: https://godoc.org/github.com/cenkalti/backoff#example_
+[advanced example]: https://pkg.go.dev/github.com/cenkalti/backoff/v4?tab=doc#pkg-examples

--- a/vendor/github.com/cenkalti/backoff/v4/context.go
+++ b/vendor/github.com/cenkalti/backoff/v4/context.go
@@ -57,10 +57,6 @@ func (b *backOffContext) NextBackOff() time.Duration {
 	case <-b.ctx.Done():
 		return Stop
 	default:
+		return b.BackOff.NextBackOff()
 	}
-	next := b.BackOff.NextBackOff()
-	if deadline, ok := b.ctx.Deadline(); ok && deadline.Sub(time.Now()) < next { // nolint: gosimple
-		return Stop
-	}
-	return next
 }

--- a/vendor/github.com/cenkalti/backoff/v4/retry.go
+++ b/vendor/github.com/cenkalti/backoff/v4/retry.go
@@ -1,6 +1,9 @@
 package backoff
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 // An Operation is executing by Retry() or RetryNotify().
 // The operation will be retried using a backoff policy if it returns an error.
@@ -53,11 +56,16 @@ func RetryNotifyWithTimer(operation Operation, b BackOff, notify Notify, t Timer
 			return nil
 		}
 
-		if permanent, ok := err.(*PermanentError); ok {
+		var permanent *PermanentError
+		if errors.As(err, &permanent) {
 			return permanent.Err
 		}
 
 		if next = b.NextBackOff(); next == Stop {
+			if cerr := ctx.Err(); cerr != nil {
+				return cerr
+			}
+
 			return err
 		}
 
@@ -88,8 +96,16 @@ func (e *PermanentError) Unwrap() error {
 	return e.Err
 }
 
+func (e *PermanentError) Is(target error) bool {
+	_, ok := target.(*PermanentError)
+	return ok
+}
+
 // Permanent wraps the given err in a *PermanentError.
-func Permanent(err error) *PermanentError {
+func Permanent(err error) error {
+	if err == nil {
+		return nil
+	}
 	return &PermanentError{
 		Err: err,
 	}

--- a/vendor/github.com/cenkalti/backoff/v4/ticker.go
+++ b/vendor/github.com/cenkalti/backoff/v4/ticker.go
@@ -33,6 +33,9 @@ func NewTicker(b BackOff) *Ticker {
 // NewTickerWithTimer returns a new Ticker with a custom timer.
 // A default timer that uses system timer is used when nil is passed.
 func NewTickerWithTimer(b BackOff, timer Timer) *Ticker {
+	if timer == nil {
+		timer = &defaultTimer{}
+	}
 	c := make(chan time.Time)
 	t := &Ticker{
 		C:     c,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,8 +89,8 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beorn7/perks v1.0.1
 ## explicit; go 1.11
 github.com/beorn7/perks/quantile
-# github.com/cenkalti/backoff/v4 v4.0.0
-## explicit; go 1.12
+# github.com/cenkalti/backoff/v4 v4.1.3
+## explicit; go 1.13
 github.com/cenkalti/backoff/v4
 # github.com/cespare/xxhash/v2 v2.1.1
 ## explicit; go 1.11


### PR DESCRIPTION
Update the "backoff" dependency.

Version 4.1.3 brings fixes for context cancelling.
https://github.com/cenkalti/backoff/commit/1357787b952893cff77d8349aaf320c3fd327c2a

However, this "patch" version change does bring an API breakage as .Permanent is now returning a go std error instead of a Permanent.Error from the backoff module.