### PR TITLE
Do not run backup or repair when load is high

### DIFF
--- a/pkg/config/server/server_test.go
+++ b/pkg/config/server/server_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/scylladb/go-log"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/scylladb/scylla-manager/v3/pkg/config"
 	"github.com/scylladb/scylla-manager/v3/pkg/config/server"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
@@ -16,8 +19,6 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/service/healthcheck"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/repair"
 	"github.com/scylladb/scylla-manager/v3/pkg/testutils"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 var configCmpOpts = cmp.Options{
@@ -78,6 +79,7 @@ func TestConfigModification(t *testing.T) {
 			DiskSpaceFreeMinPercent:   1,
 			LongPollingTimeoutSeconds: 5,
 			AgeMax:                    12 * time.Hour,
+			MaxLoadThreshold:          100,
 		},
 		Repair: repair.Config{
 			PollInterval:                    500 * time.Millisecond,
@@ -86,6 +88,7 @@ func TestConfigModification(t *testing.T) {
 			GracefulStopTimeout:             60 * time.Second,
 			ForceRepairType:                 repair.TypeAuto,
 			Murmur3PartitionerIgnoreMSBBits: 12,
+			MaxLoadThreshold:                100,
 		},
 		TimeoutConfig: scyllaclient.TimeoutConfig{
 			Timeout:     45 * time.Second,

--- a/pkg/managerclient/backup.go
+++ b/pkg/managerclient/backup.go
@@ -5,6 +5,7 @@ package managerclient
 // Stage enumeration.
 const (
 	BackupStageInit         string = "INIT"
+	BackupStageClusterCheck string = "CLUSTER_CHECK"
 	BackupStageAwaitSchema  string = "AWAIT_SCHEMA"
 	BackupStageSnapshot     string = "SNAPSHOT"
 	BackupStageIndex        string = "INDEX"
@@ -19,6 +20,7 @@ const (
 
 var backupStageName = map[string]string{
 	BackupStageInit:         "initialising",
+	BackupStageClusterCheck: "checking cluster's load",
 	BackupStageAwaitSchema:  "awaiting schema agreement",
 	BackupStageSnapshot:     "taking snapshot",
 	BackupStageIndex:        "indexing files",

--- a/pkg/service/backup/backupspec/stage.go
+++ b/pkg/service/backup/backupspec/stage.go
@@ -2,12 +2,17 @@
 
 package backupspec
 
+import (
+	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
+)
+
 // Stage specifies the backup worker stage.
 type Stage string
 
 // Stage enumeration.
 const (
 	StageInit         Stage = "INIT"
+	StageClusterCheck Stage = "CLUSTER_CHECK"
 	StageAwaitSchema  Stage = "AWAIT_SCHEMA"
 	StageSnapshot     Stage = "SNAPSHOT"
 	StageIndex        Stage = "INDEX"
@@ -37,6 +42,12 @@ var stageOrder = []Stage{
 // StageOrder listing of all stages in the order of execution.
 func StageOrder() []Stage {
 	return stageOrder
+}
+
+func DefaultStagesBackoffSetup() map[Stage]retry.Backoff {
+	return map[Stage]retry.Backoff{
+		StageClusterCheck: retry.DefaultExponentialBackoff(),
+	}
 }
 
 // Resumable run can be continued.

--- a/pkg/service/backup/backupspec/stage.go
+++ b/pkg/service/backup/backupspec/stage.go
@@ -27,6 +27,7 @@ const (
 
 var stageOrder = []Stage{
 	StageInit,
+	StageClusterCheck,
 	StageAwaitSchema,
 	StageSnapshot,
 	StageIndex,

--- a/pkg/service/backup/config.go
+++ b/pkg/service/backup/config.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/scylladb/scylla-manager/v3/pkg/service"
 	"go.uber.org/multierr"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/service"
 )
 
 // Config specifies the backup service configuration.
@@ -15,6 +16,7 @@ type Config struct {
 	DiskSpaceFreeMinPercent   int           `yaml:"disk_space_free_min_percent"`
 	LongPollingTimeoutSeconds int           `yaml:"long_polling_timeout_seconds"`
 	AgeMax                    time.Duration `yaml:"age_max"`
+	MaxLoadThreshold          float64       `yaml:"max_load_threshold"`
 }
 
 func DefaultConfig() Config {
@@ -22,6 +24,7 @@ func DefaultConfig() Config {
 		DiskSpaceFreeMinPercent:   10,
 		LongPollingTimeoutSeconds: 10,
 		AgeMax:                    12 * time.Hour,
+		MaxLoadThreshold:          100,
 	}
 }
 
@@ -36,6 +39,9 @@ func (c *Config) Validate() error {
 	}
 	if c.AgeMax < 0 {
 		err = multierr.Append(err, errors.New("invalid age_max, must be >= 0"))
+	}
+	if c.MaxLoadThreshold < 0 {
+		err = multierr.Append(err, errors.New("invalid max_load_threshold, must be >= 0"))
 	}
 
 	return err

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -779,6 +779,9 @@ func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID
 		return nil
 	}
 	stageFunc := map[Stage]func() error{
+		StageClusterCheck: func() error {
+			return w.CheckCluster(ctx, hi, s.backoffConfiguration[StageClusterCheck])
+		},
 		StageAwaitSchema: func() error {
 			clusterSession, err := s.clusterSession(ctx, clusterID)
 			if err != nil {

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -2299,3 +2299,59 @@ func TestBackupListIntegration(t *testing.T) {
 		})
 	}
 }
+
+func TestBackupClusterCheckStage(t *testing.T) {
+	const (
+		testBucket   = "backuptest-cluster_check"
+		testKeyspace = "backuptest_cluster_check"
+	)
+
+	location := s3Location(testBucket)
+	config := backup.DefaultConfig()
+
+	Print("Given: load threshold in config set to 0.0")
+	config.MaxLoadThreshold = 0
+
+	backoffSetup := DefaultStagesBackoffSetup()
+	backoffSetup[StageClusterCheck] = retry.NewExponentialBackoff(5*time.Second, 20*time.Second, 10*time.Second, 2, 0.2)
+
+	var (
+		session        = CreateSession(t)
+		clusterSession = CreateManagedClusterSessionAndDropAllKeyspaces(t)
+
+		h   = newBackupTestHelper(t, session, config, location, nil, backoffSetup)
+		ctx = context.Background()
+	)
+
+	WriteData(t, clusterSession, testKeyspace, 3)
+
+	target := backup.Target{
+		Units: []backup.Unit{
+			{
+				Keyspace: testKeyspace,
+			},
+		},
+		DC:       []string{"dc1"},
+		Location: []Location{location},
+	}
+	if err := h.service.InitTarget(ctx, h.clusterID, &target); err != nil {
+		t.Fatal(err)
+	}
+
+	Print("When: run backup")
+	err := h.service.Backup(ctx, h.clusterID, h.taskID, h.runID, target)
+
+	Print("Then: there should be an error")
+	if err == nil {
+		t.Errorf("service.Backup() expected to return error")
+	}
+
+	Print("Then: task is in CHECK_CLUSTER stage")
+	stage := ""
+	if err := session.Query("SELECT stage FROM test_scylla_manager.backup_run;", nil).Scan(&stage); err != nil {
+		t.Fatal("select stage:", err)
+	}
+	if stage != string(StageClusterCheck) {
+		t.Errorf("backup task expected to end in %s stage but is %s", StageClusterCheck, stage)
+	}
+}

--- a/pkg/service/backup/worker_clustercheck.go
+++ b/pkg/service/backup/worker_clustercheck.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2022 ScyllaDB
+
+package backup
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
+)
+
+// CheckCluster checks the current load on every element of hosts and returns the first one exceeding the configured
+// maximum threshold. See [Config.MaxLoadThreshold].
+//
+// If [Config.MaxLoadThreshold] was set to 100 the method is no-op.
+func (w *worker) CheckCluster(ctx context.Context, hosts []hostInfo, clusterCheckBackoff retry.Backoff) error {
+	if w.Config.MaxLoadThreshold == 100 {
+		return nil
+	}
+	notify := func(err error, wait time.Duration) {
+		w.Logger.Info(ctx, "Current load of one of the nodes is above the configured threshold...", "error", err, "wait", wait)
+	}
+
+	return retry.WithNotify(ctx, func() error {
+		for _, h := range hosts {
+			load, err := w.Client.CurrentLoad(ctx, h.IP)
+			if err != nil {
+				return retry.Permanent(errors.Wrap(err, "node's load metric"))
+			}
+			if load >= w.Config.MaxLoadThreshold {
+				return errors.Errorf("load %.2f on %s node is above configured threshold equal to %.2f",
+					load, h.IP, w.Config.MaxLoadThreshold)
+			}
+		}
+		return nil
+
+	}, clusterCheckBackoff, notify)
+}

--- a/pkg/service/errors.go
+++ b/pkg/service/errors.go
@@ -9,8 +9,9 @@ import (
 
 // Common errors.
 var (
-	ErrNotFound = gocql.ErrNotFound
-	ErrNilPtr   = errors.New("nil")
+	ErrNotFound                  = gocql.ErrNotFound
+	ErrNilPtr                    = errors.New("nil")
+	ErrNodeLoadMetricUnavailable = errors.New("node's load metric unavailable")
 )
 
 // errValidate is a validation error caused by inner error.

--- a/pkg/service/repair/config.go
+++ b/pkg/service/repair/config.go
@@ -6,8 +6,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/scylladb/scylla-manager/v3/pkg/service"
 	"go.uber.org/multierr"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/service"
 )
 
 // Type represents type of the repair algorithm.
@@ -30,6 +31,7 @@ type Config struct {
 	GracefulStopTimeout             time.Duration `yaml:"graceful_stop_timeout"`
 	ForceRepairType                 Type          `yaml:"force_repair_type"`
 	Murmur3PartitionerIgnoreMSBBits int           `yaml:"murmur3_partitioner_ignore_msb_bits"`
+	MaxLoadThreshold                float64       `yaml:"max_load_threshold"`
 }
 
 func DefaultConfig() Config {
@@ -39,6 +41,7 @@ func DefaultConfig() Config {
 		GracefulStopTimeout:             30 * time.Second,
 		ForceRepairType:                 TypeAuto,
 		Murmur3PartitionerIgnoreMSBBits: 12,
+		MaxLoadThreshold:                100,
 	}
 }
 
@@ -56,6 +59,9 @@ func (c *Config) Validate() error {
 	}
 	if c.GracefulStopTimeout <= 0 {
 		err = multierr.Append(err, errors.New("invalid graceful_stop_timeout, must be > 0"))
+	}
+	if c.MaxLoadThreshold < 0 {
+		err = multierr.Append(err, errors.New("invalid max_load_threshold, must be >= 0"))
 	}
 	switch c.ForceRepairType {
 	case TypeAuto, TypeRowLevel, TypeLegacy:

--- a/pkg/util/retry/backoff.go
+++ b/pkg/util/retry/backoff.go
@@ -53,3 +53,21 @@ func (b BackoffFunc) Reset() {}
 func (b BackoffFunc) Clone() Backoff {
 	return b
 }
+
+func DefaultExponentialBackoff() Backoff {
+	const (
+		waitMin        = 15 * time.Second // nolint: revive
+		waitMax        = 1 * time.Minute
+		maxElapsedTime = 15 * time.Minute
+		multiplier     = 2
+		jitter         = 0.2
+	)
+
+	return NewExponentialBackoff(
+		waitMin,
+		maxElapsedTime,
+		waitMax,
+		multiplier,
+		jitter,
+	)
+}


### PR DESCRIPTION
Closes #3181 

To be discussed:
- if prometheus is down, or if someone messed up with `scylla_reactor_utilization` metrics then neither repair nor backup will be performed.

UPDATE:
If prometheus is down, check is not going to be executed and backup/repair run as is.

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
