### PR TITLE
doc: clarify the usage of sctool flags

### DIFF
--- a/docs/source/sctool/index.rst
+++ b/docs/source/sctool/index.rst
@@ -28,10 +28,32 @@ CLI sctool
 ``sctool`` is a Command Line Interface (CLI) for the Scylla Manager server.
 The server communicates with managed Scylla clusters and performs cluster-wide operations such as automatic repair and backup.
 
-**Usage**
+Syntax
+---------
 
 .. code-block:: none
 
-   sctool command [flags] [global flags]
+   sctool <command> [flags] [global flags]
 
-Consult the left pane menu for commands.
+.. note:: Flags that have default values must be set with ``=``.
+
+See the left pane menu for commands.
+
+Examples
+----------
+
+.. code-block:: console
+
+   sctool tasks -c mycluster --show-properties=true
+
+
+.. code-block:: console
+
+   sctool repair update -c mycluster repair/aaaa1111-bb22-cc33-dd44-eeeeee555555 --enabled=false
+
+
+.. code-block:: console
+
+   scylla-manager-agent download-files --location s3:my-bucket -p=10
+
+

--- a/docs/source/sctool/index.rst
+++ b/docs/source/sctool/index.rst
@@ -25,8 +25,8 @@ CLI sctool
    version
 
 
-``sctool`` is a Command Line Interface (CLI) for the Scylla Manager server.
-The server communicates with managed Scylla clusters and performs cluster-wide operations such as automatic repair and backup.
+``sctool`` is a Command Line Interface (CLI) for the ScyllaDB Manager server.
+The server communicates with managed ScyllaDB clusters and performs cluster-wide operations such as automatic repair and backup.
 
 Syntax
 ---------


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-manager/issues/3366

This PR clarifies the usage of `sctool` command flags. It adds an explanation, as well as examples.

In addition, it replaces "Scylla" with "ScyllaDB".