### PR TITLE
Fix restore tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ include testing/.env
 INTEGRATION_TEST_ARGS := -cluster $(PUBLIC_NET)100 \
 -managed-cluster $(PUBLIC_NET)11,$(PUBLIC_NET)12,$(PUBLIC_NET)13,$(PUBLIC_NET)21,$(PUBLIC_NET)22,$(PUBLIC_NET)23 \
 -test-network $(PUBLIC_NET) \
--managed-second-cluster $(PUBLIC_NET)30 \
+-managed-second-cluster $(PUBLIC_NET)31,$(PUBLIC_NET)32 \
 -user cassandra -password cassandra \
 -agent-auth-token token \
 -s3-data-dir ./testing/minio/data -s3-provider Minio -s3-endpoint $(MINIO_ENDPOINT) -s3-access-key-id $(MINIO_USER_ACCESS_KEY) -s3-secret-access-key $(MINIO_USER_SECRET_KEY)

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ start-dev-env: .testing-up deploy-agent build-cli
 
 .PHONY: .testing-up
 .testing-up:
-	@IPV6=$(IPV6) make -C testing build down up
+	@IPV6=$(IPV6) SCYLLA_VERSION=$(SCYLLA_VERSION) make -C testing build down up
 
 .PHONY: dev-env-status
 dev-env-status:  ## Checks status of docker containers and cluster nodes

--- a/pkg/service/backup/service_backup_restore_integration_test.go
+++ b/pkg/service/backup/service_backup_restore_integration_test.go
@@ -338,7 +338,7 @@ func TestRestoreTablesSmokeIntegration(t *testing.T) {
 		testLoadCnt   = 5
 		testLoadSize  = 5
 		testBatchSize = 1
-		testParallel  = 3
+		testParallel  = 0
 	)
 
 	target := RestoreTarget{
@@ -355,7 +355,7 @@ func TestRestoreTablesSmokeIntegration(t *testing.T) {
 		RestoreTables: true,
 	}
 
-	smokeRestore(t, target, testKeyspace, testLoadCnt, testLoadSize, testUser, "{'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 3}")
+	smokeRestore(t, target, testKeyspace, testLoadCnt, testLoadSize, testUser, "{'class': 'NetworkTopologyStrategy', 'dc1': 2}")
 }
 
 func TestRestoreTablesSmokeNoReplicationIntegration(t *testing.T) {
@@ -390,7 +390,7 @@ func TestRestoreSchemaSmokeIntegration(t *testing.T) {
 		testLoadCnt   = 1
 		testLoadSize  = 1
 		testBatchSize = 2
-		testParallel  = 3
+		testParallel  = 0
 	)
 
 	target := RestoreTarget{
@@ -406,7 +406,7 @@ func TestRestoreSchemaSmokeIntegration(t *testing.T) {
 		RestoreSchema: true,
 	}
 
-	smokeRestore(t, target, testKeyspace, testLoadCnt, testLoadSize, testUser, "{'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 3}")
+	smokeRestore(t, target, testKeyspace, testLoadCnt, testLoadSize, testUser, "{'class': 'NetworkTopologyStrategy', 'dc1': 2}")
 }
 
 func smokeRestore(t *testing.T, target RestoreTarget, keyspace string, loadCnt, loadSize int, user, replication string) {
@@ -446,10 +446,14 @@ func smokeRestore(t *testing.T, target RestoreTarget, keyspace string, loadCnt, 
 		t.Fatal(err)
 	}
 
-	toValidate := []string{
-		fmt.Sprintf("%s.%s", keyspace, BigTableName),
+	toValidate := []validateTable{
+		{
+			Keyspace: keyspace,
+			Table:    BigTableName,
+			Column:   "id",
+		},
 	}
-	dstH.validateRestoreSuccess(dstSession, srcSession, target, toValidate...)
+	dstH.validateRestoreSuccess(dstSession, srcSession, target, toValidate)
 }
 
 func TestRestoreTablesRestartAgentsIntegration(t *testing.T) {
@@ -498,7 +502,7 @@ func restoreWithAgentRestart(t *testing.T, target RestoreTarget, keyspace string
 
 	// Recreate schema on destination cluster
 	if target.RestoreTables {
-		WriteData(t, dstSession, keyspace, 0)
+		WriteDataSecondClusterSchema(t, dstSession, keyspace, 0, 0)
 	}
 
 	srcH.prepareRestoreBackup(srcSession, keyspace, loadCnt, loadSize)
@@ -523,10 +527,14 @@ func restoreWithAgentRestart(t *testing.T, target RestoreTarget, keyspace string
 		t.Errorf("Expected no error but got %+v", err)
 	}
 
-	toValidate := []string{
-		fmt.Sprintf("%s.%s", keyspace, BigTableName),
+	toValidate := []validateTable{
+		{
+			Keyspace: keyspace,
+			Table:    BigTableName,
+			Column:   "id",
+		},
 	}
-	dstH.validateRestoreSuccess(dstSession, srcSession, target, toValidate...)
+	dstH.validateRestoreSuccess(dstSession, srcSession, target, toValidate)
 }
 
 func TestRestoreTablesResumeIntegration(t *testing.T) {
@@ -603,7 +611,7 @@ func restoreWithResume(t *testing.T, target RestoreTarget, keyspace string, load
 
 	// Recreate schema on destination cluster
 	if target.RestoreTables {
-		WriteData(t, dstSession, keyspace, 0)
+		WriteDataSecondClusterSchema(t, dstSession, keyspace, 0, 0)
 	}
 
 	srcH.prepareRestoreBackup(srcSession, keyspace, loadCnt, loadSize)
@@ -691,10 +699,14 @@ func restoreWithResume(t *testing.T, target RestoreTarget, keyspace string, load
 	}
 
 	Print("Then: data is restored")
-	toValidate := []string{
-		fmt.Sprintf("%s.%s", keyspace, BigTableName),
+	toValidate := []validateTable{
+		{
+			Keyspace: keyspace,
+			Table:    BigTableName,
+			Column:   "id",
+		},
 	}
-	dstH.validateRestoreSuccess(dstSession, srcSession, target, toValidate...)
+	dstH.validateRestoreSuccess(dstSession, srcSession, target, toValidate)
 }
 
 func TestRestoreTablesVersionedIntegration(t *testing.T) {
@@ -770,7 +782,7 @@ func restoreWithVersions(t *testing.T, target RestoreTarget, keyspace string, lo
 
 	Print("Recreate schema on destination cluster")
 	if target.RestoreTables {
-		WriteData(t, dstSession, keyspace, 0)
+		WriteDataSecondClusterSchema(t, dstSession, keyspace, 0, 0)
 	}
 
 	srcH.prepareRestoreBackup(srcSession, keyspace, loadCnt, loadSize)
@@ -912,10 +924,14 @@ func restoreWithVersions(t *testing.T, target RestoreTarget, keyspace string, lo
 		t.Fatal(err)
 	}
 
-	toValidate := []string{
-		fmt.Sprintf("%s.%s", keyspace, BigTableName),
+	toValidate := []validateTable{
+		{
+			Keyspace: keyspace,
+			Table:    BigTableName,
+			Column:   "id",
+		},
 	}
-	dstH.validateRestoreSuccess(dstSession, srcSession, target, toValidate...)
+	dstH.validateRestoreSuccess(dstSession, srcSession, target, toValidate)
 }
 
 func TestRestoreFullIntegration(t *testing.T) {
@@ -991,21 +1007,65 @@ func restoreAllTables(t *testing.T, schemaTarget, tablesTarget RestoreTarget, ke
 		t.Fatal(err)
 	}
 
-	toValidate := []string{
-		fmt.Sprintf("%s.%s", keyspace, BigTableName),
-		"system_auth.role_attributes",
-		"system_auth.role_members",
-		"system_auth.role_permissions",
-		"system_auth.roles",
-		"system_distributed.service_levels",
-		"system_traces.events",
-		"system_traces.node_slow_log",
-		"system_traces.node_slow_log_time_idx",
-		"system_traces.sessions",
-		"system_traces.sessions_time_idx",
+	toValidate := []validateTable{
+		{
+			Keyspace: keyspace,
+			Table:    BigTableName,
+			Column:   "id",
+		},
+		{
+			Keyspace: "system_auth",
+			Table:    "role_attributes",
+			Column:   "role",
+		},
+		{
+			Keyspace: "system_auth",
+			Table:    "role_members",
+			Column:   "role",
+		},
+		{
+			Keyspace: "system_auth",
+			Table:    "role_permissions",
+			Column:   "role",
+		},
+		{
+			Keyspace: "system_auth",
+			Table:    "roles",
+			Column:   "role",
+		},
+		{
+			Keyspace: "system_distributed",
+			Table:    "service_levels",
+			Column:   "service_level",
+		},
+		{
+			Keyspace: "system_traces",
+			Table:    "events",
+			Column:   "session_id",
+		},
+		{
+			Keyspace: "system_traces",
+			Table:    "node_slow_log",
+			Column:   "node_ip",
+		},
+		{
+			Keyspace: "system_traces",
+			Table:    "node_slow_log_time_idx",
+			Column:   "session_id",
+		},
+		{
+			Keyspace: "system_traces",
+			Table:    "sessions",
+			Column:   "session_id",
+		},
+		{
+			Keyspace: "system_traces",
+			Table:    "sessions_time_idx",
+			Column:   "session_id",
+		},
 	}
 
-	dstH.validateRestoreSuccess(dstSession, srcSession, schemaTarget, toValidate...)
+	dstH.validateRestoreSuccess(dstSession, srcSession, schemaTarget, toValidate)
 
 	tablesTarget.SnapshotTag = schemaTarget.SnapshotTag
 	dstH.ClusterID = uuid.MustRandom()
@@ -1021,7 +1081,7 @@ func restoreAllTables(t *testing.T, schemaTarget, tablesTarget RestoreTarget, ke
 		t.Fatal(err)
 	}
 
-	dstH.validateRestoreSuccess(dstSession, srcSession, tablesTarget, toValidate...)
+	dstH.validateRestoreSuccess(dstSession, srcSession, tablesTarget, toValidate)
 }
 
 // regenerateRestoreTarget applies GetRestoreTarget onto given restore target.
@@ -1087,14 +1147,40 @@ func grantPermissionsToUser(s gocqlx.Session, target RestoreTarget, user string)
 	return iter.Close()
 }
 
-func (h *restoreTestHelper) validateRestoreSuccess(dstSession, srcSession gocqlx.Session, target RestoreTarget, tables ...string) {
+type validateTable struct {
+	Keyspace string
+	Table    string
+	Column   string
+}
+
+func (h *restoreTestHelper) getRowCount(s gocqlx.Session, vt validateTable) int {
+	h.T.Helper()
+
+	var (
+		cnt int
+		tmp string
+	)
+
+	it := s.Query(fmt.Sprintf("SELECT %s FROM %s.%s", vt.Column, vt.Keyspace, vt.Table), nil).Iter()
+	for it.Scan(&tmp) {
+		cnt++
+	}
+	if err := it.Close(); err != nil {
+		h.T.Fatalf("Couldn't get tables (%s.%s, col: %s) row count: %s", vt.Keyspace, vt.Table, vt.Column, err)
+	}
+
+	return cnt
+}
+
+func (h *restoreTestHelper) validateRestoreSuccess(dstSession, srcSession gocqlx.Session, target RestoreTarget, tables []validateTable) {
 	h.T.Helper()
 	Print("Then: validate restore result")
 
 	pr, err := h.service.GetRestoreProgress(context.Background(), h.ClusterID, h.TaskID, h.RunID)
 	if err != nil {
-		h.T.Fatal(err)
+		h.T.Fatalf("Couldn't get progress: %s", err)
 	}
+
 	Printf("And: restore progress: %+#v\n", pr)
 	if pr.Size != pr.Restored || pr.Size != pr.Downloaded {
 		h.T.Fatal("Expected complete restore")
@@ -1111,15 +1197,15 @@ func (h *restoreTestHelper) validateRestoreSuccess(dstSession, srcSession gocqlx
 	}
 
 	if target.RestoreSchema {
+		// Required to load schema changes
 		h.restartScylla()
 	}
 
-	// Validate restored tombstone_gc mode
+	Print("And: validate that restore preserves tombstone_gc mode")
 	for _, t := range tables {
-		kst := strings.Split(t, ".")
-		mode, err := h.service.GetTableTombstoneGC(context.Background(), h.ClusterID, kst[0], kst[1])
+		mode, err := h.service.GetTableTombstoneGC(context.Background(), h.ClusterID, t.Keyspace, t.Table)
 		if err != nil {
-			h.T.Fatalf("Couldn't check %s tombstone_gc mode: %s", t, err)
+			h.T.Fatalf("Couldn't check table's tombstone_gc mode (%s): %s", t, err)
 		}
 		if mode != "timeout" {
 			h.T.Fatalf("Expected 'timeout' tombstone_gc mode, got: %s", mode)
@@ -1128,27 +1214,17 @@ func (h *restoreTestHelper) validateRestoreSuccess(dstSession, srcSession gocqlx
 
 	Print("When: query contents of restored table")
 	for _, t := range tables {
-		var dstCount int
-		// Right after repair, we can expect to get correct responses with consistency 1
-		q := dstSession.Query("SELECT COUNT(*) FROM "+t, nil).Consistency(gocql.One)
-		WaitCond(h.T, func() bool {
-			return q.Get(&dstCount) == nil
-		}, condCheckInterval, maxWaitCond)
-
-		// srcCount should be treated as 0 when restoring schema
-		var srcCount int
+		dstCnt := h.getRowCount(dstSession, t)
+		srcCnt := 0
 		if target.RestoreTables {
-			q = srcSession.Query("SELECT COUNT(*) FROM "+t, nil).Consistency(gocql.One)
-			WaitCond(h.T, func() bool {
-				return q.Get(&srcCount) == nil
-			}, condCheckInterval, maxWaitCond)
+			srcCnt = h.getRowCount(srcSession, t)
 		}
 
-		h.T.Logf("%s, srcCount = %d, dstCount = %d", t, srcCount, dstCount)
-		if dstCount != srcCount {
+		h.T.Logf("%s, srcCount = %d, dstCount = %d", t, srcCnt, dstCnt)
+		if dstCnt != srcCnt {
 			// Destination cluster has additional users used for restore
-			if t == "system_auth.roles" || t == "system_auth.role_permissions" {
-				if target.RestoreTables && dstCount < srcCount {
+			if t.Keyspace == "system_auth" {
+				if target.RestoreTables && dstCnt < srcCnt {
 					h.T.Fatalf("%s: srcCount != dstCount", t)
 				}
 				continue
@@ -1208,7 +1284,7 @@ func (h *restoreTestHelper) prepareRestoreBackupWithFeatures(session gocqlx.Sess
 	}
 
 	// Create keyspace and table
-	WriteDataToSecondCluster(h.T, session, keyspace, 0, 0)
+	WriteDataSecondClusterSchema(h.T, session, keyspace, 0, 0)
 
 	ExecStmt(h.T,
 		session,
@@ -1235,7 +1311,7 @@ func (h *restoreTestHelper) prepareRestoreBackup(session gocqlx.Session, keyspac
 	ctx := context.Background()
 
 	// Create keyspace and table
-	WriteDataToSecondCluster(h.T, session, keyspace, 0, 0)
+	WriteDataSecondClusterSchema(h.T, session, keyspace, 0, 0)
 
 	if err := h.Client.DisableAutoCompaction(ctx, keyspace, BigTableName); err != nil {
 		h.T.Fatal(err)
@@ -1245,7 +1321,7 @@ func (h *restoreTestHelper) prepareRestoreBackup(session gocqlx.Session, keyspac
 	for i := 0; i < loadCnt; i++ {
 		Printf("When: Write load nr %d to second cluster", i)
 
-		startingID = WriteDataToSecondCluster(h.T, session, keyspace, startingID, loadSize)
+		startingID = WriteDataSecondClusterSchema(h.T, session, keyspace, startingID, loadSize)
 		if err := h.Client.FlushTable(ctx, keyspace, BigTableName); err != nil {
 			h.T.Fatal(err)
 		}

--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -200,7 +200,7 @@ func (g *generator) Result() chan<- jobResult {
 	return g.result
 }
 
-func (g *generator) Run(ctx context.Context) (err error) {
+func (g *generator) Run(ctx context.Context) error {
 	g.logger.Info(ctx, "Start repair")
 
 	g.fillNext(ctx)
@@ -217,7 +217,6 @@ func (g *generator) Run(ctx context.Context) (err error) {
 		time.AfterFunc(g.gracefulStopTimeout, func() {
 			close(stop)
 		})
-		err = ctx.Err()
 	}
 loop:
 	for {
@@ -249,7 +248,7 @@ loop:
 	if g.failed > 0 {
 		return errors.Errorf("repair %d token ranges out of %d", g.failed, g.count)
 	}
-	return err
+	return ctx.Err()
 }
 
 func (g *generator) processResult(ctx context.Context, r jobResult) {

--- a/pkg/testutils/db/db.go
+++ b/pkg/testutils/db/db.go
@@ -192,11 +192,11 @@ func WriteData(t *testing.T, session gocqlx.Session, keyspace string, sizeMiB in
 	writeData(t, session, keyspace, 0, sizeMiB, "{'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 3}", tables...)
 }
 
-// WriteDataToSecondCluster creates big_table in the provided keyspace with the size in MiB with replication set for second cluster.
-func WriteDataToSecondCluster(t *testing.T, session gocqlx.Session, keyspace string, startingID, sizeMiB int, tables ...string) int {
+// WriteDataSecondClusterSchema creates big_table in the provided keyspace with the size in MiB with replication set for second cluster.
+func WriteDataSecondClusterSchema(t *testing.T, session gocqlx.Session, keyspace string, startingID, sizeMiB int, tables ...string) int {
 	t.Helper()
 
-	return writeData(t, session, keyspace, startingID, sizeMiB, "{'class': 'NetworkTopologyStrategy', 'dc1': 1}", tables...)
+	return writeData(t, session, keyspace, startingID, sizeMiB, "{'class': 'NetworkTopologyStrategy', 'dc1': 2}", tables...)
 }
 
 // WriteData creates big_table in the provided keyspace with the size in MiB.

--- a/pkg/testutils/db/db.go
+++ b/pkg/testutils/db/db.go
@@ -189,23 +189,32 @@ const BigTableName = "big_table"
 func WriteData(t *testing.T, session gocqlx.Session, keyspace string, sizeMiB int, tables ...string) {
 	t.Helper()
 
-	writeData(t, session, keyspace, 0, sizeMiB, "{'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 3}", tables...)
+	RawWriteData(t, session, keyspace, 0, sizeMiB, "{'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 3}", true, tables...)
 }
 
 // WriteDataSecondClusterSchema creates big_table in the provided keyspace with the size in MiB with replication set for second cluster.
 func WriteDataSecondClusterSchema(t *testing.T, session gocqlx.Session, keyspace string, startingID, sizeMiB int, tables ...string) int {
 	t.Helper()
 
-	return writeData(t, session, keyspace, startingID, sizeMiB, "{'class': 'NetworkTopologyStrategy', 'dc1': 2}", tables...)
+	return RawWriteData(t, session, keyspace, startingID, sizeMiB, "{'class': 'NetworkTopologyStrategy', 'dc1': 2}", false, tables...)
 }
 
-// WriteData creates big_table in the provided keyspace with the size in MiB.
+// RawWriteData creates big_table in the provided keyspace with the size in MiB.
 // It returns starting ID for the future calls, so that rows created from different calls to this function does not overlap.
-func writeData(t *testing.T, session gocqlx.Session, keyspace string, startingID, sizeMiB int, replication string, tables ...string) int {
+// It's also required to specify keyspace replication and whether table should use compaction.
+func RawWriteData(t *testing.T, session gocqlx.Session, keyspace string, startingID, sizeMiB int, replication string, compaction bool, tables ...string) int {
 	t.Helper()
 
-	ExecStmt(t, session, "CREATE KEYSPACE IF NOT EXISTS "+keyspace+" WITH replication = "+replication)
+	var (
+		ksStmt     = "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = %s"
+		tStmt      = "CREATE TABLE IF NOT EXISTS %s.%s (id int PRIMARY KEY, data blob)"
+		insertStmt = "INSERT INTO %s.%s (id, data) VALUES (?, ?)"
+	)
+	if !compaction {
+		tStmt += " WITH compaction = {'enabled': 'false', 'class': 'NullCompactionStrategy'}"
+	}
 
+	ExecStmt(t, session, fmt.Sprintf(ksStmt, keyspace, replication))
 	if len(tables) == 0 {
 		tables = []string{BigTableName}
 	}
@@ -214,10 +223,10 @@ func writeData(t *testing.T, session gocqlx.Session, keyspace string, startingID
 	rowsCnt := bytes / 4096
 
 	for i := range tables {
-		ExecStmt(t, session, fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s.%s (id int PRIMARY KEY, data blob)", keyspace, tables[i]))
-		stmt := fmt.Sprintf("INSERT INTO %s.%s (id, data) VALUES (?, ?)", keyspace, tables[i])
+		ExecStmt(t, session, fmt.Sprintf(tStmt, keyspace, tables[i]))
+
+		stmt := fmt.Sprintf(insertStmt, keyspace, tables[i])
 		q := session.Query(stmt, []string{"id", "data"})
-		defer q.Release()
 
 		data := make([]byte, 4096)
 		if _, err := rand.Read(data); err != nil {
@@ -229,6 +238,8 @@ func writeData(t *testing.T, session gocqlx.Session, keyspace string, startingID
 				t.Fatal(err)
 			}
 		}
+
+		q.Release()
 	}
 
 	return startingID + rowsCnt

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -27,7 +27,7 @@ ifeq ($(IP_FAMILY), IPV6)
 endif
 
 SCYLLA_ARGS := --smp 2 --memory 1G --seeds $(SECOND_NET)11,$(SECOND_NET)21
-SCYLLA_SECOND_CLUSTER_ARGS := --smp 2 --memory 1G --seeds $(SECOND_NET)30
+SCYLLA_SECOND_CLUSTER_ARGS := --smp 2 --memory 1G --seeds $(SECOND_NET)31
 
 export SCYLLA_ARGS
 export SCYLLA_SECOND_CLUSTER_ARGS
@@ -68,13 +68,13 @@ else
 endif
 	@echo "==> Starting containers"
 	mkdir -p $(MINIO_DATA_DIR)
-	@. ./.env && CURRENT_UID=$(CURRENT_UID) CURRENT_GID=$(CURRENT_GID) $(COMPOSE) -f docker-compose.yaml -f $(COMPOSE_FILE) up -d dc1_node_1 dc2_node_1
+	@. ./.env && CURRENT_UID=$(CURRENT_UID) CURRENT_GID=$(CURRENT_GID) $(COMPOSE) -f docker-compose.yaml -f $(COMPOSE_FILE) up -d dc1_node_1 dc2_node_1 second_cluster_dc1_node_1
 	$(COMPOSE) exec -T --privileged dc1_node_1 sudo bash -c 'echo "fs.aio-max-nr = 1048579" > /etc/sysctl.d/50-scylla.conf'
 	$(COMPOSE) exec -T --privileged dc1_node_1 sudo sysctl -p /etc/sysctl.d/50-scylla.conf
 	@echo "==> Waiting for first nodes from DC1 and DC2 to spin up"
 	@until [ 2 -le $$($(NODETOOL) status | grep -c "UN") ]; do echo -n "."; sleep 2; done ; echo ""
 	@echo "==> First nodes from DC1 and DC2 are ready"
-	@. ./.env && CURRENT_UID=$(CURRENT_UID) CURRENT_GID=$(CURRENT_GID) $(COMPOSE) -f docker-compose.yaml -f $(COMPOSE_FILE) up -d dc1_node_2 dc2_node_2
+	@. ./.env && CURRENT_UID=$(CURRENT_UID) CURRENT_GID=$(CURRENT_GID) $(COMPOSE) -f docker-compose.yaml -f $(COMPOSE_FILE) up -d dc1_node_2 dc2_node_2 second_cluster_dc1_node_2
 	@echo "==> Waiting for second nodes from DC1 and DC2 to spin up"
 	@until [ 4 -le $$($(NODETOOL) status | grep -c "UN") ]; do echo -n "."; sleep 2; done ; echo ""
 	@echo "==> Second nodes from DC1 and DC2 are ready"

--- a/testing/docker-compose-ipv4.yaml
+++ b/testing/docker-compose-ipv4.yaml
@@ -50,12 +50,20 @@ services:
         ipv4_address: 192.168.200.23
 
   second_cluster_dc1_node_1:
-    command: ${SCYLLA_SECOND_CLUSTER_ARGS} --rpc-address 192.168.100.30 --alternator-address 192.168.200.30 --listen-address 192.168.200.30
+    command: ${SCYLLA_SECOND_CLUSTER_ARGS} --rpc-address 192.168.100.31 --alternator-address 192.168.200.31 --listen-address 192.168.200.31
     networks:
       public:
-        ipv4_address: 192.168.100.30
+        ipv4_address: 192.168.100.31
       second:
-        ipv4_address: 192.168.200.30
+        ipv4_address: 192.168.200.31
+
+  second_cluster_dc1_node_2:
+    command: ${SCYLLA_SECOND_CLUSTER_ARGS} --rpc-address 192.168.100.32 --alternator-address 192.168.200.32 --listen-address 192.168.200.32
+    networks:
+      public:
+        ipv4_address: 192.168.100.32
+      second:
+        ipv4_address: 192.168.200.32
 
   scylla-manager-db:
     command: --smp 1 --memory 500M --api-address 0.0.0.0 --seeds 192.168.200.100 --rpc-address 192.168.200.100 --alternator-address 192.168.200.100 --listen-address 192.168.200.100

--- a/testing/docker-compose-ipv6.yaml
+++ b/testing/docker-compose-ipv6.yaml
@@ -50,12 +50,20 @@ services:
         ipv6_address: 2001:0DB9:200::23
 
   second_cluster_dc1_node_1:
-    command: ${SCYLLA_SECOND_CLUSTER_ARGS} --rpc-address 2001:0DB9:100::30 --alternator-address 2001:0DB9:200::30 --listen-address 2001:0DB9:200::30
+    command: ${SCYLLA_SECOND_CLUSTER_ARGS} --rpc-address 2001:0DB9:100::31 --alternator-address 2001:0DB9:200::31 --listen-address 2001:0DB9:200::31
     networks:
       public:
-        ipv6_address: 2001:0DB9:100::30
+        ipv6_address: 2001:0DB9:100::31
       second:
-        ipv6_address: 2001:0DB9:200::30
+        ipv6_address: 2001:0DB9:200::31
+
+  second_cluster_dc1_node_2:
+    command: ${SCYLLA_SECOND_CLUSTER_ARGS} --rpc-address 2001:0DB9:100::32 --alternator-address 2001:0DB9:200::32 --listen-address 2001:0DB9:200::32
+    networks:
+      public:
+        ipv6_address: 2001:0DB9:100::32
+      second:
+        ipv6_address: 2001:0DB9:200::32
 
   scylla-manager-db:
     command: --smp 1 --memory 500M --api-address 0.0.0.0 --seeds 2001:0DB9:200::100 --rpc-address 2001:0DB9:200::100 --alternator-address 2001:0DB9:200::100 --listen-address 2001:0DB9:200::100

--- a/testing/docker-compose.yaml
+++ b/testing/docker-compose.yaml
@@ -141,6 +141,26 @@ services:
       public:
       second:
 
+  second_cluster_dc1_node_2:
+    image: scylladb/scylla-agent:${SCYLLA_VERSION}
+    privileged: true
+    volumes:
+      - type: bind
+        source: ./scylla/cassandra-second-cluster.properties
+        target: /etc/scylla/cassandra-rackdc.properties
+      - type: bind
+        source: ./scylla/scylla-second-cluster.yaml
+        target: /etc/scylla/scylla.yaml
+      - type: bind
+        source: ./scylla/certs/
+        target: /etc/scylla/certs
+      - type: bind
+        source: ./scylla/cqlshrc
+        target: /root/.cassandra/cqlshrc
+    networks:
+      public:
+      second:
+
   scylla-manager-db:
     image: ${SCYLLA_IMAGE}:${SCYLLA_VERSION}
     ports:


### PR DESCRIPTION
This PR add an additional node to restore src cluster. This results in:
- changing tests so that we restore into ks with identical schema as in src
- improve overall restore tests quality

Because of the #3481, master wasn't green recently, so this PR also fixes minor implementation bugs and fixes flaky tests (more info in commit messages).

Related #3466 
Possibly related #3485
Fixes  #3479