### PR TITLE
service/repair: fix on generator way of context.Done handling

### DIFF
--- a/pkg/service/repair/controller.go
+++ b/pkg/service/repair/controller.go
@@ -179,7 +179,7 @@ func (c *rowLevelRepairController) TryBlock(hosts []string) (bool, allowance) {
 
 func (c *rowLevelRepairController) shouldBlock(hosts []string, intensity float64) bool {
 	// ALLOW if nothing is running
-	if len(c.busyReplicas) == 0 {
+	if !c.Busy() {
 		return true
 	}
 


### PR DESCRIPTION
Fixes flaky `TestServiceRepairIntegration/kill_repairs_on_task_failure/when_task_is_cancelled` integration test.
Actually the test is correct, but the code that suppose to handle _context.Done()_ signal doesn't give the priority to _context.Done()_, but it's possible that select clause will choose different branch.
It's fixed here.

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
