### PR TITLE
fix(testing): make scylla load faster

### DIFF
--- a/testing/scylla/config/scylla-second-cluster.yaml
+++ b/testing/scylla/config/scylla-second-cluster.yaml
@@ -808,3 +808,4 @@ api_doc_dir: /usr/lib/scylla/api/api-doc/
 alternator_port: 8000
 alternator_write_isolation: only_rmw_uses_lwt
 enable_ipv6_dns_lookup: true
+skip_wait_for_gossip_to_settle: 0

--- a/testing/scylla/config/scylla.yaml
+++ b/testing/scylla/config/scylla.yaml
@@ -808,3 +808,4 @@ api_doc_dir: /usr/lib/scylla/api/api-doc/
 alternator_port: 8000
 alternator_write_isolation: only_rmw_uses_lwt
 enable_ipv6_dns_lookup: true
+skip_wait_for_gossip_to_settle: 0


### PR DESCRIPTION
After https://github.com/scylladb/scylla-manager/pull/3436 cluster nodes are bootstrap one by one to ensure stability As result test env boostraping too long.
Fortunately there is a way to make skylla load faster via `skip_wait_for_gossip_to_settle` which makes it not to wait for gossip to settle, which readuces load time 5 fold

Closes https://github.com/scylladb/scylla-manager/issues/3472