### PR TITLE
doc: fix the description of repair parallel

### DIFF
--- a/docs/source/sctool/partials/sctool_repair.yaml
+++ b/docs/source/sctool/partials/sctool_repair.yaml
@@ -105,10 +105,10 @@ options:
   default_value: "0"
   usage: |
     The maximum number of Scylla repair jobs that can run at the same time (on different token ranges and replicas).
-    Each node can take part in at most one repair at any given moment.
     By default the maximum possible parallelism is used.
     The effective parallelism depends on a keyspace replication factor (RF) and the number of nodes.
-    The formula to calculate is is as follows: number of nodes / RF, ex. for 6 node cluster with RF=3 the maximum parallelism is 2.
+    The formula to calculate is is as follows: number of nodes / RF.
+    For example, the maximum parallelism for a 6 node cluster with RF=3 is 2.
 - name: retry-wait
   default_value: 10m
   usage: |


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-manager/issues/3505

This commit fixes the description for the `parallel` option of `sctool repair`:
- The incorrect information about one-repair-per-node is removed.
- The language is fixed for better clarity.

@karol-kokoszka I think it should be backported to version 3.1 and 3.0.


