### PR TITLE
rclone: overwrite when checksum is different

### DIFF
--- a/pkg/config/agent/agent_test.go
+++ b/pkg/config/agent/agent_test.go
@@ -14,9 +14,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v2"
+
 	"github.com/scylladb/scylla-manager/v3/pkg/config/agent"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
-	"gopkg.in/yaml.v2"
 )
 
 func TestParseConfig(t *testing.T) {
@@ -112,11 +113,11 @@ func TestParseConfig(t *testing.T) {
 
 			golden, err := os.ReadFile(test.Golden)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatal(test.Golden, err)
 			}
 
 			if diff := cmp.Diff(buf.Bytes(), golden); diff != "" {
-				t.Fatal(diff)
+				t.Fatal(test.Golden, diff)
 			}
 		})
 	}

--- a/pkg/config/agent/testdata/auth_token_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/auth_token_overwrite.golden.yaml
@@ -31,7 +31,7 @@ rclone:
   dry_run: false
   interactive: false
   check_sum: false
-  size_only: true
+  size_only: false
   ignore_times: false
   ignore_existing: false
   ignore_errors: true

--- a/pkg/config/agent/testdata/basic.golden.yaml
+++ b/pkg/config/agent/testdata/basic.golden.yaml
@@ -31,7 +31,7 @@ rclone:
   dry_run: false
   interactive: false
   check_sum: false
-  size_only: true
+  size_only: false
   ignore_times: false
   ignore_existing: false
   ignore_errors: true

--- a/pkg/config/agent/testdata/debug_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/debug_overwrite.golden.yaml
@@ -31,7 +31,7 @@ rclone:
   dry_run: false
   interactive: false
   check_sum: false
-  size_only: true
+  size_only: false
   ignore_times: false
   ignore_existing: false
   ignore_errors: true

--- a/pkg/config/agent/testdata/https_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/https_overwrite.golden.yaml
@@ -31,7 +31,7 @@ rclone:
   dry_run: false
   interactive: false
   check_sum: false
-  size_only: true
+  size_only: false
   ignore_times: false
   ignore_existing: false
   ignore_errors: true

--- a/pkg/config/agent/testdata/prometheus_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/prometheus_overwrite.golden.yaml
@@ -31,7 +31,7 @@ rclone:
   dry_run: false
   interactive: false
   check_sum: false
-  size_only: true
+  size_only: false
   ignore_times: false
   ignore_existing: false
   ignore_errors: true

--- a/pkg/config/agent/testdata/scylla_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/scylla_overwrite.golden.yaml
@@ -31,7 +31,7 @@ rclone:
   dry_run: false
   interactive: false
   check_sum: false
-  size_only: true
+  size_only: false
   ignore_times: false
   ignore_existing: false
   ignore_errors: true

--- a/pkg/config/agent/testdata/structs_empty.golden.yaml
+++ b/pkg/config/agent/testdata/structs_empty.golden.yaml
@@ -31,7 +31,7 @@ rclone:
   dry_run: false
   interactive: false
   check_sum: false
-  size_only: true
+  size_only: false
   ignore_times: false
   ignore_existing: false
   ignore_errors: true

--- a/pkg/rclone/options.go
+++ b/pkg/rclone/options.go
@@ -38,8 +38,8 @@ func DefaultGlobalOptions() GlobalOptions {
 	c.LogLevel = fs.LogLevelDebug
 	// Don't use JSON log format in logging.
 	c.UseJSONLog = false
-	// Skip based on size only, not mod-time or checksum.
-	c.SizeOnly = true
+	// Skip based on size, mod-time and checksum.
+	c.SizeOnly = false
 	// Skip post copy check of checksums.
 	c.IgnoreChecksum = true
 	// Delete even if there are I/O errors.

--- a/pkg/scyllaclient/client_rclone_test.go
+++ b/pkg/scyllaclient/client_rclone_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient/scyllaclienttest"
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/agent/models"
@@ -484,7 +485,7 @@ func TestRclonePut(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Same size file is ignored
+	// Same size file, but different content is not ignored
 	if err := putString("olleh"); err != nil {
 		t.Fatal(err)
 	}
@@ -494,8 +495,8 @@ func TestRclonePut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cmp.Diff("hello", string(content)) != "" {
-		t.Fatalf("put/a = %s, expected %s", string(content), "hello")
+	if cmp.Diff("olleh", string(content)) != "" {
+		t.Fatalf("put/a = %s, expected %s", string(content), "olleh")
 	}
 }
 


### PR DESCRIPTION
Follow up to https://github.com/scylladb/scylla-manager/issues/3288

It changes SizeOnly flag on RClone to false.
SizeOnly = false means that RClone is going to compare files checking their checksum as well, not size only.

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
