### PR TITLE
Do not restore CDC tables

### DIFF
--- a/pkg/service/backup/testdata/restore/get_target/continue_false.golden.json
+++ b/pkg/service/backup/testdata/restore/get_target/continue_false.golden.json
@@ -4,10 +4,13 @@
   ],
   "keyspace": [
     "*",
-    "!system_schema"
+    "!system_schema",
+    "!system_distributed_everywhere.cdc_generation_descriptions_v2",
+    "!system_distributed cdc_streams_descriptions_v2",
+    "!system_distributed.cdc_generation_timestamps",
+    "!*.*_scylla_cdc_log"
   ],
   "snapshot_tag": "sm_20060102150405UTC",
   "batch_size": 2,
-  "parallel": 0,
   "restore_tables": true
 }

--- a/pkg/service/backup/testdata/restore/get_target/default_values.golden.json
+++ b/pkg/service/backup/testdata/restore/get_target/default_values.golden.json
@@ -4,11 +4,14 @@
   ],
   "keyspace": [
     "*",
-    "!system_schema"
+    "!system_schema",
+    "!system_distributed_everywhere.cdc_generation_descriptions_v2",
+    "!system_distributed cdc_streams_descriptions_v2",
+    "!system_distributed.cdc_generation_timestamps",
+    "!*.*_scylla_cdc_log"
   ],
   "snapshot_tag": "sm_20060102150405UTC",
   "batch_size": 2,
-  "parallel": 0,
   "restore_tables": true,
   "continue": true
 }

--- a/pkg/service/backup/testdata/restore/get_target/schema.golden.json
+++ b/pkg/service/backup/testdata/restore/get_target/schema.golden.json
@@ -7,7 +7,6 @@
   ],
   "snapshot_tag": "sm_20060102150405UTC",
   "batch_size": 99,
-  "parallel": 0,
   "restore_schema": true,
   "continue": true
 }

--- a/pkg/service/backup/testdata/restore/get_target/tables.golden.json
+++ b/pkg/service/backup/testdata/restore/get_target/tables.golden.json
@@ -5,7 +5,11 @@
   "keyspace": [
     "my_keyspace.*",
     "!my_keyspace.my_table",
-    "!system_schema"
+    "!system_schema",
+    "!system_distributed_everywhere.cdc_generation_descriptions_v2",
+    "!system_distributed cdc_streams_descriptions_v2",
+    "!system_distributed.cdc_generation_timestamps",
+    "!*.*_scylla_cdc_log"
   ],
   "snapshot_tag": "sm_20060102150405UTC",
   "batch_size": 99,


### PR DESCRIPTION
We cannot restore CDC tables because SM cannot alter them and ensure data consistency.
Fixes #3347