### PR TITLE
release: builds from master to be part of 3.2-dev

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,5 +1,5 @@
 RELEASE      := 0.$(shell date +%Y%m%d).$(shell git describe --always)
-VERSION	     ?= 3.1-dev
+VERSION	     ?= 3.2-dev
 
 ifdef $$VERSION
 VERSION := $$VERSION


### PR DESCRIPTION
Changing dist version to 3.2-dev due to coming release of scylla-manager-3.1

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
