### PR TITLE
Remind about resetting tombstone_gc after restore

### DIFF
--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -992,7 +992,7 @@ func (rp RestoreProgress) status() string {
 		if len(rp.Progress.Keyspaces) == 1 && rp.Progress.Keyspaces[0].Keyspace == "system_schema" {
 			return "DONE - restart required (see restore docs)"
 		}
-		return "DONE - repair required (see restore docs)"
+		return "DONE - tombstone_gc mode reset and repair required (see restore docs)"
 	}
 	return s
 }


### PR DESCRIPTION
This PR reminds user to also reset tombstone_gc mode (alongside repair) after successful restore.
