### PR TITLE
Don't block backup on dumping schema error

### DIFF
--- a/pkg/service/backup/restore.go
+++ b/pkg/service/backup/restore.go
@@ -258,24 +258,22 @@ func (s *Service) forEachRestoredManifest(clusterID uuid.UUID, target RestoreTar
 
 // listAllViews is the utility function that queries system_schema.views table to get list of all views created on the cluster.
 // system_schema.views contains view definitions for materialized views and for secondary indexes.
-func (s *Service) listAllViews(ctx context.Context, clusterID uuid.UUID) (views []string, err error) {
-	// Get cluster session
+func (s *Service) listAllViews(ctx context.Context, clusterID uuid.UUID) ([]string, error) {
 	clusterSession, err := s.clusterSession(ctx, clusterID)
 	if err != nil {
 		return nil, errors.Wrap(err, "get CQL cluster session")
 	}
+	defer clusterSession.Close()
 
 	iter := qb.Select("system_schema.views").
 		Columns("keyspace_name", "view_name").
 		Query(clusterSession).Iter()
-	defer func() {
-		err = iter.Close()
-	}()
 
+	var views []string
 	var keyspace, view string
 	for iter.Scan(&keyspace, &view) {
 		views = append(views, keyspace+"."+view)
 	}
 
-	return
+	return views, iter.Close()
 }

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -807,17 +807,21 @@ func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID
 		return nil
 	}
 	stageFunc := map[Stage]func() error{
-		StageAwaitSchema: func() error {
+		StageAwaitSchema: func() error { // nolint: unparam
 			clusterSession, err := s.clusterSession(ctx, clusterID)
 			if err != nil {
-				w.Logger.Info(ctx, "No CQL cluster session, backup of schema as CQL files would be skipped", "error", err)
+				w.Logger.Info(ctx, "No CQL cluster session, backup of schema as CQL files will be skipped", "error", err)
 				return nil
 			}
 			defer clusterSession.Close()
 
 			w.AwaitSchemaAgreement(ctx, clusterSession)
 
-			return w.DumpSchema(ctx, clusterSession)
+			if err = w.DumpSchema(ctx, clusterSession); err != nil {
+				w.Logger.Info(ctx, "Couldn't dump schema, backup of schema as CQL files will be skipped", "error", err)
+				w.Schema = nil
+			}
+			return nil
 		},
 		StageSnapshot: func() error {
 			return w.Snapshot(ctx, hi, target.SnapshotParallel)


### PR DESCRIPTION
As we do not use backed-up schema file for restoring purposes, we can always continue backup, even when this step fails.
Fixes #3433
