### PR TITLE
CI: skip publish docker during release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           version: latest
           workdir: dist
-          args: release
+          args: release --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Following 79107c2e351458339e6e91129f4f002f0909bd81 , we don't really need to publish docker images since it's been done by our Jenkins job. Adding `--skip-publish` so the release in GitHub will be created

