### PR TITLE
backup-cleaner: fixed code that couldn't compile since aa7cc731

### DIFF
--- a/cloud/backup-cleaner/main.go
+++ b/cloud/backup-cleaner/main.go
@@ -140,7 +140,7 @@ func loadManifestInto(dir, fileName string, files *strset.Set) {
 
 	var filesCount int64
 
-	c.ForEachIndexIterFiles(&m, func(dir string, cbFiles []string) {
+	c.ForEachIndexIterFiles(nil, &m, func(dir string, cbFiles []string) {
 		for _, f := range cbFiles {
 			files.Add(path.Join(dir, f))
 			filesCount++


### PR DESCRIPTION
This PR fixes code in living **cloud** directory that couldn't compile since aa7cc731.
This part of code isn't used by Scylla Manager so it was unfortunately missed when refactoring given function.
