### PR TITLE
fix(restore-tests): make restartScylla to check on other nodes

### DIFF
--- a/.github/actions/test-setup/action.yml
+++ b/.github/actions/test-setup/action.yml
@@ -1,13 +1,18 @@
 name: "Set up testing dependencies"
 description: "Set up GO, package dependencies and install-dependencies"
+
 inputs:
+  scylla-version:
+    description: "Specifies Scylla version for test environment"
+    required: false
   ip-family:
-    description: "Should test environment target IPV6 instead of IPV4"
+    description: "Specifies IP family for test environment (IPV4/IPV6)"
     required: false
   start-dev-env:
     description: "Should this action run 'make start-dev-env'"
     required: false
     default: 'true'
+
 runs:
   using: "composite"
   steps:
@@ -16,12 +21,6 @@ runs:
       with:
         go-version-file: ./go.mod
         cache-dependency-path: '**/go.sum'
-
-    - name: Set target IP-family
-      shell: bash
-      run: |
-        echo "IPV6=true" >> $GITHUB_ENV
-      if: ${{ inputs.ip-family == 'IPV6' }}
 
     - name: Restore dependencies
       uses: actions/cache@v3
@@ -37,5 +36,5 @@ runs:
 
     - name: Start dev env
       if: inputs.start-dev-env == 'true'
-      run: make start-dev-env
+      run: make start-dev-env SCYLLA_VERSION=${{ inputs.scylla-version }} IP_FAMILY=${{ inputs.ip-family }}
       shell: bash

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   checks:
@@ -26,12 +26,13 @@ jobs:
       - name: Run unit tests
         run: make unit-test
 
-  ipv4-run-integration-tests:
+  integration-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        scylla-version: [ 5.0.0, 5.0.13, 5.1.0, 5.1.13, 5.2.0, 5.2.4 ]
+        ip-family: [ IPV4, IPV6 ]
     uses: ./.github/workflows/integration-tests.yaml
     with:
-      ip-family: IPV4
-
-  ipv6-run-integration-tests:
-    uses: ./.github/workflows/integration-tests.yaml
-    with:
-      ip-family: IPV6
+      scylla-version: ${{ matrix.scylla-version }}
+      ip-family: ${{ matrix.ip-family }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -3,6 +3,9 @@ run-name: Integration tests
 on:
   workflow_call:
     inputs:
+      scylla-version:
+        required: false
+        type: string
       ip-family:
         required: false
         type: string
@@ -11,104 +14,88 @@ jobs:
   # Right now both restore-tables and restore-schema tests take way longer than any other pkg tests.
   # For this reason they are divided into two distinct jobs, so that the whole workflow can be executed faster.
   restore-tables:
-    name: ${{inputs.ip-family}} Test restore tables
+    name: Test restore tables
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
-      - name: Set target IP-family
-        run: |
-          echo "IPV6=true" >> $GITHUB_ENV
-        if: ${{ inputs.ip-family == 'IPV6' }}
-
       - name: Setup testing dependencies
         uses: ./.github/actions/test-setup
         with:
+          scylla-version: ${{ inputs.scylla-version }}
           ip-family: ${{ inputs.ip-family }}
 
       - name: Run tests
-        run: make pkg-integration-test PKG=./pkg/service/backup RUN='"TestRestoreTables.*Integration"'
+        run: make pkg-integration-test IP_FAMILY=${{ inputs.ip-family }} PKG=./pkg/service/backup RUN='"TestRestoreTables.*Integration"'
 
   restore-schema:
-    name: ${{inputs.ip-family}} Test restore schema
+    name: Test restore schema
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
-      - name: Set target IP-family
-        run: |
-          echo "IPV6=true" >> $GITHUB_ENV
-        if: ${{ inputs.ip-family == 'IPV6' }}
-
       - name: Setup testing dependencies
         uses: ./.github/actions/test-setup
         with:
+          scylla-version: ${{ inputs.scylla-version }}
           ip-family: ${{ inputs.ip-family }}
 
         # Go does not support negative lookahead in regex expressions, so it has to be done manually.
         # This regex ensures that all restore tests that didn't match restore-tables job will be run here.
       - name: Run tests
-        run: make pkg-integration-test PKG=./pkg/service/backup RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+        run: make pkg-integration-test IP_FAMILY=${{ inputs.ip-family }} PKG=./pkg/service/backup RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
 
   backup:
-    name: ${{inputs.ip-family}} Test backup
+    name: Test backup
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
-      - name: Set target IP-family
-        run: |
-          echo "IPV6=true" >> $GITHUB_ENV
-        if: ${{ inputs.ip-family == 'IPV6' }}
-
       - name: Setup testing dependencies
         uses: ./.github/actions/test-setup
         with:
+          scylla-version: ${{ inputs.scylla-version }}
           ip-family: ${{ inputs.ip-family }}
 
         # Until backup and restore live in the same pkg, we have to use regex to separate their tests.
         # The same negative lookahead workaround as in restore-schema.
       - name: Run tests
-        run: make pkg-integration-test PKG=./pkg/service/backup RUN='"Test([^R]|.{1}[^e]|.{2}[^s]|.{3}[^t]|.{4}[^o]|.{5}[^r]|.{6}[^e]).*Integration"'
+        run: make pkg-integration-test IP_FAMILY=${{ inputs.ip-family }} PKG=./pkg/service/backup RUN='"Test([^R]|.{1}[^e]|.{2}[^s]|.{3}[^t]|.{4}[^o]|.{5}[^r]|.{6}[^e]).*Integration"'
 
   repair:
-    name: ${{inputs.ip-family}} Test repair
+    name: Test repair
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
-      - name: Set target IP-family
-        run: |
-          echo "IPV6=true" >> $GITHUB_ENV
-        if: ${{ inputs.ip-family == 'IPV6' }}
-
       - name: Setup testing dependencies
         uses: ./.github/actions/test-setup
         with:
+          scylla-version: ${{ inputs.scylla-version }}
           ip-family: ${{ inputs.ip-family }}
 
       - name: Run tests
-        run: make pkg-integration-test PKG=./pkg/service/repair
+        run: make pkg-integration-test IP_FAMILY=${{ inputs.ip-family }} PKG=./pkg/service/repair
 
   small-pkg:
-    name: ${{inputs.ip-family}} Test other, smaller packages
+    name: Test other, smaller packages
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 
-      - name: Set target IP-family
+      - name: Set IP_FAMILY var for all tests
         run: |
-          echo "IPV6=true" >> $GITHUB_ENV
-        if: ${{ inputs.ip-family == 'IPV6' }}
+          echo "IP_FAMILY=${{ inputs.ip-family }}" >> $GITHUB_ENV
 
       - name: Setup testing dependencies
         uses: ./.github/actions/test-setup
         with:
+          scylla-version: ${{ inputs.scylla-version }}
           ip-family: ${{ inputs.ip-family }}
 
       - name: Run cqlping tests

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,13 @@ GIT_ROOT = $(shell git rev-parse --show-toplevel)
 GOBIN ?= $(shell pwd)/bin
 GOFILES = go list -f '{{range .GoFiles}}{{ $$.Dir }}/{{ . }} {{end}}{{range .TestGoFiles}}{{ $$.Dir }}/{{ . }} {{end}}' $(PKG)
 
-IPV6?=false
+SCYLLA_VERSION?=5.1.13
+IP_FAMILY?=IPV4
 
 MANAGER_CONFIG := testing/scylla-manager/scylla-manager.yaml
 PUBLIC_NET := 192.168.200.
 MINIO_ENDPOINT := http://192.168.200.99:9000
-ifneq ($(IPV6), false)
+ifeq ($(IP_FAMILY), IPV6)
 	MANAGER_CONFIG := testing/scylla-manager/scylla-manager-ipv6.yaml
 	PUBLIC_NET := 2001:0DB9:200::
 	MINIO_ENDPOINT := http://[2001:0DB9:200::99]:9000

--- a/testing/.env
+++ b/testing/.env
@@ -1,7 +1,6 @@
 COMPOSE_PROJECT_NAME="scylla_manager"
 
 SCYLLA_IMAGE=scylladb/scylla
-SCYLLA_VERSION=5.0.3
 
 SSL_AUTHORITY_CRT=scylla/certs/ca.crt
 SSL_CLIENT_KEY=scylla/certs/cl.key

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -9,7 +9,8 @@ YQ           := ../bin/yq
 CURRENT_UID  := $(shell id -u)
 CURRENT_GID  := $(shell id -g)
 
-IPV6?=false
+SCYLLA_VERSION?=5.1.13
+IP_FAMILY?=IPV4
 
 MINIO_ENDPOINT := http://192.168.200.99:9000
 COMPOSE_FILE := docker-compose-ipv4.yaml
@@ -17,7 +18,7 @@ AGENT_CONFIG := scylla-manager-agent/scylla-manager-agent.yaml
 PUBLIC_NET := 192.168.100.
 SECOND_NET := 192.168.200.
 
-ifneq ($(IPV6), false)
+ifeq ($(IP_FAMILY), IPV6)
 	MINIO_ENDPOINT := http://[2001:0DB9:200::99]:9000
 	COMPOSE_FILE := docker-compose-ipv6.yaml
 	AGENT_CONFIG := scylla-manager-agent/scylla-manager-agent-ipv6.yaml
@@ -36,7 +37,7 @@ include .env
 
 .PHONY: build
 build: ## Build custom docker image
-	@echo "==> Building custom Scylla image for testing"
+	@echo "==> Building custom Scylla $(SCYLLA_VERSION) image for testing"
 	@docker build --network=host \
 		--build-arg=SCYLLA_IMAGE=$(SCYLLA_IMAGE) \
 		--build-arg=SCYLLA_VERSION=$(SCYLLA_VERSION) \
@@ -48,6 +49,7 @@ build: ## Build custom docker image
 .PHONY: up
 up: ## Start docker containers
 up:
+	@echo "==> Starting testing env with SCYLLA_VERSION=$(SCYLLA_VERSION) and IP_FAMILY=$(IP_FAMILY)"
 # Scylla bootstap proceedure have requirements that leads us to follow certain recipe:
 # 1. Spin up first node on the cluster
 # 2. Spin up and join other seed node, which is first node from DC2


### PR DESCRIPTION
After making scylla [skip gossip settling](https://github.com/scylladb/scylla-manager/pull/3483) restart become unstable.
Test can think that node is ready to operate while it is not.

Closes https://github.com/scylladb/scylla-manager/issues/3485