### PR TITLE
Fix scheduling of task with --interval and without --start-date

### DIFF
--- a/pkg/command/flag/flag.go
+++ b/pkg/command/flag/flag.go
@@ -140,7 +140,7 @@ func (w Wrapper) interval(p *Duration) {
 	w.MustMarkDeprecated("interval", "use cron instead")
 }
 
-func (w Wrapper) startDate(p *Time) {
+func (w Wrapper) startDate(p *StartDate) {
 	w.fs.VarP(p, "start-date", "s", usage["start-date"])
 	w.MustMarkDeprecated("start-date", "use cron instead")
 }

--- a/pkg/command/flag/task.go
+++ b/pkg/command/flag/task.go
@@ -21,7 +21,7 @@ type TaskBase struct {
 	window     []string
 	timezone   Timezone
 	interval   Duration
-	startDate  Time
+	startDate  StartDate
 	numRetries int
 	retryWait  Duration
 }

--- a/pkg/command/flag/type_test.go
+++ b/pkg/command/flag/type_test.go
@@ -12,21 +12,37 @@ import (
 
 func TestParseTime(t *testing.T) {
 	table := []struct {
-		S string
-		D time.Duration
-		E string
+		S  string
+		T  time.Time
+		ZN bool
+		E  string
 	}{
 		{
 			S: "now",
-			D: 0,
+			T: timeutc.Now(),
+		},
+		{
+			S:  "now",
+			T:  time.Time{},
+			ZN: true,
+		},
+		{
+			S:  "now+0h",
+			T:  time.Time{},
+			ZN: true,
 		},
 		{
 			S: "now+1h",
-			D: time.Hour,
+			T: timeutc.Now().Add(time.Hour),
+		},
+		{
+			S:  "now+2h",
+			T:  timeutc.Now().Add(2 * time.Hour),
+			ZN: true,
 		},
 		{
 			S: timeutc.Now().Add(time.Hour).Format(time.RFC3339),
-			D: time.Hour,
+			T: timeutc.Now().Add(time.Hour),
 		},
 		{
 			S: "2019-05-02T15:04:05Z07:00",
@@ -37,7 +53,7 @@ func TestParseTime(t *testing.T) {
 	const epsilon = 5 * time.Second
 
 	for i, test := range table {
-		m, err := parserTime(test.S)
+		m, err := parserTime(test.S, test.ZN)
 
 		msg := ""
 		if err != nil {
@@ -53,12 +69,9 @@ func TestParseTime(t *testing.T) {
 			continue
 		}
 
-		diff := timeutc.Now().Add(test.D).Sub(m)
-		if diff < 0 {
-			diff *= -1
-		}
+		diff := test.T.Sub(m).Abs()
 		if diff > epsilon {
-			t.Fatal(i, m, test.D, diff, test.S)
+			t.Fatal(i, m, test.T, diff, test.S)
 		}
 	}
 }

--- a/pkg/service/scheduler/service.go
+++ b/pkg/service/scheduler/service.go
@@ -286,6 +286,8 @@ func (s *Service) PutTask(ctx context.Context, t *Task) error {
 			if t.Sched.Cron.IsZero() {
 				run = true
 			}
+		} else if t.Sched.StartDate.Before(now()) {
+			return errors.New("start date of scheduled task cannot be in the past")
 		}
 
 		if err := table.SchedulerTask.InsertQuery(s.session).BindStruct(t).ExecRelease(); err != nil {


### PR DESCRIPTION
Legacy Trigger uses both `startDate` and `interval` to calculate next activation of given task, so even when `--start-date` isn't specified by the user (but the `--interval` flag is), it should be set to `now` and inserted to DB. Without it SM cannot correctly calculate next task activation after restart.

Fixes #3283