### PR TITLE
Fix restore progress display with nil progress

### DIFF
--- a/pkg/managerclient/restore.go
+++ b/pkg/managerclient/restore.go
@@ -4,17 +4,21 @@ package managerclient
 
 // Stage enumeration.
 const (
-	RestoreStageInit   = "INIT"
-	RestoreStageData   = "DATA"
-	RestoreStageRepair = "REPAIR"
-	RestoreStageDone   = "DONE"
+	RestoreStageInit       = "INIT"
+	RestoreStageDisableTGC = "DISABLE_TGC"
+	RestoreStageData       = "DATA"
+	RestoreStageRepair     = "REPAIR"
+	RestoreStageEnableTG   = "ENABLE_TGC"
+	RestoreStageDone       = "DONE"
 )
 
 var restoreStageName = map[string]string{
-	RestoreStageInit:   "initialising",
-	RestoreStageData:   "restoring backed-up data",
-	RestoreStageRepair: "repairing restored tables",
-	RestoreStageDone:   "",
+	RestoreStageInit:       "initialising",
+	RestoreStageDisableTGC: "disabling restored tables tombstone_gc",
+	RestoreStageData:       "restoring backed-up data",
+	RestoreStageRepair:     "repairing restored tables",
+	RestoreStageEnableTG:   "enabling restored tables tombstone_gc",
+	RestoreStageDone:       "",
 }
 
 // RestoreStageName returns verbose name for restore stage.

--- a/pkg/service/backup/backupspec/stage.go
+++ b/pkg/service/backup/backupspec/stage.go
@@ -69,8 +69,8 @@ const (
 	StageRestoreDisableTGC              = "DISABLE_TGC"
 	StageRestoreData       RestoreStage = "DATA"
 	StageRestoreRepair     RestoreStage = "REPAIR"
-	StageRestoreDone       RestoreStage = "DONE"
 	StageRestoreEnableTGC               = "ENABLE_TGC"
+	StageRestoreDone       RestoreStage = "DONE"
 )
 
 // RestoreStageOrder lists all restore stages in the order of their execution.

--- a/pkg/service/backup/service_backup_restore_integration_test.go
+++ b/pkg/service/backup/service_backup_restore_integration_test.go
@@ -607,10 +607,6 @@ func restoreWithResume(t *testing.T, target RestoreTarget, keyspace string, load
 		body, _ := io.ReadAll(tee)
 		resp.Body = io.NopCloser(&copiedBody)
 
-		if strings.Contains(resp.Request.URL.Path, "repair") {
-			fmt.Println("")
-		}
-
 		// Response to repair status
 		if resp.Request.URL.Path == "/storage_service/repair_status" && resp.Request.Method == http.MethodGet && resp.Request.URL.Query()["id"][0] != "-1" {
 			status := string(body)


### PR DESCRIPTION
The following [dtest](https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/manager-dtest/lastCompletedBuild/testReport/manager_restore_tests/TestScyllaMgmtRestore/test_restore_alter_batch_size/) was querying restore progress right after task creation, which resulted in getting nil RestoreProgress.Progress, which caused panic when displaying restore progress. This PR fixes this behavior.
