### PR TITLE
testing: different filter for finding test scylla containers

### DIFF
--- a/testing/nodes_cp
+++ b/testing/nodes_cp
@@ -8,10 +8,6 @@ set -eu -o pipefail
 declare -r SRC_PATH=$1
 declare -r DEST_PATH=$2
 
-for name in $(docker ps -f name=scylla_manager_dc --format {{.Names}}); do
-    docker cp ${SRC_PATH} ${name}:${DEST_PATH}
-done
-
-for name in $(docker ps -f name=scylla_manager_second --format {{.Names}}); do
+for name in $(docker ps -f name=dc1_node -f name=dc2_node --format {{.Names}}); do
     docker cp ${SRC_PATH} ${name}:${DEST_PATH}
 done

--- a/testing/nodes_exec
+++ b/testing/nodes_exec
@@ -14,16 +14,7 @@ case "$1" in
         ;;
 esac
 
-for name in $(docker ps -f name=scylla_manager_dc --format {{.Names}}); do
-    if [[ ${SILENT} == 1 ]]; then
-        docker exec ${name} bash -c "$*" > /dev/null
-    else
-        echo "> ${name}"
-        docker exec ${name} bash -c "$*"
-    fi
-done
-
-for name in $(docker ps -f name=scylla_manager_second --format {{.Names}}); do
+for name in $(docker ps -f name=dc1_node -f name=dc2_node --format {{.Names}}); do
     if [[ ${SILENT} == 1 ]]; then
         docker exec ${name} bash -c "$*" > /dev/null
     else


### PR DESCRIPTION
With the latest version of docker I use on my machine, 
`docker ps -f name=scylla_manager_dc --format {{.Names}}` is not able to find test scylla containers.
It's because docker uses `-` instead of `_` to create container name.

It's changed to be filtered against "dc1_node" and "dc2_node" names instead.

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
