### PR TITLE
Wrap table name in quotes when using CQL in restore

### DIFF
--- a/pkg/service/backup/restore_worker_schema.go
+++ b/pkg/service/backup/restore_worker_schema.go
@@ -119,7 +119,7 @@ func (w *restoreWorker) ExecOnDisabledTable(ctx context.Context, keyspace, table
 }
 
 func alterGGSStatement(keyspace, table string, ggs int) string {
-	return fmt.Sprintf("ALTER TABLE %s.%s WITH gc_grace_seconds=%d", keyspace, table, ggs)
+	return fmt.Sprintf(`ALTER TABLE "%s"."%s" WITH gc_grace_seconds=%d`, keyspace, table, ggs)
 }
 
 func (w *restoreWorker) GetTableVersion(ctx context.Context, keyspace, table string) (string, error) {


### PR DESCRIPTION
Since gocql does not support `alter` queries, the restore procedure uses `ExecStmt` instead of query builder, which requires that we wrap unusual keyspace and table names in quotes (e.g. `keyspace_name=10gb_sizetiered`).

Fixes #3316 
