### PR TITLE
dist/Makefile: switch to `--clean` instead of `--rm-dist`

### DIFF
--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -10,6 +10,8 @@ changelog:
       - '^makefile:'
       - '^testing:'
 
+snapshot:
+    name_template: '{{ .Version }}-SNAPSHOT'
 builds:
   - id: server
     dir: ../pkg
@@ -63,22 +65,22 @@ builds:
       - -X github.com/scylladb/scylla-manager/v3/pkg.version={{ .Version }}
 
 archives:
-  - name_template: "{{ .ProjectName }}_{{ .Version }}.{{ .Os }}_{{ .Arch }}"
+  - name_template: >-
+      {{ .ProjectName }}_{{ .Version }}.{{ .Os }}_{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "arm64" }}aarch64{{ end }}
     files:
       - etc
       - license/LICENSE*
       - scripts
       - systemd
-    replacements:
-      amd64: x86_64
-      arm64: aarch64
+    rlcp: true
 
 nfpms:
   - id: server
     builds:
       - server
     package_name: "scylla-manager-server"
-    file_name_template: "{{ .ProjectName }}-server-{{ .Version }}_{{ .Os }}.{{ .Arch }}"
+    file_name_template: >-
+      {{ .ProjectName }}-server-{{ .Version }}_{{ .Os }}.{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "arm64" }}aarch64{{ end }}
     vendor: ScyllaDB
     homepage: https://www.scylladb.com/product/scylla-manager/
     maintainer: Michał Jan Matczuk <michal@scylladb.com>
@@ -120,16 +122,15 @@ nfpms:
       deb:
         conflicts:
           - scylla-manager
-        file_name_template: "{{ .ProjectName }}-server_{{ .Version }}.{{ .Os }}_{{ .Arch }}"
+        file_name_template: >-
+          {{ .ProjectName }}-server_{{ .Version }}.{{ .Os }}_{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "arm64" }}aarch64{{ end }}
+
         scripts:
           preinstall: deb/scylla-manager-server.preinst
           postinstall: deb/scylla-manager-server.postinst
           preremove: deb/scylla-manager-server.prerm
           postremove: deb/scylla-manager-server.postrm
       rpm:
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
         scripts:
           preinstall: rpm/scylla-manager-server.preinst
           postinstall: rpm/scylla-manager-server.postinst
@@ -140,7 +141,8 @@ nfpms:
     builds:
       - client
     package_name: "scylla-manager-client"
-    file_name_template: "{{ .ProjectName }}-client-{{ .Version }}_{{ .Os }}.{{ .Arch }}"
+    file_name_template: >-
+      {{ .ProjectName }}-client-{{ .Version }}_{{ .Os }}.{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "arm64" }}aarch64{{ end }}
     vendor: ScyllaDB
     homepage: https://www.scylladb.com/product/scylla-manager/
     maintainer: Michał Jan Matczuk <michal@scylladb.com>
@@ -165,13 +167,11 @@ nfpms:
       compression: xz
     overrides:
       deb:
-        file_name_template: "{{ .ProjectName }}-client_{{ .Version }}.{{ .Os }}_{{ .Arch }}"
+        file_name_template: >-
+          {{ .ProjectName }}-client_{{ .Version }}.{{ .Os }}_{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "arm64" }}aarch64{{ end }}
         scripts:
           postinstall: deb/scylla-manager-client.postinst
       rpm:
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
         scripts:
           postinstall: rpm/scylla-manager-client.postinst
 
@@ -179,7 +179,8 @@ nfpms:
     builds:
       - agent
     package_name: "scylla-manager-agent"
-    file_name_template: "{{ .ProjectName }}-agent-{{ .Version }}_{{ .Os }}.{{ .Arch }}"
+    file_name_template: >-
+      {{ .ProjectName }}-agent-{{ .Version }}_{{ .Os }}.{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "arm64" }}aarch64{{ end }}
     vendor: ScyllaDB
     homepage: https://www.scylladb.com/product/scylla-manager/
     maintainer: Michał Jan Matczuk <michal@scylladb.com>
@@ -215,16 +216,14 @@ nfpms:
       compression: xz
     overrides:
       deb:
-        file_name_template: "{{ .ProjectName }}-agent_{{ .Version }}.{{ .Os }}_{{ .Arch }}"
+        file_name_template: >-
+          {{ .ProjectName }}-agent_{{ .Version }}.{{ .Os }}_{{- if eq .Arch "amd64" }}x86_64{{- else if eq .Arch "arm64" }}aarch64{{ end }}
         scripts:
           preinstall: deb/scylla-manager-agent.preinst
           postinstall: deb/scylla-manager-agent.postinst
           preremove: deb/scylla-manager-agent.prerm
           postremove: deb/scylla-manager-agent.postrm
       rpm:
-        replacements:
-          amd64: x86_64
-          arm64: aarch64
         scripts:
           preinstall: rpm/scylla-manager-agent.preinst
           postinstall: rpm/scylla-manager-agent.postinst

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -9,7 +9,7 @@ VERSION_NAME := $(VERSION)-$(RELEASE)
 $(shell echo $(VERSION) > .version)
 $(shell echo $(RELEASE) > .release)
 
-GORELEASER := goreleaser --rm-dist
+GORELEASER := goreleaser --clean
 .PHONY: release
 release:
 	git tag $(VERSION_NAME) || true


### PR DESCRIPTION
During local build i noticed the following warning
```
• DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
• DEPRECATED: `archives.rlcp` will be the default soon, check https://goreleaser.com/deprecations#archivesrlcp for more info
• DEPRECATED: `archives.replacements` should not be used anymore, check https://goreleaser.com/deprecations#archivesreplacements for more info
• DEPRECATED: `nfpms.replacements` should not be used anymore, check https://goreleaser.com/deprecations#nfpmsreplacements for more info
• DEPRECATED: `nfpms.replacements` should not be used anymore, check https://goreleaser.com/deprecations#nfpmsreplacements for more info
• DEPRECATED: `nfpms.replacements` should not be used anymore, check https://goreleaser.com/deprecations#nfpmsreplacements for more info
```

when running `make snapshot` (in master), the default template is `{{ .Version }}-SNAPSHOT-{{.ShortCommit}}` , the `.ShortCommit` is redundant (already part of `.Version`), so removing it

