### PR TITLE
docker: move to ubuntu22.04 based image

### DIFF
--- a/dist/docker/scylla-manager-agent.dockerfile
+++ b/dist/docker/scylla-manager-agent.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \

--- a/dist/docker/scylla-manager.dockerfile
+++ b/dist/docker/scylla-manager.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \


### PR DESCRIPTION
Move docker images to be based on ubuntu:22.04

Closes: https://github.com/scylladb/scylla-manager/issues/3305
