### PR TITLE
Tests for restoring scylla tables

### DIFF
--- a/pkg/service/backup/restore.go
+++ b/pkg/service/backup/restore.go
@@ -49,13 +49,14 @@ func (s *Service) GetRestoreTarget(ctx context.Context, clusterID uuid.UUID, pro
 		}
 		// Skip restoration of those tables regardless of the '--keyspace' param
 		doNotRestore := []string{
+			"system",        // system.* tables are recreated on every cluster and shouldn't even be backed-up
 			"system_schema", // Schema restoration is only possible with '--restore-schema' flag
 			// Don't restore tables related to CDC.
 			// Currently, it is forbidden to alter those tables, so SM wouldn't be able to ensure their data consistency.
 			// Moreover, those tables usually contain data with small TTL value,
 			// so their contents would probably expire right after restore has ended.
 			"system_distributed_everywhere.cdc_generation_descriptions_v2",
-			"system_distributed cdc_streams_descriptions_v2",
+			"system_distributed.cdc_streams_descriptions_v2",
 			"system_distributed.cdc_generation_timestamps",
 			"*.*_scylla_cdc_log", // All regular CDC tables have "_scylla_cdc_log" suffix
 		}

--- a/pkg/service/backup/restore_worker_tables.go
+++ b/pkg/service/backup/restore_worker_tables.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2023 ScyllaDB
+
 package backup
 
 import (

--- a/pkg/service/backup/testdata/restore/get_target/continue_false.golden.json
+++ b/pkg/service/backup/testdata/restore/get_target/continue_false.golden.json
@@ -4,9 +4,10 @@
   ],
   "keyspace": [
     "*",
+    "!system",
     "!system_schema",
     "!system_distributed_everywhere.cdc_generation_descriptions_v2",
-    "!system_distributed cdc_streams_descriptions_v2",
+    "!system_distributed.cdc_streams_descriptions_v2",
     "!system_distributed.cdc_generation_timestamps",
     "!*.*_scylla_cdc_log"
   ],

--- a/pkg/service/backup/testdata/restore/get_target/default_values.golden.json
+++ b/pkg/service/backup/testdata/restore/get_target/default_values.golden.json
@@ -4,9 +4,10 @@
   ],
   "keyspace": [
     "*",
+    "!system",
     "!system_schema",
     "!system_distributed_everywhere.cdc_generation_descriptions_v2",
-    "!system_distributed cdc_streams_descriptions_v2",
+    "!system_distributed.cdc_streams_descriptions_v2",
     "!system_distributed.cdc_generation_timestamps",
     "!*.*_scylla_cdc_log"
   ],

--- a/pkg/service/backup/testdata/restore/get_target/tables.golden.json
+++ b/pkg/service/backup/testdata/restore/get_target/tables.golden.json
@@ -5,9 +5,10 @@
   "keyspace": [
     "my_keyspace.*",
     "!my_keyspace.my_table",
+    "!system",
     "!system_schema",
     "!system_distributed_everywhere.cdc_generation_descriptions_v2",
-    "!system_distributed cdc_streams_descriptions_v2",
+    "!system_distributed.cdc_streams_descriptions_v2",
     "!system_distributed.cdc_generation_timestamps",
     "!*.*_scylla_cdc_log"
   ],


### PR DESCRIPTION
This PR fixes bug in restore cdc tables blacklisting.
Moreover, it adds test for restoring Scylla tables `system_auth.* system_traces.* system_distributed.service_levels`.
