### PR TITLE
Missing flag descriptions

### DIFF
--- a/pkg/command/backup/res.yaml
+++ b/pkg/command/backup/res.yaml
@@ -7,6 +7,11 @@ long: |
 
 retention: |
   The `number of backups` to store, once this number is reached, the next backup which comes in from this destination will initiate a purge of the oldest backup.
+  Can be used simultaneously with '--retention-days' flag.
+
+retention-days: |
+  The `number of days` for which backup is stored, the next backup will initiate a purge of all expired backups.
+  Can be used simultaneously with '--retention' flag.
 
 rate-limit: |
   Limits the upload rate (as expressed in  megabytes (MiB) per second) at which snapshotfiles can be uploaded from a Scylla node to its backup destination.

--- a/pkg/command/flag/flag.go
+++ b/pkg/command/flag/flag.go
@@ -100,7 +100,7 @@ func (w Wrapper) Datacenter(p *[]string) {
 }
 
 func (w Wrapper) FailFast(p *bool) {
-	w.fs.BoolVar(p, "fail-fast", false, usage["fail-fats"])
+	w.fs.BoolVar(p, "fail-fast", false, usage["fail-fast"])
 }
 
 func (w Wrapper) Keyspace(p *[]string) {


### PR DESCRIPTION
Commit 65e2d34d rewrote sctool commands and misspelled 'fail-fast', which resulted in lack of description for this flag.
On the other hand, description for 'retention-days' has never been provided. 
