### PR TITLE
Add metric to report progress of the restore process

### DIFF
--- a/pkg/service/backup/restore.go
+++ b/pkg/service/backup/restore.go
@@ -5,6 +5,7 @@ package backup
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -186,10 +187,23 @@ func (s *Service) Restore(ctx context.Context, clusterID, taskID, runID uuid.UUI
 	}
 
 	var w restorer
-	if target.RestoreSchema {
-		w = &schemaWorker{restoreWorkerTools: tools}
+	ru, err := s.GetRestoreUnits(ctx, clusterID, target)
+	if err != nil {
+		return fmt.Errorf("could not get restore units for current restore run: %w", err)
+	}
+
+	var totalBytesToRestore int64
+	for _, unit := range ru {
+		totalBytesToRestore += unit.Size
+	}
+
+	if target.RestoreTables {
+		w = &tablesWorker{
+			restoreWorkerTools: tools,
+			progress:           NewTotalRestoreProgress(totalBytesToRestore),
+		}
 	} else {
-		w = &tablesWorker{restoreWorkerTools: tools}
+		w = &schemaWorker{restoreWorkerTools: tools}
 	}
 
 	if err = w.restore(ctx, run, target); err != nil {

--- a/pkg/service/backup/restore_worker_tables.go
+++ b/pkg/service/backup/restore_worker_tables.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/scylladb/go-set/strset"
+	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 )
@@ -18,6 +20,46 @@ type tablesWorker struct {
 
 	hosts        []restoreHost // Restore units created for currently restored location
 	continuation bool          // Defines if the worker is part of resume task that is the continuation of previous run
+	progress     *TotalRestoreProgress
+}
+
+// TotalRestoreProgress is a struct that holds information about the total progress of the restore job.
+type TotalRestoreProgress struct {
+	restoredBytes       int64
+	totalBytesToRestore int64
+	mu                  sync.RWMutex
+}
+
+func NewTotalRestoreProgress(totalBytesToRestore int64) *TotalRestoreProgress {
+	return &TotalRestoreProgress{
+		restoredBytes:       0,
+		totalBytesToRestore: totalBytesToRestore,
+	}
+}
+
+// CurrentProgress returns current progress of the restore job in percentage.
+func (p *TotalRestoreProgress) CurrentProgress() float64 {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.totalBytesToRestore == 0 {
+		return 100
+	}
+
+	if p.restoredBytes == 0 {
+		return 0
+	}
+
+	progress := float64(p.restoredBytes) / float64(p.totalBytesToRestore) * 100
+	return progress
+}
+
+// Update updates the progress of the restore job, caller should provide number of bytes restored by its job.
+func (p *TotalRestoreProgress) Update(bytesRestored int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.restoredBytes += bytesRestored
 }
 
 // restoreData restores files from every location specified in restore target.
@@ -26,7 +68,7 @@ func (w *tablesWorker) restore(ctx context.Context, run *RestoreRun, target Rest
 		w.continuation = true
 	}
 	if !w.continuation {
-		w.initRemainingBytesMetric(ctx, run, target)
+		w.initRestoreMetrics(ctx, run, target)
 	}
 
 	stageFunc := map[RestoreStage]func() error{
@@ -123,6 +165,7 @@ func (w *tablesWorker) locationRestoreHandler(ctx context.Context, run *RestoreR
 			continuation:       w.continuation,
 			hosts:              w.hosts,
 			miwc:               miwc,
+			progress:           w.progress,
 		}
 
 		return miwc.ForEachIndexIterWithError(target.Keyspace, iw.filesMetaRestoreHandler(ctx, run, target))
@@ -227,7 +270,7 @@ func (w *tablesWorker) stageRepair(ctx context.Context, run *RestoreRun, _ Resto
 	return w.repairSvc.Repair(ctx, run.ClusterID, run.RepairTaskID, repairRunID, repairTarget)
 }
 
-func (w *tablesWorker) initRemainingBytesMetric(ctx context.Context, run *RestoreRun, target RestoreTarget) {
+func (w *tablesWorker) initRestoreMetrics(ctx context.Context, run *RestoreRun, target RestoreTarget) {
 	for _, location := range target.Location {
 		err := w.forEachRestoredManifest(
 			ctx,
@@ -245,12 +288,25 @@ func (w *tablesWorker) initRemainingBytesMetric(ctx context.Context, run *Restor
 					})
 				for kspace, sizePerTable := range sizePerTableAndKeyspace {
 					for table, size := range sizePerTable {
-						w.metrics.SetRemainingBytes(run.ClusterID, target.SnapshotTag, location, miwc.DC, miwc.NodeID,
-							kspace, table, size)
+						labels := metrics.RestoreBytesLabels{
+							ClusterID:   run.ClusterID.String(),
+							SnapshotTag: target.SnapshotTag,
+							Location:    location.String(),
+							DC:          miwc.DC,
+							Node:        miwc.NodeID,
+							Keyspace:    kspace,
+							Table:       table,
+						}
+						w.metrics.SetRemainingBytes(labels, size)
 					}
 				}
 				return err
 			})
+		progressLabels := metrics.RestoreProgressLabels{
+			ClusterID:   run.ClusterID.String(),
+			SnapshotTag: target.SnapshotTag,
+		}
+		w.metrics.SetProgress(progressLabels, 0)
 		if err != nil {
 			w.Logger.Info(ctx, "Couldn't count restore data size", "location", w.location)
 			continue

--- a/pkg/service/backup/restore_worker_tables_test.go
+++ b/pkg/service/backup/restore_worker_tables_test.go
@@ -1,0 +1,63 @@
+// Copyright (C) 2023 ScyllaDB
+
+package backup_test
+
+import (
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
+)
+
+func TestTotalRestoreProgres(t *testing.T) {
+	type inputs struct {
+		restoredBytes       int64
+		totalBytesToRestore int64
+	}
+	tests := []struct {
+		name   string
+		fields inputs
+		want   float64
+	}{
+		{
+			name: "100% progress",
+			fields: inputs{
+				restoredBytes:       100,
+				totalBytesToRestore: 100,
+			},
+			want: 100,
+		},
+		{
+			name: "50% progress",
+			fields: inputs{
+				restoredBytes:       50,
+				totalBytesToRestore: 100,
+			},
+			want: 50,
+		},
+		{
+			name: "no bytes were restored yet",
+			fields: inputs{
+				restoredBytes:       0,
+				totalBytesToRestore: 100,
+			},
+			want: 0,
+		},
+		{
+			name: "empty restore, no bytes to restore",
+			fields: inputs{
+				restoredBytes:       0,
+				totalBytesToRestore: 0,
+			},
+			want: 100,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			progress := backup.NewTotalRestoreProgress(tt.fields.totalBytesToRestore)
+			progress.Update(tt.fields.restoredBytes)
+			if got := progress.CurrentProgress(); got != tt.want {
+				t.Errorf("CurrentProgress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes https://github.com/scylladb/scylla-manager/issues/3397

This PR introduces a new `progress` metric that reports progress of the restore process for a given `backup.RestoreTarget` target

Used 100MB backup to test this metric locally, here's the outcome.
![Screenshot 2023-07-04 at 09 55 23](https://github.com/scylladb/scylla-manager/assets/35968924/abbc382a-0ac1-4ed7-a579-f6a6cddaf9e8)



