### PR TITLE
Additional validation for restore hosts

### DIFF
--- a/pkg/scyllaclient/client_ping.go
+++ b/pkg/scyllaclient/client_ping.go
@@ -20,7 +20,7 @@ import (
 	"go.uber.org/multierr"
 )
 
-// GetLiveNodesWithLocationAccess returns subset of nodes that passed connectivity check
+// GetLiveNodesWithLocationAccess returns subset of nodes which are UN, passed connectivity check
 // and have access to remote location.
 func (c *Client) GetLiveNodesWithLocationAccess(ctx context.Context, nodes NodeStatusInfoSlice, remotePath string) (NodeStatusInfoSlice, error) {
 	liveNodes, err := c.GetLiveNodes(ctx, nodes)
@@ -28,8 +28,12 @@ func (c *Client) GetLiveNodesWithLocationAccess(ctx context.Context, nodes NodeS
 		return nil, err
 	}
 
-	nodeErr := make([]error, len(liveNodes))
+	liveNodes = liveNodes.Live()
+	if len(liveNodes) == 0 {
+		return nil, errors.New("no live (UN) nodes")
+	}
 
+	nodeErr := make([]error, len(liveNodes))
 	err = parallel.Run(len(liveNodes), parallel.NoLimit, func(i int) error {
 		n := liveNodes[i]
 


### PR DESCRIPTION
This PR adds validation of UN state for nodes which will be performing restore. Drained nodes cannot use load and stream, so this change is necessary.

Fixes #3344
Fixes #3342

This type of validation might be additionally required in restore schema workflow in #3339