### PR TITLE
service/repair: use info log level for repair done message

### DIFF
--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -132,7 +132,7 @@ func (w *worker) runRepair(ctx context.Context, job job) error {
 	if err := w.waitRepairStatus(ctx, jobID, host, ttr.Keyspace, ttr.Table); err != nil {
 		return errors.Wrapf(err, "host %s: keyspace %s table %s command %d", host, ttr.Keyspace, ttr.Table, jobID)
 	}
-	logger.Debug(ctx, "Repair done")
+	logger.Info(ctx, "Repair done")
 
 	return nil
 }


### PR DESCRIPTION
It's equally important as 'Repairing' message and would help to debug on production where default log level is info.
