### PR TITLE
Improve sctool tasks/info readability

### DIFF
--- a/pkg/command/info/cmd.go
+++ b/pkg/command/info/cmd.go
@@ -58,13 +58,16 @@ func (cmd *command) run(args []string) error {
 
 	w := cmd.OutOrStdout()
 
-	task, err := cmd.client.GetTask(cmd.Context(), cmd.cluster, taskType, taskID)
+	tasks, err := cmd.client.ListTasks(cmd.Context(), cmd.cluster, taskType, true, "", taskID.String())
 	if err != nil {
 		return err
 	}
+	if len(tasks.TaskListItemSlice) != 1 {
+		return fmt.Errorf("expected exactly 1 task, got %d", len(tasks.TaskListItemSlice))
+	}
 
 	ti := managerclient.TaskInfo{
-		Task: task,
+		TaskListItem: tasks.TaskListItemSlice[0],
 	}
 	if err := ti.Render(w); err != nil {
 		return err

--- a/pkg/command/legacy/task/tasklist/cmd.go
+++ b/pkg/command/legacy/task/tasklist/cmd.go
@@ -72,7 +72,7 @@ func (cmd *command) run() error {
 
 	w := cmd.OutOrStdout()
 	h := func(clusterID string) error {
-		tasks, err := cmd.client.ListTasks(cmd.Context(), clusterID, cmd.taskType, cmd.all, cmd.status)
+		tasks, err := cmd.client.ListTasks(cmd.Context(), clusterID, cmd.taskType, cmd.all, cmd.status, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/command/tasks/cmd.go
+++ b/pkg/command/tasks/cmd.go
@@ -76,7 +76,7 @@ func (cmd *command) run() error {
 
 	w := cmd.OutOrStdout()
 	h := func(clusterID string) error {
-		tasks, err := cmd.client.ListTasks(cmd.Context(), clusterID, cmd.taskType, cmd.all, cmd.status)
+		tasks, err := cmd.client.ListTasks(cmd.Context(), clusterID, cmd.taskType, cmd.all, cmd.status, "")
 		if err != nil {
 			return err
 		}

--- a/pkg/managerclient/client.go
+++ b/pkg/managerclient/client.go
@@ -338,13 +338,14 @@ func (c *Client) UpdateTask(ctx context.Context, clusterID string, t *Task) erro
 }
 
 // ListTasks returns tasks within a clusterID, optionally filtered by task type tp.
-func (c *Client) ListTasks(ctx context.Context, clusterID, taskType string, all bool, status string) (TaskListItems, error) {
+func (c *Client) ListTasks(ctx context.Context, clusterID, taskType string, all bool, status string, taskID string) (TaskListItems, error) {
 	resp, err := c.operations.GetClusterClusterIDTasks(&operations.GetClusterClusterIDTasksParams{
 		Context:   ctx,
 		ClusterID: clusterID,
 		Type:      &taskType,
 		All:       &all,
 		Status:    &status,
+		TaskID:    &taskID,
 	})
 	if err != nil {
 		return TaskListItems{}, err

--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -14,9 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-manager/v3/pkg/managerclient/table"
-	"github.com/scylladb/scylla-manager/v3/pkg/util/duration"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/inexlist"
-	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/version"
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla-manager/models"
 	"github.com/scylladb/termtables"
@@ -467,22 +465,6 @@ type TaskListItems struct {
 
 // Render renders TaskListItems in a tabular format.
 func (li TaskListItems) Render(w io.Writer) error {
-	now := timeutc.Now()
-
-	ago := func(t *strfmt.DateTime) string {
-		if t == nil {
-			return ""
-		}
-		return duration.Duration(now.Sub(time.Time(*t)).Truncate(time.Second)).String() + " ago"
-	}
-
-	in := func(t *strfmt.DateTime) string {
-		if t == nil {
-			return ""
-		}
-		return "in " + duration.Duration(time.Time(*t).Sub(now).Truncate(time.Second)).String()
-	}
-
 	var doneRestoreTask bool
 
 	columns := []any{"Task", "Schedule", "Window", "Timezone", "Success", "Error", "Last Success", "Last Error", "Status", "Next"}
@@ -521,12 +503,12 @@ func (li TaskListItems) Render(w io.Writer) error {
 		if t.Suspended {
 			next = "[SUSPENDED]"
 		} else {
-			next = in(t.NextActivation)
+			next = FormatTimePointer(t.NextActivation)
 		}
 
 		row := []any{
 			id, schedule, strings.Join(t.Schedule.Window, ","), t.Schedule.Timezone,
-			t.SuccessCount, t.ErrorCount, ago(t.LastSuccess), ago(t.LastError),
+			t.SuccessCount, t.ErrorCount, FormatTimePointer(t.LastSuccess), FormatTimePointer(t.LastError),
 			status, next,
 		}
 		if li.ShowProps {

--- a/pkg/rclone/operations/errors_test.go
+++ b/pkg/rclone/operations/errors_test.go
@@ -14,7 +14,7 @@ func TestParseAWSError(t *testing.T) {
 		err404 := errors.New(`s3 upload: 404 Not Found: <?xml version="1.0" encoding="UTF-8"?>
 	<Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist</Message><BucketName>backuptest-rclone</BucketName><RequestId>5ZYP7GJWCJE67BDY</RequestId><HostId>254h+dP3mw7YqUJKSyfUgAPl+wxT8yLiqSgRb6Somygc/N5a/bu144Lw1bmD1bbRB0YLquP2+iY=</HostId></Error>`)
 
-		e, err := parseAWSError(err404)
+		e, err := ParseBackendXMLError(err404)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -23,7 +23,7 @@ func TestParseAWSError(t *testing.T) {
 
 	t.Run("not XML", func(t *testing.T) {
 		errNet := &net.AddrError{}
-		_, err := parseAWSError(errNet)
+		_, err := ParseBackendXMLError(errNet)
 		if err == nil {
 			t.Fatal("expected error")
 		}
@@ -33,7 +33,7 @@ func TestParseAWSError(t *testing.T) {
 	t.Run("invalid XML", func(t *testing.T) {
 		errFoo := errors.New(`<?xml version="1.0" encoding="UTF-8"?><Foo></Foo>`)
 
-		_, err := parseAWSError(errFoo)
+		_, err := ParseBackendXMLError(errFoo)
 		if err == nil {
 			t.Fatal("expected error")
 		}

--- a/pkg/rclone/operations/operations.go
+++ b/pkg/rclone/operations/operations.go
@@ -29,7 +29,7 @@ func asPermissionError(op string, l fs.Fs, err error) PermissionError {
 	statusCode := 400
 
 	if l.Name() == "s3" {
-		e, _ := parseAWSError(err) // nolint: errcheck
+		e, _ := ParseBackendXMLError(err) // nolint: errcheck
 		if e != nil {
 			err = e
 		} else {

--- a/pkg/rclone/rcserver/rcserver.go
+++ b/pkg/rclone/rcserver/rcserver.go
@@ -92,7 +92,10 @@ func (s Server) writeError(path string, in rc.Params, w http.ResponseWriter, err
 			status = http.StatusForbidden
 		}
 	}
-
+	// Try to parse xml errors for increased readability
+	if xmlErr, e := operations.ParseBackendXMLError(err); e == nil {
+		err = xmlErr
+	}
 	w.WriteHeader(status)
 	err = s.writeJSON(w, rc.Params{
 		"status":  status,

--- a/pkg/restapi/task.go
+++ b/pkg/restapi/task.go
@@ -126,6 +126,13 @@ func (h *taskHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	if s := r.FormValue("task_id"); s != "" {
+		filter.TaskID, err = uuid.Parse(s)
+		if err != nil {
+			respondBadRequest(w, r, err)
+			return
+		}
+	}
 
 	cid := mustClusterIDFromCtx(r)
 	tasks, err := h.Scheduler.ListTasks(r.Context(), cid, filter)

--- a/pkg/scyllaclient/client_ping.go
+++ b/pkg/scyllaclient/client_ping.go
@@ -53,7 +53,7 @@ func (c *Client) GetLiveNodesWithLocationAccess(ctx context.Context, nodes NodeS
 		nodeErr[i] = err
 
 		return nil
-	})
+	}, parallel.NopNotify)
 	if err != nil {
 		return nil, errors.Wrap(err, "check location access")
 	}

--- a/pkg/service/healthcheck/service.go
+++ b/pkg/service/healthcheck/service.go
@@ -161,7 +161,7 @@ func (s *Service) parallelNodeInfoFunc(ctx context.Context, clusterID uuid.UUID,
 				s.decorateNodeStatus(&out[i], ni)
 			}
 			return
-		})
+		}, parallel.NopNotify)
 	}
 }
 
@@ -202,7 +202,7 @@ func (s *Service) parallelRESTPingFunc(ctx context.Context, clusterID uuid.UUID,
 			}
 
 			return
-		})
+		}, parallel.NopNotify)
 	}
 }
 
@@ -255,7 +255,7 @@ func (s *Service) parallelCQLPingFunc(ctx context.Context, clusterID uuid.UUID, 
 			}
 
 			return
-		})
+		}, parallel.NopNotify)
 	}
 }
 
@@ -299,7 +299,7 @@ func (s *Service) parallelAlternatorPingFunc(ctx context.Context, clusterID uuid
 			}
 
 			return
-		})
+		}, parallel.NopNotify)
 	}
 }
 

--- a/pkg/service/scheduler/service_list.go
+++ b/pkg/service/scheduler/service_list.go
@@ -27,6 +27,7 @@ type ListFilter struct {
 	Disabled bool
 	Deleted  bool
 	Short    bool
+	TaskID   uuid.UUID
 }
 
 // ListTasks returns cluster tasks given the filtering criteria.
@@ -61,6 +62,9 @@ func (s *Service) ListTasks(ctx context.Context, clusterID uuid.UUID, filter Lis
 		b.Where(qb.In("status"))
 		b.AllowFiltering()
 		m["status"] = filter.Status
+	}
+	if filter.TaskID != uuid.Nil {
+		b.Where(qb.EqLit("id", filter.TaskID.String()))
 	}
 
 	q := b.Query(s.session)

--- a/pkg/tools/filler/filler.go
+++ b/pkg/tools/filler/filler.go
@@ -50,7 +50,7 @@ func (f *Filler) Run(ctx context.Context) error {
 
 	f.ctx = ctx
 
-	if err := parallel.Run(f.parallel, parallel.NoLimit, f.fill); err != nil {
+	if err := parallel.Run(f.parallel, parallel.NoLimit, f.fill, parallel.NopNotify); err != nil {
 		return errors.Wrap(err, "fill data")
 	}
 
@@ -128,11 +128,11 @@ func NewMultiFiller(tables int, session gocqlx.Session, size, bufSize int64, par
 func (f *MultiFiller) Run(ctx context.Context) error {
 	f.ctx = ctx
 
-	if err := parallel.Run(f.tables, runtime.NumCPU(), f.create); err != nil {
+	if err := parallel.Run(f.tables, runtime.NumCPU(), f.create, parallel.NopNotify); err != nil {
 		return errors.Wrap(err, "create table")
 	}
 
-	if err := parallel.Run(f.parallel, parallel.NoLimit, f.fill); err != nil {
+	if err := parallel.Run(f.parallel, parallel.NoLimit, f.fill, parallel.NopNotify); err != nil {
 		return errors.Wrap(err, "fill data")
 	}
 

--- a/pkg/util/parallel/parallel_test.go
+++ b/pkg/util/parallel/parallel_test.go
@@ -62,7 +62,7 @@ func TestRun(t *testing.T) {
 			}
 
 			start := timeutc.Now()
-			if err := Run(n, test.Limit, f); err != nil {
+			if err := Run(n, test.Limit, f, NopNotify); err != nil {
 				t.Error("Run() error", err)
 			}
 			d := timeutc.Since(start)
@@ -104,7 +104,7 @@ func TestAbort(t *testing.T) {
 		return Abort(errors.New("boo"))
 	}
 
-	if err := Run(10, 1, f); err == nil {
+	if err := Run(10, 1, f, NopNotify); err == nil {
 		t.Error("Run() expected error")
 	}
 
@@ -116,7 +116,7 @@ func TestAbort(t *testing.T) {
 func TestEmpty(t *testing.T) {
 	t.Parallel()
 
-	if err := Run(0, NoLimit, nil); err != nil {
+	if err := Run(0, NoLimit, nil, NopNotify); err != nil {
 		t.Fatal("Run() error", err)
 	}
 }

--- a/swagger/gen/scylla-manager/client/operations/get_cluster_cluster_id_tasks_parameters.go
+++ b/swagger/gen/scylla-manager/client/operations/get_cluster_cluster_id_tasks_parameters.go
@@ -70,6 +70,8 @@ type GetClusterClusterIDTasksParams struct {
 	Short *bool
 	/*Status*/
 	Status *string
+	/*TaskID*/
+	TaskID *string
 	/*Type*/
 	Type *string
 
@@ -155,6 +157,17 @@ func (o *GetClusterClusterIDTasksParams) SetStatus(status *string) {
 	o.Status = status
 }
 
+// WithTaskID adds the taskID to the get cluster cluster ID tasks params
+func (o *GetClusterClusterIDTasksParams) WithTaskID(taskID *string) *GetClusterClusterIDTasksParams {
+	o.SetTaskID(taskID)
+	return o
+}
+
+// SetTaskID adds the taskId to the get cluster cluster ID tasks params
+func (o *GetClusterClusterIDTasksParams) SetTaskID(taskID *string) {
+	o.TaskID = taskID
+}
+
 // WithType adds the typeVar to the get cluster cluster ID tasks params
 func (o *GetClusterClusterIDTasksParams) WithType(typeVar *string) *GetClusterClusterIDTasksParams {
 	o.SetType(typeVar)
@@ -221,6 +234,22 @@ func (o *GetClusterClusterIDTasksParams) WriteToRequest(r runtime.ClientRequest,
 		qStatus := qrStatus
 		if qStatus != "" {
 			if err := r.SetQueryParam("status", qStatus); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.TaskID != nil {
+
+		// query param task_id
+		var qrTaskID string
+		if o.TaskID != nil {
+			qrTaskID = *o.TaskID
+		}
+		qTaskID := qrTaskID
+		if qTaskID != "" {
+			if err := r.SetQueryParam("task_id", qTaskID); err != nil {
 				return err
 			}
 		}

--- a/swagger/scylla-manager.json
+++ b/swagger/scylla-manager.json
@@ -1257,6 +1257,12 @@
             "in": "query",
             "type": "boolean",
             "required": false
+          },
+          {
+            "name": "task_id",
+            "in": "query",
+            "type": "string",
+            "required": false
           }
         ],
         "responses": {


### PR DESCRIPTION
This PR changes 4 main things:
- show full next activation date (not just delta) in `sctool tasks`
- show next activation date in `sctool info` even for non-standard cron (e.g. `--interval '7d'`, `--cron '@every 2h'`)
- log errors in `parallel.Run` instead of appending them (return only 1 error)
- parse XML backed errors before returning them to SM

Fixes #3333