### PR TITLE
Fix non  ending repair runs

### DIFF
--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -222,9 +222,6 @@ func (w *worker) waitRepairStatus(ctx context.Context, id int32, host, keyspace,
 		}
 		s, err := w.client.RepairStatus(ctx, host, keyspace, id, waitSeconds)
 		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-				continue
-			}
 			if w.tableDeleted(ctx, err, keyspace, table) {
 				return errTableDeleted
 			}


### PR DESCRIPTION
SM kept on retrying to query repair status even when encountering context cancellation or deadline exceeded.
This caused it to loop indefinitely in case Scylla is overloaded.