### PR TITLE
service.go: fix repair semantics regression

### DIFF
--- a/pkg/service/repair/controller_test.go
+++ b/pkg/service/repair/controller_test.go
@@ -240,9 +240,7 @@ func TestRowLevelRepairController(t *testing.T) {
 			if a.Ranges != controllerTestDefaultRangesLimit {
 				t.Fatalf("TryBlock()=%v, expected %d ranges", a, controllerTestDefaultRangesLimit)
 			}
-			if a.ShardsPercent != 0.5 {
-				t.Fatalf("TryBlock()=%v, expected %f shards percent", a, 0.5)
-			}
+
 			queue = append(queue, a)
 		}
 		if ok, _ := ctl.TryBlock([]string{"a", "b", "c"}); ok {

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -565,9 +565,15 @@ func (s *Service) hostRangeLimits(ctx context.Context, client *scyllaclient.Clie
 			return errors.Wrapf(err, "%s: get shard count", h)
 		}
 
+		// Since we don't issue repairs for per-shard ranges anymore floating point 'intensity' becomes irrelevant.
+		// We will allow up to a single repair task per replica host as our documentation mandates and will allow
+		// 1 or more token ranges per repair task. The maximum amount ranges per task is limited by
+		// s.maxRepairRangesInParallel().
 		v := rangesLimit{
-			Default: int(shards),
-			Max:     s.maxRepairRangesInParallel(shards, totalMemory),
+			Default: 1,
+			//TODO: collect max_repair_ranges_in_parallel from scylla hosts using a not-yet-existing API
+			// In the meantime use good-enough value
+			Max: s.maxRepairRangesInParallel(shards, totalMemory),
 		}
 		s.logger.Info(ctx, "Host repair intensity limit", "host", h, "limit", v)
 


### PR DESCRIPTION
Restore the repair task sanity.

Make the code correspond design and Documentation.
See more in the patches description.

Fixes #3463 and #3424

