### PR TITLE
Revert "fix(testing): make scylla load faster"

### DIFF
--- a/testing/scylla/config/scylla-second-cluster.yaml
+++ b/testing/scylla/config/scylla-second-cluster.yaml
@@ -808,4 +808,3 @@ api_doc_dir: /usr/lib/scylla/api/api-doc/
 alternator_port: 8000
 alternator_write_isolation: only_rmw_uses_lwt
 enable_ipv6_dns_lookup: true
-skip_wait_for_gossip_to_settle: 0

--- a/testing/scylla/config/scylla.yaml
+++ b/testing/scylla/config/scylla.yaml
@@ -808,4 +808,3 @@ api_doc_dir: /usr/lib/scylla/api/api-doc/
 alternator_port: 8000
 alternator_write_isolation: only_rmw_uses_lwt
 enable_ipv6_dns_lookup: true
-skip_wait_for_gossip_to_settle: 0


### PR DESCRIPTION
Reverts scylladb/scylla-manager#3483

Unfortunately I it made restore tests to fail:
```
-- When: query contents of restored table
    service_backup_restore_integration_test.go:1024: restoretest_full.big_table, srcCount = 512, dstCount = 512
    service_backup_restore_integration_test.go:1024: system_auth.role_attributes, srcCount = 1, dstCount = 1
    service_backup_restore_integration_test.go:1024: system_auth.role_members, srcCount = 1, dstCount = 1
    service_backup_restore_integration_test.go:1024: system_auth.role_permissions, srcCount = 5, dstCount = 18
    service_backup_restore_integration_test.go:1024: system_auth.roles, srcCount = 3, dstCount = 4
    service_backup_restore_integration_test.go:1024: system_distributed.service_levels, srcCount = 1, dstCount = 1
    service_backup_restore_integration_test.go:1024: system_traces.events, srcCount = 18, dstCount = 18
    service_backup_restore_integration_test.go:1024: system_traces.node_slow_log, srcCount = 0, dstCount = 0
    service_backup_restore_integration_test.go:1024: system_traces.node_slow_log_time_idx, srcCount = 0, dstCount = 0
    service_backup_restore_integration_test.go:1024: system_traces.sessions, srcCount = 6, dstCount = 6
    service_backup_restore_integration_test.go:1024: system_traces.sessions_time_idx, srcCount = 6, dstCount = 6
--- PASS: TestRestoreFullIntegration (106.03s)
```

I have tried to stabilize it, with no progress.