### PR TITLE
agent/benchmark: fixed rclone initialization

### DIFF
--- a/pkg/cmd/agent/benchmark.go
+++ b/pkg/cmd/agent/benchmark.go
@@ -70,9 +70,9 @@ var benchmarkCmd = &cobra.Command{
 		}
 
 		// Set rate limit
-		rclone.StartAccountingOperations()
-		// Start accounting after setting all options
 		rclone.SetRateLimit(benchmarkArgs.rateLimit)
+		// Start accounting after setting all options
+		rclone.StartAccountingOperations()
 
 		// Run the scenarios
 		w := cmd.OutOrStderr()


### PR DESCRIPTION
This PR fixes the way in which command `./scylla-manager-agent benchmark` initializes rclone.
It used to set rate limit in a way that it didn't have any effect on actual download conducted by rclone.