### PR TITLE
Fix empty post-restore repair

### DIFF
--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -65,6 +65,9 @@ func (s *Service) Runner() Runner {
 	return Runner{service: s}
 }
 
+// ErrEmptyRepair is returned when there is nothing to repair (e.g. repaired keyspaces are not replicated).
+var ErrEmptyRepair = errors.New("nothing to repair")
+
 // GetTarget converts runner properties into repair Target.
 func (s *Service) GetTarget(ctx context.Context, clusterID uuid.UUID, properties json.RawMessage) (Target, error) {
 	p := defaultTaskProperties()
@@ -176,7 +179,7 @@ func (s *Service) GetTarget(ctx context.Context, clusterID uuid.UUID, properties
 	// Get the filtered units
 	t.Units, err = f.Apply(false)
 	if err != nil {
-		return t, err
+		return t, errors.Wrap(ErrEmptyRepair, err.Error())
 	}
 
 	// Ignore nodes in status DOWN


### PR DESCRIPTION
Repair task ends with an error when there is nothing to repair (e.g. repaired tables are not replicated).
In this case, restore procedure should just skip this step and not display any repair progress.
This PR fixes that and adds a test, which tries to restore data into non-replicated keyspace (this test fails without provided fix).