### PR TITLE
restore: do not include no shards into batch_size

### DIFF
--- a/pkg/service/backup/restore_worker.go
+++ b/pkg/service/backup/restore_worker.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/gocqlx/v2/qb"
+
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/schema/table"
 	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
@@ -19,7 +20,6 @@ import (
 // If set, OngoingRunProgress represents unfinished RestoreRunProgress created in previous run.
 type restoreHost struct {
 	Host               string
-	Shards             uint
 	OngoingRunProgress *RestoreRunProgress
 }
 


### PR DESCRIPTION
Batches are too big.
Number of shards is completely irrelevant for restore.

It's a cherry pick from https://github.com/scylladb/scylla-manager/pull/3331

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
