### PR TITLE
Run integration tests in parallel in github actions

### DIFF
--- a/.github/actions/test-setup/action.yml
+++ b/.github/actions/test-setup/action.yml
@@ -1,0 +1,32 @@
+name: "Set up testing dependencies"
+description: "Set up GO, package dependencies and install-dependencies"
+inputs:
+  start-dev-env:
+    description: "Should this action run 'make start-dev-env'"
+    required: false
+    default: 'true'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: ./go.mod
+        cache-dependency-path: '**/go.sum'
+
+    - name: Restore dependencies
+      uses: actions/cache@v3
+      id: cache-dependencies
+      with:
+        path: ~/work/scylla-manager/scylla-manager/bin
+        key: ${{ runner.os }}-${{ hashFiles('~/work/scylla-manager/scylla-manager/install-dependencies.sh', '~/work/scylla-manager/scylla-manager/mod/go.sum') }}
+
+    - name: Install dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: ./install-dependencies.sh
+      shell: bash
+
+    - name: Start dev env
+      if: inputs.start-dev-env == 'true'
+      run: make start-dev-env
+      shell: bash

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,92 +8,115 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  sanity:
-    name: Sanity check
-    runs-on: ubuntu-latest
-    steps:
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Set Go version
-        run: |
-          echo "GOVERSION=$(cat .go-version)" >> $GITHUB_ENV
-
-      - name: Set up Go
-        uses: actions/setup-go@v1
-        id: go
-        with:
-          go-version: "${{env.GOVERSION}}"
-
-      - name: Set up env variables
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-          echo "$(go env -w GOCACHE=/home/runner/work/scylla-manager/scylla-manager/.cache/go-build/)"
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-          echo "GOCACHEPATTERN=.cache/go-build/**" >> $GITHUB_ENV
-          echo "date=$(date  +'%m-%Y')" >> $GITHUB_ENV
-
-      - name: Restore Module Cache
-        uses: actions/cache@v2
-        id: cache-go-modules
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Restore dependencies
-        uses: actions/cache@v2
-        id: cache-dependencies
-        with:
-         path: ~/work/scylla-manager/scylla-manager/bin
-         key: ${{ runner.os }}-${{ hashFiles('**/install-dependencies.sh', '**/mod/go.sum') }}
-
-      - name: Install dependencies
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
-        run: |
-          ./install-dependencies.sh
-
-      - name: Unit Tests
-        run: |
-          make unit-test
-
-      - name: Lint
-        run: |
-          make .check-lint
-  integration:
-    name: Integration tests
+  checks:
+    name: Various checks
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-      - name: Set Go version
-        run: |
-          echo "GOVERSION=$(cat .go-version)" >> $GITHUB_ENV
-      - name: Set up Go
-        uses: actions/setup-go@v1
-        id: go
+        uses: actions/checkout@v3
+
+      - name: Setup testing dependencies
+        uses: ./.github/actions/test-setup
         with:
-          go-version: "${{env.GOVERSION}}"
-      - name: Set up env variables
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-          echo "$(go env -w GOCACHE=/home/runner/work/scylla-manager/scylla-manager/.cache/go-build/)"
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-          echo "GOCACHEPATTERN=.cache/go-build/**" >> $GITHUB_ENV
-          echo "date=$(date  +'%m-%Y')" >> $GITHUB_ENV
-      - name: Install dependencies
-        if: steps.cache-dependencies.outputs.cache-hit != 'true'
-        run: |
-          ./install-dependencies.sh
-      - name: Setup test environment
-        run: |
-          make start-dev-env
-      - name: Integration tests
-        run: |
-          make integration-test
+          start-dev-env: false
+
+      - name: Run checks
+        run: make check
+
+      - name: Run unit tests
+        run: make unit-test
+
+  # Right now both restore-tables and restore-schema tests take way longer than any other pkg tests.
+  # For this reason they are divided into two distinct jobs, so that the whole workflow can be executed faster.
+  restore-tables:
+    name: Test restore tables
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Setup testing dependencies
+        uses: ./.github/actions/test-setup
+
+      - name: Run tests
+        run: make pkg-integration-test PKG=./pkg/service/backup RUN='"TestRestoreTables.*Integration"'
+
+  restore-schema:
+    name: Test restore schema
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Setup testing dependencies
+        uses: ./.github/actions/test-setup
+
+        # Go does not support negative lookahead in regex expressions, so it has to be done manually.
+        # This regex ensures that all restore tests that didn't match restore-tables job will be run here.
+      - name: Run tests
+        run: make pkg-integration-test PKG=./pkg/service/backup RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+
+  backup:
+    name: Test backup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Setup testing dependencies
+        uses: ./.github/actions/test-setup
+
+        # Until backup and restore live in the same pkg, we have to use regex to separate their tests.
+        # The same negative lookahead workaround as in restore-schema.
+      - name: Run tests
+        run: make pkg-integration-test PKG=./pkg/service/backup RUN='"Test([^R]|.{1}[^e]|.{2}[^s]|.{3}[^t]|.{4}[^o]|.{5}[^r]|.{6}[^e]).*Integration"'
+
+  repair:
+    name: Test repair
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Setup testing dependencies
+        uses: ./.github/actions/test-setup
+
+      - name: Run tests
+        run: make pkg-integration-test PKG=./pkg/service/repair
+
+  small-pkg:
+    name: Test other, smaller packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Setup testing dependencies
+        uses: ./.github/actions/test-setup
+
+      - name: Run cqlping tests
+        run: make pkg-integration-test PKG=./pkg/ping/cqlping
+
+      - name: Run dynamoping tests
+        run: make pkg-integration-test PKG=./pkg/ping/dynamoping
+
+      - name: Run scyllaclient tests
+        run: make pkg-integration-test PKG=./pkg/scyllaclient
+
+      - name: Run cluster tests
+        run: make pkg-integration-test PKG=./pkg/service/cluster
+
+      - name: Run healthcheck tests
+        run: make pkg-integration-test PKG=./pkg/service/healthcheck
+
+      - name: Run scheduler tests
+        run: make pkg-integration-test PKG=./pkg/service/scheduler
+
+      - name: Run store tests
+        run: make pkg-integration-test PKG=./pkg/store
+
+      - name: Run migrate tests
+        run: make pkg-integration-test PKG=./pkg/schema/migrate
+
+      - name: Run netwait tests
+        run: make pkg-integration-test PKG=./pkg/util/netwait

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -3,6 +3,7 @@ all: help
 COMPOSE    := docker-compose
 CQLSH      := $(COMPOSE) exec scylla-manager-db cqlsh
 CQLSH_NODE := $(COMPOSE) exec -T dc1_node_1 cqlsh
+NODETOOL   := $(COMPOSE) exec -T dc1_node_1 nodetool
 YQ         := ../bin/yq
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
@@ -39,7 +40,7 @@ endif
 	$(COMPOSE) exec -T --privileged dc1_node_1 sudo bash -c 'echo "fs.aio-max-nr = 1048579" > /etc/sysctl.d/50-scylla.conf'
 	$(COMPOSE) exec -T --privileged dc1_node_1 sudo sysctl -p /etc/sysctl.d/50-scylla.conf
 	@echo "==> Waiting for cluster"
-	@until $(CQLSH_NODE) 192.168.100.11 -e "DESCRIBE SCHEMA" > /dev/null ; do echo "..."; sleep 2; done
+	@until [ 6 -eq $$($(NODETOOL) status | grep -c "UN") ]; do echo "..."; sleep 2; done
 	@./nodes_exec rm /root/.cqlshrc
 	@echo "==> Adding Minio user"
 	./minio/add_user.sh


### PR DESCRIPTION
This PR refactors environment set up, so that it's cleaner and reusable.
It also makes github actions run each pkg test in a separate job in parallel. 
In order to further improve performance:
- backup and restore tests have been separated into different jobs (even though they live in the same pkg #3381)
- restore tables tests and restore schema tests have been further divided into different jobs (because both of them take huge amount of time)
- tests for smaller packages have been merged into one job (we don't need to set up env for each of them separately)

Fixes #3372
