### PR TITLE
restore: set default parallelism to 0 (infinity)

### DIFF
--- a/pkg/service/backup/restore_model.go
+++ b/pkg/service/backup/restore_model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
 	"github.com/scylladb/gocqlx/v2"
+
 	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
@@ -29,7 +30,7 @@ type RestoreTarget struct {
 func defaultRestoreTarget() RestoreTarget {
 	return RestoreTarget{
 		BatchSize: 2,
-		Parallel:  1,
+		Parallel:  0,
 		Continue:  true,
 	}
 }
@@ -46,8 +47,8 @@ func (t RestoreTarget) validateProperties() error {
 	if t.BatchSize <= 0 {
 		return errors.New("batch size param has to be greater than zero")
 	}
-	if t.Parallel <= 0 {
-		return errors.New("parallel param has to be greater than zero")
+	if t.Parallel < 0 {
+		return errors.New("parallel param has to be greater or equal to zero")
 	}
 	if t.RestoreSchema == t.RestoreTables {
 		return errors.New("choose EXACTLY ONE restore type ('--restore-schema' or '--restore-tables' flag)")

--- a/pkg/service/backup/service_backup_restore_integration_test.go
+++ b/pkg/service/backup/service_backup_restore_integration_test.go
@@ -141,7 +141,7 @@ func TestRestoreGetTargetIntegration(t *testing.T) {
 			}
 
 			if diff := cmp.Diff(golden, v, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
-				t.Fatal(diff)
+				t.Fatal(tc.golden, diff)
 			}
 		})
 	}

--- a/pkg/service/backup/testdata/restore/get_target/continue_false.golden.json
+++ b/pkg/service/backup/testdata/restore/get_target/continue_false.golden.json
@@ -8,6 +8,6 @@
   ],
   "snapshot_tag": "sm_20060102150405UTC",
   "batch_size": 2,
-  "parallel": 1,
+  "parallel": 0,
   "restore_tables": true
 }

--- a/pkg/service/backup/testdata/restore/get_target/default_values.golden.json
+++ b/pkg/service/backup/testdata/restore/get_target/default_values.golden.json
@@ -8,7 +8,7 @@
   ],
   "snapshot_tag": "sm_20060102150405UTC",
   "batch_size": 2,
-  "parallel": 1,
+  "parallel": 0,
   "restore_tables": true,
   "continue": true
 }

--- a/pkg/service/backup/testdata/restore/get_target/non_positive_parallel.input.json
+++ b/pkg/service/backup/testdata/restore/get_target/non_positive_parallel.input.json
@@ -3,6 +3,6 @@
     "s3:restoretest-get-target"
   ],
   "snapshot_tag": "sm_20060102150405UTC",
-  "parallel": 0,
+  "parallel": -1,
   "restore_tables": true
 }

--- a/pkg/service/backup/testdata/restore/get_target/schema.golden.json
+++ b/pkg/service/backup/testdata/restore/get_target/schema.golden.json
@@ -7,7 +7,7 @@
   ],
   "snapshot_tag": "sm_20060102150405UTC",
   "batch_size": 99,
-  "parallel": 1,
+  "parallel": 0,
   "restore_schema": true,
   "continue": true
 }


### PR DESCRIPTION
Restore default parallelism to 0 (inf).


---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
