### PR TITLE
Restore progress display fix

### DIFF
--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -987,16 +987,12 @@ func (rp RestoreProgress) addHeader(w io.Writer) error {
 
 // status returns task status with optional restore stage.
 func (rp RestoreProgress) status() string {
-	stage := BackupStageName(rp.Progress.Stage)
 	s := rp.Run.Status
 	if s == "DONE" {
 		if len(rp.Progress.Keyspaces) == 1 && rp.Progress.Keyspaces[0].Keyspace == "system_schema" {
 			return "DONE - restart required (see restore docs)"
 		}
 		return "DONE - repair required (see restore docs)"
-	}
-	if s != "NEW" && stage != "" {
-		s += " (" + stage + ")"
 	}
 	return s
 }

--- a/pkg/restapi/task.go
+++ b/pkg/restapi/task.go
@@ -444,6 +444,10 @@ func (h *taskHandler) taskRunProgress(w http.ResponseWriter, r *http.Request) {
 				prog.Progress = repair.Progress{}
 			case scheduler.BackupTask:
 				prog.Progress = backup.Progress{}
+			case scheduler.RestoreTask:
+				prog.Progress = backup.RestoreProgress{}
+			case scheduler.ValidateBackupTask:
+				prog.Progress = backup.ValidationHostProgress{}
 			}
 			render.Respond(w, r, prog)
 			return


### PR DESCRIPTION
SM prefers to return empty progress instead of error 404 when task run hasn't been found. 
Restore (and validateBackup as well I believe) was lacking this approach and that's why #3289 happened.

Still need to check if this PR for sure fixes this issue.