### PR TITLE
Separate restoring schema and tables

### DIFF
--- a/pkg/service/backup/backupspec/versioning.go
+++ b/pkg/service/backup/backupspec/versioning.go
@@ -4,7 +4,6 @@ package backupspec
 
 import (
 	"path"
-	"sort"
 	"strings"
 	"time"
 )
@@ -28,17 +27,8 @@ func (vt VersionedSSTable) FullName() string {
 	return vt.Name + "." + vt.Version
 }
 
-// VersionedMap maps SSTable name to its versions.
-type VersionedMap map[string][]VersionedSSTable
-
-// SortByTime sorts each file versions by their ascending creation time.
-func (vm VersionedMap) SortByTime() {
-	for _, versions := range vm {
-		sort.Slice(versions, func(i, j int) bool {
-			return versions[i].Version < versions[j].Version
-		})
-	}
-}
+// VersionedMap maps SSTable name to its versions with respect to currently restored snapshot tag.
+type VersionedMap map[string]VersionedSSTable
 
 // VersionedFileExt returns the snapshot tag extension of versioned file.
 // If using alongside with RcloneMoveDir or RcloneCopyDir as suffix option,

--- a/pkg/service/backup/restore_progress.go
+++ b/pkg/service/backup/restore_progress.go
@@ -11,7 +11,7 @@ import (
 )
 
 // aggregateProgress returns restore progress information classified by keyspace and tables.
-func (w *restoreWorker) aggregateProgress(ctx context.Context, run *RestoreRun) RestoreProgress {
+func (w *restoreWorkerTools) aggregateProgress(ctx context.Context, run *RestoreRun) RestoreProgress {
 	var (
 		p = RestoreProgress{
 			SnapshotTag: run.SnapshotTag,
@@ -125,7 +125,7 @@ func (rp *restoreProgress) calcParentProgress(child restoreProgress) {
 
 // ForEachProgress iterates over all RestoreRunProgress that belong to the run.
 // NOTE: callback is always called with the same pointer - only the value that it points to changes.
-func (w *restoreWorker) ForEachProgress(ctx context.Context, run *RestoreRun, cb func(*RestoreRunProgress)) {
+func (w *restoreWorkerTools) ForEachProgress(ctx context.Context, run *RestoreRun, cb func(*RestoreRunProgress)) {
 	iter := table.RestoreRunProgress.SelectQuery(w.managerSession).BindMap(qb.M{
 		"cluster_id": run.ClusterID,
 		"task_id":    run.TaskID,
@@ -151,7 +151,7 @@ func (w *restoreWorker) ForEachProgress(ctx context.Context, run *RestoreRun, cb
 // ForEachTableProgress iterates over all RestoreRunProgress that belong to the run
 // with the same manifest, keyspace and table as the run.
 // NOTE: callback is always called with the same pointer - only the value that it points to changes.
-func (w *restoreWorker) ForEachTableProgress(ctx context.Context, run *RestoreRun, cb func(*RestoreRunProgress)) {
+func (w *restoreWorkerTools) ForEachTableProgress(ctx context.Context, run *RestoreRun, cb func(*RestoreRunProgress)) {
 	iter := qb.Select(table.RestoreRunProgress.Name()).Where(
 		qb.Eq("cluster_id"),
 		qb.Eq("task_id"),

--- a/pkg/service/backup/restore_worker.go
+++ b/pkg/service/backup/restore_worker.go
@@ -4,172 +4,59 @@ package backup
 
 import (
 	"context"
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
 
 	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
+	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/gocqlx/v2/qb"
-
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/schema/table"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 )
 
-// restoreHost represents host that can be used for restoring files.
-// If set, OngoingRunProgress represents unfinished RestoreRunProgress created in previous run.
-type restoreHost struct {
-	Host               string
-	OngoingRunProgress *RestoreRunProgress
+// restoreWorker represents common functionalities of both schemaWorker and tablesWorker
+// that are needed to perform restore procedure.
+type restoreWorker interface {
+	restore(ctx context.Context, run *RestoreRun, target RestoreTarget) error
+	newUnits(ctx context.Context, target RestoreTarget) ([]RestoreUnit, error)
+	startFromScratch()
+	insertRun(ctx context.Context, run *RestoreRun)
+	decorateWithPrevRun(ctx context.Context, run *RestoreRun) error
+	clonePrevProgress(ctx context.Context, run *RestoreRun)
 }
 
-// bundle represents SSTables with the same ID.
-type bundle []string
-
-// restoreWorker is responsible for coordinating restore procedure.
-type restoreWorker struct {
+// restoreWorkerTools consists of utils common for both schemaWorker and tablesWorker.
+type restoreWorkerTools struct {
 	workerTools
 
-	metrics metrics.RestoreM
-	// Fields below are constant among all restore runs of the same restore task.
+	metrics        metrics.RestoreM
 	managerSession gocqlx.Session
 	clusterSession gocqlx.Session
-	// Iterates over all manifests in given location with
-	// cluster ID and snapshot tag specified in restore target.
+	// Iterates over all manifests in given location with cluster ID and snapshot tag specified in restore target.
 	forEachRestoredManifest func(ctx context.Context, location Location, f func(ManifestInfoWithContent) error) error
 
-	// Fields below are mutable for each restore run
-	location     Location                // Currently restored location
-	miwc         ManifestInfoWithContent // Currently restored manifest
-	hosts        []restoreHost           // Restore units created for currently restored location
-	bundles      map[string]bundle       // Maps bundle to it's ID
-	bundleIDPool chan string             // IDs of the bundles that are yet to be restored
-	// Maps original SSTable name to its existing older versions (does not include the newest version).
-	// Versions are sorted by ascending time of their creation.
+	location Location                // Currently restored location
+	miwc     ManifestInfoWithContent // Currently restored manifest
+	// Maps original SSTable name to its existing older version (with respect to currently restored snapshot tag)
+	// that should be used during the restore procedure. It should be initialized per each restored table.
 	versionedFiles VersionedMap
-	resumed        bool // Set to true if current run has already skipped all tables restored in previous run
 }
 
-func (w *restoreWorker) insertRun(ctx context.Context, run *RestoreRun) {
-	if err := table.RestoreRun.InsertQuery(w.managerSession).BindStruct(run).ExecRelease(); err != nil {
-		w.Logger.Error(ctx, "Insert run",
-			"run", *run,
-			"error", err,
-		)
-	}
-}
-
-func (w *restoreWorker) insertRunProgress(ctx context.Context, pr *RestoreRunProgress) {
-	if err := table.RestoreRunProgress.InsertQuery(w.managerSession).BindStruct(pr).ExecRelease(); err != nil {
-		w.Logger.Error(ctx, "Insert run progress",
-			"progress", *pr,
-			"error", err,
-		)
-	}
-}
-
-func (w *restoreWorker) deleteRunProgress(ctx context.Context, pr *RestoreRunProgress) {
-	if err := table.RestoreRunProgress.DeleteQuery(w.managerSession).BindStruct(pr).ExecRelease(); err != nil {
-		w.Logger.Error(ctx, "Delete run progress",
-			"progress", *pr,
-			"error", err,
-		)
-	}
-}
-
-// decorateWithPrevRun gets restore task previous run and if it is not done
-// sets prev ID on the given run.
-func (w *restoreWorker) decorateWithPrevRun(ctx context.Context, run *RestoreRun) error {
-	prev, err := w.GetRun(ctx, run.ClusterID, run.TaskID, uuid.Nil)
-	if errors.Is(err, gocql.ErrNotFound) {
-		return nil
-	}
-	if err != nil {
-		return errors.Wrap(err, "get run")
-	}
-	if prev.Stage == StageRestoreDone {
-		return nil
-	}
-
-	w.Logger.Info(ctx, "Resuming previous run", "prev_run_id", prev.ID)
-
-	run.PrevID = prev.ID
-	run.Location = prev.Location
-	run.ManifestPath = prev.ManifestPath
-	run.Keyspace = prev.Keyspace
-	run.Table = prev.Table
-	run.Stage = prev.Stage
-	run.Units = prev.Units
-
-	return nil
-}
-
-// clonePrevProgress copies all the previous run progress into
-// current run progress.
-func (w *restoreWorker) clonePrevProgress(ctx context.Context, run *RestoreRun) {
-	q := table.RestoreRunProgress.InsertQuery(w.managerSession)
-	defer q.Release()
-
-	prevRun := &RestoreRun{
-		ClusterID: run.ClusterID,
-		TaskID:    run.TaskID,
-		ID:        run.PrevID,
-	}
-
-	w.ForEachProgress(ctx, prevRun, func(pr *RestoreRunProgress) {
-		pr.RunID = run.ID
-		if validateTimeIsSet(pr.RestoreCompletedAt) {
-			// Recreate metrics for restore run progresses that were already completed in the previous run.
-			// Do not update the {downloaded,skipped,failed} metrics since they are local to given run.
-			size := pr.Downloaded + pr.Skipped + pr.VersionedProgress
-			w.metrics.UpdateRestoreProgress(pr.ClusterID, pr.ManifestPath, pr.Keyspace, pr.Table, size)
-			w.metrics.UpdateFilesSize(pr.ClusterID, pr.ManifestPath, pr.Keyspace, pr.Table, size)
-		}
-
-		if err := q.BindStruct(pr).Exec(); err != nil {
-			w.Logger.Error(ctx, "Couldn't clone run progress",
-				"run_progress", *pr,
-				"error", err,
-			)
-		}
-	})
-}
-
-// GetRun returns run with specified cluster, task and run ID.
-// If run ID is not specified, it returns latest run with specified cluster and task ID.
-func (w *restoreWorker) GetRun(ctx context.Context, clusterID, taskID, runID uuid.UUID) (*RestoreRun, error) {
-	w.Logger.Debug(ctx, "Get run",
-		"cluster_id", clusterID,
-		"task_id", taskID,
-		"run_id", runID,
-	)
-
-	var q *gocqlx.Queryx
-	if runID != uuid.Nil {
-		q = table.RestoreRun.GetQuery(w.managerSession).BindMap(qb.M{
-			"cluster_id": clusterID,
-			"task_id":    taskID,
-			"id":         runID,
-		})
-	} else {
-		q = table.RestoreRun.SelectQuery(w.managerSession).BindMap(qb.M{
-			"cluster_id": clusterID,
-			"task_id":    taskID,
-		})
-	}
-
-	var r RestoreRun
-	return &r, q.GetRelease(&r)
-}
-
-func (w *restoreWorker) newUnits(ctx context.Context, target RestoreTarget) ([]RestoreUnit, error) {
+func (w *restoreWorkerTools) newUnits(ctx context.Context, target RestoreTarget) ([]RestoreUnit, error) {
 	var (
 		units   []RestoreUnit
 		unitMap = make(map[string]RestoreUnit)
 	)
 
 	var foundManifest bool
-	for _, w.location = range target.Location {
+	for _, l := range target.Location {
 		manifestHandler := func(miwc ManifestInfoWithContent) error {
 			foundManifest = true
 
@@ -197,7 +84,7 @@ func (w *restoreWorker) newUnits(ctx context.Context, target RestoreTarget) ([]R
 			return miwc.ForEachIndexIter(target.Keyspace, filesHandler)
 		}
 
-		if err := w.forEachRestoredManifest(ctx, w.location, manifestHandler); err != nil {
+		if err := w.forEachRestoredManifest(ctx, l, manifestHandler); err != nil {
 			return nil, err
 		}
 	}
@@ -227,8 +114,272 @@ func (w *restoreWorker) newUnits(ctx context.Context, target RestoreTarget) ([]R
 	return units, nil
 }
 
+// initVersionedFiles gathers information about versioned files from specified dir.
+func (w *restoreWorkerTools) initVersionedFiles(ctx context.Context, host, dir string) error {
+	w.versionedFiles = make(VersionedMap)
+	allVersions := make(map[string][]VersionedSSTable)
+
+	opts := &scyllaclient.RcloneListDirOpts{
+		FilesOnly:     true,
+		VersionedOnly: true,
+	}
+	f := func(item *scyllaclient.RcloneListDirItem) {
+		name, version := SplitNameAndVersion(item.Name)
+		allVersions[name] = append(allVersions[name], VersionedSSTable{
+			Name:    name,
+			Version: version,
+			Size:    item.Size,
+		})
+	}
+
+	if err := w.Client.RcloneListDirIter(ctx, host, dir, opts, f); err != nil {
+		return errors.Wrapf(err, "host %s: listing versioned SSTables", host)
+	}
+
+	restoreT, err := SnapshotTagTime(w.SnapshotTag)
+	if err != nil {
+		return err
+	}
+	// Chose correct version with respect to currently restored snapshot tag
+	for _, versions := range allVersions {
+		var candidate VersionedSSTable
+		for _, v := range versions {
+			tagT, err := SnapshotTagTime(v.Version)
+			if err != nil {
+				return err
+			}
+			if tagT.After(restoreT) {
+				if candidate.Version == "" || v.Version < candidate.Version {
+					candidate = v
+				}
+			}
+		}
+
+		if candidate.Version != "" {
+			w.versionedFiles[candidate.Name] = candidate
+		}
+	}
+
+	if len(w.versionedFiles) > 0 {
+		w.Logger.Info(ctx, "Chosen versioned SSTables",
+			"host", host,
+			"dir", dir,
+			"versionedSSTables", w.versionedFiles,
+		)
+	}
+
+	return nil
+}
+
+// cleanUploadDir deletes all SSTables from host's upload directory except for those present in excludedFiles.
+func (w *restoreWorkerTools) cleanUploadDir(ctx context.Context, host, uploadDir string, excludedFiles []string) error {
+	s := strset.New(excludedFiles...)
+	var filesToBeDeleted []string
+
+	getFilesToBeDeleted := func(item *scyllaclient.RcloneListDirItem) {
+		if !s.Has(item.Name) {
+			filesToBeDeleted = append(filesToBeDeleted, item.Name)
+		}
+	}
+
+	opts := &scyllaclient.RcloneListDirOpts{FilesOnly: true}
+	if err := w.Client.RcloneListDirIter(ctx, host, uploadDir, opts, getFilesToBeDeleted); err != nil {
+		return errors.Wrapf(err, "list dir: %s on host: %s", uploadDir, host)
+	}
+
+	if len(filesToBeDeleted) > 0 {
+		w.Logger.Info(ctx, "Delete files from host's upload directory",
+			"host", host,
+			"upload_dir", uploadDir,
+			"files", filesToBeDeleted,
+		)
+	}
+
+	for _, f := range filesToBeDeleted {
+		remotePath := path.Join(uploadDir, f)
+		if err := w.Client.RcloneDeleteFile(ctx, host, remotePath); err != nil {
+			return errors.Wrapf(err, "delete file: %s on host: %s", remotePath, host)
+		}
+	}
+
+	return nil
+}
+
+func (w *restoreWorkerTools) ValidateTableExists(ctx context.Context, keyspace, table string) error {
+	q := qb.Select("system_schema.tables").
+		Columns("table_name").
+		Where(qb.Eq("keyspace_name"), qb.Eq("table_name")).
+		Query(w.clusterSession).
+		Bind(keyspace, table)
+	defer q.Release()
+
+	var name string
+	if err := q.Scan(&name); err != nil {
+		return errors.Wrap(err, "validate table exists")
+	}
+
+	return nil
+}
+
+func (w *restoreWorkerTools) GetTableVersion(ctx context.Context, keyspace, table string) (string, error) {
+	q := qb.Select("system_schema.tables").
+		Columns("id").
+		Where(qb.Eq("keyspace_name"), qb.Eq("table_name")).
+		Query(w.clusterSession).
+		Bind(keyspace, table)
+
+	defer q.Release()
+
+	var version string
+	if err := q.Scan(&version); err != nil {
+		return "", errors.Wrap(err, "record table's version")
+	}
+	// Table's version is stripped of '-' characters
+	version = strings.ReplaceAll(version, "-", "")
+
+	w.Logger.Info(ctx, "Received table's version",
+		"keyspace", keyspace,
+		"table", table,
+		"version", version,
+	)
+
+	return version, nil
+}
+
+// DisableTableGGS disables 'tombstone_gc' option for the time of restoring tables' contents.
+// It should be enabled by the user after repairing restored cluster.
+func (w *restoreWorkerTools) DisableTableGGS(ctx context.Context, keyspace, table string) error {
+	w.Logger.Info(ctx, "Disabling table's gc_grace_seconds",
+		"keyspace", keyspace,
+		"table", table,
+	)
+
+	if err := w.clusterSession.ExecStmt(disableTableGGSStatement(keyspace, table)); err != nil {
+		return errors.Wrap(err, "disable gc_grace_seconds")
+	}
+	return nil
+}
+
+func disableTableGGSStatement(keyspace, table string) string {
+	return fmt.Sprintf(`ALTER TABLE "%s"."%s" WITH tombstone_gc = {'mode':'disabled'}`, keyspace, table)
+}
+
+func (w *restoreWorkerTools) insertRun(ctx context.Context, run *RestoreRun) {
+	if err := table.RestoreRun.InsertQuery(w.managerSession).BindStruct(run).ExecRelease(); err != nil {
+		w.Logger.Error(ctx, "Insert run",
+			"run", *run,
+			"error", err,
+		)
+	}
+}
+
+func (w *restoreWorkerTools) insertRunProgress(ctx context.Context, pr *RestoreRunProgress) {
+	if err := table.RestoreRunProgress.InsertQuery(w.managerSession).BindStruct(pr).ExecRelease(); err != nil {
+		w.Logger.Error(ctx, "Insert run progress",
+			"progress", *pr,
+			"error", err,
+		)
+	}
+}
+
+func (w *restoreWorkerTools) deleteRunProgress(ctx context.Context, pr *RestoreRunProgress) {
+	if err := table.RestoreRunProgress.DeleteQuery(w.managerSession).BindStruct(pr).ExecRelease(); err != nil {
+		w.Logger.Error(ctx, "Delete run progress",
+			"progress", *pr,
+			"error", err,
+		)
+	}
+}
+
+// decorateWithPrevRun gets restore task previous run and if it is not done
+// sets prev ID on the given run.
+func (w *restoreWorkerTools) decorateWithPrevRun(ctx context.Context, run *RestoreRun) error {
+	prev, err := w.GetRun(ctx, run.ClusterID, run.TaskID, uuid.Nil)
+	if errors.Is(err, gocql.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return errors.Wrap(err, "get run")
+	}
+	if prev.Stage == StageRestoreDone {
+		return nil
+	}
+
+	w.Logger.Info(ctx, "Resuming previous run", "prev_run_id", prev.ID)
+
+	run.PrevID = prev.ID
+	run.Location = prev.Location
+	run.ManifestPath = prev.ManifestPath
+	run.Keyspace = prev.Keyspace
+	run.Table = prev.Table
+	run.Stage = prev.Stage
+	run.Units = prev.Units
+
+	return nil
+}
+
+// clonePrevProgress copies all the previous run progress into
+// current run progress.
+func (w *restoreWorkerTools) clonePrevProgress(ctx context.Context, run *RestoreRun) {
+	q := table.RestoreRunProgress.InsertQuery(w.managerSession)
+	defer q.Release()
+
+	prevRun := &RestoreRun{
+		ClusterID: run.ClusterID,
+		TaskID:    run.TaskID,
+		ID:        run.PrevID,
+	}
+
+	w.ForEachProgress(ctx, prevRun, func(pr *RestoreRunProgress) {
+		pr.RunID = run.ID
+		if validateTimeIsSet(pr.RestoreCompletedAt) {
+			// Recreate metrics for restore run progresses that were already completed in the previous run.
+			// Do not update the {downloaded,skipped,failed} metrics since they are local to given run.
+			size := pr.Downloaded + pr.Skipped + pr.VersionedProgress
+			w.metrics.UpdateRestoreProgress(pr.ClusterID, pr.ManifestPath, pr.Keyspace, pr.Table, size)
+			w.metrics.UpdateFilesSize(pr.ClusterID, pr.ManifestPath, pr.Keyspace, pr.Table, size)
+		}
+
+		if err := q.BindStruct(pr).Exec(); err != nil {
+			w.Logger.Error(ctx, "Couldn't clone run progress",
+				"run_progress", *pr,
+				"error", err,
+			)
+		}
+	})
+
+	w.Logger.Info(ctx, "Run after decoration", "run", *run)
+}
+
+// GetRun returns run with specified cluster, task and run ID.
+// If run ID is not specified, it returns the latest run with specified cluster and task ID.
+func (w *restoreWorkerTools) GetRun(ctx context.Context, clusterID, taskID, runID uuid.UUID) (*RestoreRun, error) {
+	w.Logger.Debug(ctx, "Get run",
+		"cluster_id", clusterID,
+		"task_id", taskID,
+		"run_id", runID,
+	)
+
+	var q *gocqlx.Queryx
+	if runID != uuid.Nil {
+		q = table.RestoreRun.GetQuery(w.managerSession).BindMap(qb.M{
+			"cluster_id": clusterID,
+			"task_id":    taskID,
+			"id":         runID,
+		})
+	} else {
+		q = table.RestoreRun.SelectQuery(w.managerSession).BindMap(qb.M{
+			"cluster_id": clusterID,
+			"task_id":    taskID,
+		})
+	}
+
+	var r RestoreRun
+	return &r, q.GetRelease(&r)
+}
+
 // getProgress fetches restore worker's run and returns its aggregated progress information.
-func (w *restoreWorker) getProgress(ctx context.Context) (RestoreProgress, error) {
+func (w *restoreWorkerTools) getProgress(ctx context.Context) (RestoreProgress, error) {
 	w.Logger.Debug(ctx, "Getting progress",
 		"cluster_id", w.ClusterID,
 		"task_id", w.TaskID,
@@ -242,3 +393,44 @@ func (w *restoreWorker) getProgress(ctx context.Context) (RestoreProgress, error
 
 	return w.aggregateProgress(ctx, run), nil
 }
+
+// sstableID returns ID from SSTable name.
+// Supported SSTable format versions are: "mc", "md", "me", "la", "ka".
+// Scylla code validating SSTable format can be found here:
+// https://github.com/scylladb/scylladb/blob/2c1ef0d2b768a793c284fc68944526179bfd0171/sstables/sstables.cc#L2333
+func sstableID(sstable string) string {
+	parts := strings.Split(sstable, "-")
+
+	if regexLaMx.MatchString(sstable) {
+		return parts[1]
+	}
+	if regexKa.MatchString(sstable) {
+		return parts[3]
+	}
+
+	panic(unknownSSTableError(sstable))
+}
+
+func renameSSTableID(sstable, newID string) string {
+	parts := strings.Split(sstable, "-")
+
+	switch {
+	case regexLaMx.MatchString(sstable):
+		parts[1] = newID
+	case regexKa.MatchString(sstable):
+		parts[3] = newID
+	default:
+		panic(unknownSSTableError(sstable))
+	}
+
+	return strings.Join(parts, "-")
+}
+
+func unknownSSTableError(sstable string) error {
+	return errors.Errorf("unknown SSTable format version: %s. Supported versions are: 'mc', 'md', 'me', 'la', 'ka'", sstable)
+}
+
+var (
+	regexLaMx = regexp.MustCompile(`(la|m[cde])-(\d+)-(\w+)-(.*)`)
+	regexKa   = regexp.MustCompile(`(\w+)-(\w+)-ka-(\d+)-(.*)`)
+)

--- a/pkg/service/backup/restore_worker_schema.go
+++ b/pkg/service/backup/restore_worker_schema.go
@@ -41,6 +41,9 @@ func (w *schemaWorker) restore(ctx context.Context, run *RestoreRun, target Rest
 	if err != nil {
 		return errors.Wrap(err, "get status")
 	}
+	if len(status) != len(status.Live()) {
+		return errors.New("not all nodes are in the UN state")
+	}
 	// Clean upload dirs.
 	// This is required as we rename SSTables during download in order to avoid name overlaps.
 	for _, u := range run.Units {

--- a/pkg/service/backup/restore_worker_schema.go
+++ b/pkg/service/backup/restore_worker_schema.go
@@ -4,145 +4,244 @@ package backup
 
 import (
 	"context"
-	"fmt"
-	"math"
-	"strings"
+	"path"
+	"strconv"
 
 	"github.com/pkg/errors"
-	"github.com/scylladb/gocqlx/v2/qb"
-	"go.uber.org/multierr"
+	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
+	"go.uber.org/atomic"
 )
 
-func (w *restoreWorker) ValidateTableExists(ctx context.Context, keyspace, table string) error {
-	q := qb.Select("system_schema.tables").
-		Columns("table_name").
-		Where(qb.Eq("keyspace_name"), qb.Eq("table_name")).
-		Query(w.clusterSession).
-		Bind(keyspace, table)
-	defer q.Release()
+type schemaWorker struct {
+	restoreWorkerTools
 
-	var name string
-	if err := q.Scan(&name); err != nil {
-		return errors.Wrap(err, "validate table exists")
+	hosts           []string
+	generationCnt   atomic.Int64
+	renamedSSTables map[string]string
+}
+
+// restore downloads all backed-up schema files to each node in the cluster. This approach is necessary because
+// it's not possible to alter gc_grace_seconds or tombstone_gc on schema tables (safety requirement for nodetool refresh).
+// It introduces great data duplication, but is necessary in order to simulate schema repair on each node.
+// Luckily, schema files are small, so this shouldn't be noticeable in terms of performance.
+// When all files are downloaded, they are restored using nodetool refresh.
+// Note that due to small schema size:
+// - resuming schema restoration will always start from scratch
+// - schema restoration does not use long polling for updating download progress
+// Adding the ability to resume schema restoration might be added in the future.
+func (w *schemaWorker) restore(ctx context.Context, run *RestoreRun, target RestoreTarget) error {
+	w.AwaitSchemaAgreement(ctx, w.clusterSession)
+
+	w.Logger.Info(ctx, "Started restoring schema")
+	defer w.Logger.Info(ctx, "Restoring schema finished")
+
+	status, err := w.Client.Status(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get status")
 	}
+	// Clean upload dirs.
+	// This is required as we rename SSTables during download in order to avoid name overlaps.
+	for _, u := range run.Units {
+		for _, t := range u.Tables {
+			version, err := w.GetTableVersion(ctx, u.Keyspace, t.Table)
+			if err != nil {
+				return err
+			}
+			uploadDir := uploadTableDir(u.Keyspace, t.Table, version)
+
+			for _, h := range status {
+				if err := w.cleanUploadDir(ctx, h.Addr, uploadDir, nil); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	// Download files
+	for _, l := range target.Location {
+		if err = w.locationDownloadHandler(ctx, run, target, l); err != nil {
+			return err
+		}
+	}
+	// Set restore start in all run progresses
+	w.ForEachProgress(ctx, run, func(pr *RestoreRunProgress) {
+		pr.setRestoreStartedAt()
+		w.insertRunProgress(ctx, pr)
+	})
+	// Load schema SSTables on all nodes
+	err = parallel.Run(len(status), parallel.NoLimit, func(i int) error {
+		host := status[i]
+
+		for _, ks := range run.Units {
+			for _, t := range ks.Tables {
+				if _, err := w.Client.LoadSSTables(ctx, host.Addr, ks.Keyspace, t.Table, false, false); err != nil {
+					return errors.Wrap(err, "restore schema")
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	// Set restore completed in all run progresses
+	w.ForEachProgress(ctx, run, func(pr *RestoreRunProgress) {
+		pr.setRestoreCompletedAt()
+		w.insertRunProgress(ctx, pr)
+		w.metrics.UpdateRestoreProgress(pr.ClusterID, pr.ManifestPath, pr.Keyspace, pr.Table, pr.Downloaded)
+	})
 
 	return nil
 }
 
-func (w *restoreWorker) GetGraceSeconds(ctx context.Context, keyspace, table string) (int, error) {
-	q := qb.Select("system_schema.tables").
-		Columns("gc_grace_seconds").
-		Where(qb.Eq("keyspace_name"), qb.Eq("table_name")).
-		Query(w.clusterSession).
-		Bind(keyspace, table)
-	defer q.Release()
+func (w *schemaWorker) locationDownloadHandler(ctx context.Context, run *RestoreRun, target RestoreTarget, location Location) error {
+	w.Logger.Info(ctx, "Downloading schema from location", "location", location)
+	defer w.Logger.Info(ctx, "Downloading schema from location finished", "location", location)
 
-	var ggs int
-	if err := q.Scan(&ggs); err != nil {
-		return 0, errors.Wrap(err, "get gc_grace_seconds")
+	w.location = location
+	run.Location = location.String()
+
+	if err := w.initHosts(ctx); err != nil {
+		return errors.Wrap(err, "initialize hosts")
 	}
 
-	w.Logger.Info(ctx, "Received table's gc_grace_seconds",
-		"keyspace", keyspace,
-		"table", table,
-		"gc_grace_seconds", ggs,
-	)
+	tableDownloadHandler := func(fm FilesMeta) error {
+		w.Logger.Info(ctx, "Downloading schema table", "keyspace", fm.Keyspace, "table", fm.Table)
+		defer w.Logger.Info(ctx, "Downloading schema table finished", "keyspace", fm.Keyspace, "table", fm.Table)
 
-	return ggs, nil
-}
+		run.Table = fm.Table
+		run.Keyspace = fm.Keyspace
 
-func (w *restoreWorker) SetGraceSeconds(ctx context.Context, keyspace, table string, ggs int) error {
-	w.Logger.Info(ctx, "Setting table's gc_grace_seconds",
-		"keyspace", keyspace,
-		"table", table,
-		"gc_grace_seconds", ggs,
-	)
+		w.metrics.SetFilesSize(run.ClusterID, run.ManifestPath, run.Keyspace, run.Table, fm.Size)
 
-	if err := w.clusterSession.ExecStmt(alterGGSStatement(keyspace, table, ggs)); err != nil {
-		return errors.Wrap(err, "set gc_grace_seconds")
+		return w.workFunc(ctx, run, target, fm)
 	}
 
-	return nil
+	manifestDownloadHandler := func(miwc ManifestInfoWithContent) error {
+		w.Logger.Info(ctx, "Downloading schema from manifest", "manifest", miwc.ManifestInfo)
+		defer w.Logger.Info(ctx, "Downloading schema from manifest", "manifest", miwc.ManifestInfo)
+
+		w.miwc = miwc
+		run.ManifestPath = miwc.Path()
+		w.insertRun(ctx, run)
+
+		return miwc.ForEachIndexIterWithError(target.Keyspace, tableDownloadHandler)
+	}
+
+	return w.forEachRestoredManifest(ctx, location, manifestDownloadHandler)
 }
 
-// ExecOnDisabledTable executes given function with
-// table's compaction and gc_grace_seconds temporarily disabled.
-func (w *restoreWorker) ExecOnDisabledTable(ctx context.Context, keyspace, table string, f func() error) (err error) {
-	w.Logger.Info(ctx, "Temporarily disabling compaction and gc_grace_seconds",
-		"keyspace", keyspace,
-		"table", table,
-	)
-
-	// Temporarily disable gc grace seconds
-	ggs, err := w.GetGraceSeconds(ctx, keyspace, table)
+func (w *schemaWorker) workFunc(ctx context.Context, run *RestoreRun, target RestoreTarget, fm FilesMeta) error {
+	version, err := w.GetTableVersion(ctx, fm.Keyspace, fm.Table)
 	if err != nil {
 		return err
 	}
 
-	const maxGGS = math.MaxInt32
-	if err = w.SetGraceSeconds(ctx, keyspace, table, maxGGS); err != nil {
-		return err
-	}
-	// Reset gc grace seconds
-	defer func() {
-		if ggsErr := w.SetGraceSeconds(context.Background(), keyspace, table, ggs); ggsErr != nil {
-			ggsErr = fmt.Errorf(
-				"%w: please reset gc_grace_seconds manually by running \"%s\" in CQLSH",
-				ggsErr,
-				alterGGSStatement(keyspace, table, ggs),
-			)
-			err = multierr.Append(err, ggsErr)
-		}
-	}()
-
-	// Temporarily disable compaction
-	comp, err := w.Client.IsAutoCompactionEnabled(ctx, keyspace, table)
-	if comp {
-		if err = w.Client.DisableAutoCompaction(ctx, keyspace, table); err != nil {
-			return err
-		}
-		// Reset compaction
-		defer func() {
-			if compErr := w.Client.EnableAutoCompaction(context.Background(), keyspace, table); compErr != nil {
-				compErr = fmt.Errorf(
-					"%w: please enable autocompaction manually by running \"nodetool enableautocompaction %s.%s\"",
-					compErr,
-					keyspace,
-					table,
-				)
-				err = multierr.Append(err, compErr)
-			}
-		}()
-	}
-
-	return f()
-}
-
-func alterGGSStatement(keyspace, table string, ggs int) string {
-	return fmt.Sprintf(`ALTER TABLE "%s"."%s" WITH gc_grace_seconds=%d`, keyspace, table, ggs)
-}
-
-func (w *restoreWorker) GetTableVersion(ctx context.Context, keyspace, table string) (string, error) {
-	q := qb.Select("system_schema.tables").
-		Columns("id").
-		Where(qb.Eq("keyspace_name"), qb.Eq("table_name")).
-		Query(w.clusterSession).
-		Bind(keyspace, table)
-
-	defer q.Release()
-
-	var version string
-	if err := q.Scan(&version); err != nil {
-		return "", errors.Wrap(err, "record table's version")
-	}
-	// Table's version is stripped of '-' characters
-	version = strings.ReplaceAll(version, "-", "")
-
-	w.Logger.Info(ctx, "Received table's version",
-		"keyspace", keyspace,
-		"table", table,
-		"version", version,
+	var (
+		srcDir = w.location.RemotePath(w.miwc.SSTableVersionDir(fm.Keyspace, fm.Table, fm.Version))
+		dstDir = uploadTableDir(fm.Keyspace, fm.Table, version)
 	)
 
-	return version, nil
+	w.Logger.Info(ctx, "Start downloading schema files",
+		"keyspace", fm.Keyspace,
+		"table", fm.Table,
+		"src_dir", srcDir,
+		"dst_dir", dstDir,
+		"files", fm.Files,
+	)
+
+	w.initRenamedID(fm.Files)
+	if err = w.initVersionedFiles(ctx, w.hosts[0], srcDir); err != nil {
+		return errors.Wrap(err, "initialize versioned SSTables")
+	}
+
+	return parallel.Run(len(w.hosts), target.Parallel, func(i int) error {
+		host := w.hosts[i]
+
+		if err := w.checkAvailableDiskSpace(ctx, hostInfo{IP: host}); err != nil {
+			return errors.Wrapf(err, "validate free disk space on host: %s", host)
+		}
+
+		start := timeutc.Now()
+		// Rely on rclone ability to limit number of concurrent transfers
+		err := parallel.Run(len(fm.Files), parallel.NoLimit, func(j int) error {
+			file := fm.Files[j]
+			// Rename SSTable in the destination in order to avoid name conflicts
+			dstFile := w.renamedSSTables[file]
+			// Take the correct version of restored file
+			srcFile := file
+			if v, ok := w.versionedFiles[file]; ok {
+				srcFile = v.FullName()
+			}
+
+			srcPath := path.Join(srcDir, srcFile)
+			dstPath := path.Join(dstDir, dstFile)
+
+			return w.Client.RcloneCopyFile(ctx, host, dstPath, srcPath)
+		})
+		if err != nil {
+			return errors.Wrapf(err, "download renamed SSTables on host: %s", host)
+		}
+		end := timeutc.Now()
+		// In order to ensure that the size calculated in newUnits matches the sum of restored bytes from
+		// run progresses, insert only fraction of the whole downloaded size. This is caused by the data duplication.
+		proportionalSize := int64((int(fm.Size) + i) / len(w.hosts))
+
+		w.insertRunProgress(ctx, &RestoreRunProgress{
+			ClusterID:           run.ClusterID,
+			TaskID:              run.TaskID,
+			RunID:               run.ID,
+			ManifestPath:        run.ManifestPath,
+			Keyspace:            run.Keyspace,
+			Table:               run.Table,
+			Host:                host,
+			DownloadStartedAt:   &start,
+			DownloadCompletedAt: &end,
+			Downloaded:          proportionalSize,
+		})
+		w.metrics.UpdateFilesProgress(run.ClusterID, run.ManifestPath, run.Keyspace, run.Table, proportionalSize, 0, 0)
+
+		return nil
+	})
 }
+
+func (w *schemaWorker) initHosts(ctx context.Context) error {
+	status, err := w.Client.Status(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get client status")
+	}
+
+	remotePath := w.location.RemotePath("")
+	checkedNodes, err := w.Client.GetLiveNodesWithLocationAccess(ctx, status, remotePath)
+	if err != nil {
+		return errors.Wrap(err, "no live nodes with location access")
+	}
+
+	w.hosts = make([]string, 0)
+	for _, host := range checkedNodes {
+		w.hosts = append(w.hosts, host.Addr)
+	}
+
+	w.Logger.Info(ctx, "Initialized restore hosts", "hosts", w.hosts)
+	return nil
+}
+
+func (w *schemaWorker) initRenamedID(sstables []string) {
+	bundles := make(map[string][]string)
+	for _, sst := range sstables {
+		id := sstableID(sst)
+		bundles[id] = append(bundles[id], sst)
+	}
+
+	w.renamedSSTables = make(map[string]string)
+	for _, b := range bundles {
+		newID := int(w.generationCnt.Add(1))
+		for _, sst := range b {
+			w.renamedSSTables[sst] = renameSSTableID(sst, strconv.Itoa(newID))
+		}
+	}
+}
+
+func (w *schemaWorker) startFromScratch() {}

--- a/pkg/service/backup/service_backup_restore_integration_test.go
+++ b/pkg/service/backup/service_backup_restore_integration_test.go
@@ -443,33 +443,6 @@ func TestRestoreTablesNodeDownIntegration(t *testing.T) {
 	restoreWithNodeDown(t, target, testKeyspace, testLoadCnt, testLoadSize)
 }
 
-func TestRestoreSchemaNodeDownIntegration(t *testing.T) {
-	const (
-		testBucket    = "restoretest-schema-node-down"
-		testKeyspace  = "restoretest_schema_node_down"
-		testLoadCnt   = 1
-		testLoadSize  = 1
-		testBatchSize = 2
-		testParallel  = 1
-	)
-
-	target := RestoreTarget{
-		Location: []Location{
-			{
-				DC:       "dc1",
-				Provider: S3,
-				Path:     testBucket,
-			},
-		},
-		Keyspace:      []string{"system_schema"},
-		BatchSize:     testBatchSize,
-		Parallel:      testParallel,
-		RestoreSchema: true,
-	}
-
-	restoreWithNodeDown(t, target, testKeyspace, testLoadCnt, testLoadSize)
-}
-
 func restoreWithNodeDown(t *testing.T, target RestoreTarget, keyspace string, loadCnt, loadSize int) {
 	Print("Given: downed node")
 	if stdout, stderr, err := ExecOnHost("192.168.100.11", CmdBlockScyllaREST); err != nil {


### PR DESCRIPTION
This PR separates workflow of restoring schema and tables. The main differences are:
- restoring tables requires altering ggs which is forbidden on schema tables
- restoring schema duplicates data across all nodes in order to simulate repair
- restoring schema cannot be resumed and monitoring of its progress is rather weak
- restoring schema does not show data duplication on metrics and progress

Even though it might look like a regression, restoring schema should have much bigger success ratio with those changes.

Sorry for such a big commit, but those changes couldn't really be divided because of all the refactor that needed to be done at once.