### PR TITLE
promproxy: use scylla listen address when prometheus address missing

### DIFF
--- a/pkg/cmd/agent/router.go
+++ b/pkg/cmd/agent/router.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/scylladb/go-log"
+
 	"github.com/scylladb/scylla-manager/v3/pkg/auth"
 	"github.com/scylladb/scylla-manager/v3/pkg/config/agent"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/httphandler"
@@ -45,8 +46,12 @@ func newRouter(c agent.Config, rclone http.Handler, logger log.Logger) http.Hand
 }
 
 func promProxy(c agent.Config) http.Handler {
+	addr := c.Scylla.PrometheusAddress
+	if addr == "" {
+		addr = c.Scylla.ListenAddress
+	}
 	return &httputil.ReverseProxy{
-		Director: director(net.JoinHostPort(c.Scylla.PrometheusAddress, c.Scylla.PrometheusPort)),
+		Director: director(net.JoinHostPort(addr, c.Scylla.PrometheusPort)),
 	}
 }
 


### PR DESCRIPTION
Fixes #3235 

More info https://github.com/scylladb/scylladb/issues/9701

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
