### PR TITLE
Extend sctool cluster list with CQL credentials

### DIFF
--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -37,13 +37,17 @@ type ClusterSlice []*models.Cluster
 
 // Render renders ClusterSlice in a tabular format.
 func (cs ClusterSlice) Render(w io.Writer) error {
-	t := table.New("ID", "Name", "Port")
+	t := table.New("ID", "Name", "Port", "CQL credentials")
 	for _, c := range cs {
 		p := "default"
 		if c.Port != 0 {
 			p = fmt.Sprint(c.Port)
 		}
-		t.AddRow(c.ID, c.Name, p)
+		creds := "not set"
+		if c.Username != "" && c.Password != "" {
+			creds = "set"
+		}
+		t.AddRow(c.ID, c.Name, p, creds)
 	}
 	if _, err := w.Write([]byte(t.String())); err != nil {
 		return err

--- a/pkg/restapi/cluster.go
+++ b/pkg/restapi/cluster.go
@@ -77,6 +77,22 @@ func (h clusterHandler) listClusters(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check if cluster CQL credentials are set, but don't return them
+	for _, c := range ids {
+		ok, err := h.svc.CheckCQLCredentials(c.ID)
+		if err != nil {
+			respondError(w, r, errors.Wrapf(err, "cluster %s: check CQL credentials", c.ID))
+			return
+		}
+		if ok {
+			c.Username = "set"
+			c.Password = "set"
+		} else {
+			c.Username = "not set"
+			c.Password = "not set"
+		}
+	}
+
 	if len(ids) == 0 {
 		render.Respond(w, r, []struct{}{})
 		return

--- a/pkg/restapi/cluster_test.go
+++ b/pkg/restapi/cluster_test.go
@@ -29,6 +29,7 @@ func TestClusterList(t *testing.T) {
 	expected := []*cluster.Cluster{{ID: uuid.MustRandom(), Name: "name"}}
 
 	m := restapi.NewMockClusterService(ctrl)
+	m.EXPECT().CheckCQLCredentials(gomock.Any()).Return(true, nil)
 	m.EXPECT().ListClusters(gomock.Any(), &cluster.Filter{}).Return(expected, nil)
 
 	h := restapi.New(restapi.Services{Cluster: m}, log.Logger{})

--- a/pkg/restapi/mock_clusterservice_test.go
+++ b/pkg/restapi/mock_clusterservice_test.go
@@ -36,6 +36,21 @@ func (m *MockClusterService) EXPECT() *MockClusterServiceMockRecorder {
 	return m.recorder
 }
 
+// CheckCQLCredentials mocks base method.
+func (m *MockClusterService) CheckCQLCredentials(arg0 uuid.UUID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckCQLCredentials", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckCQLCredentials indicates an expected call of CheckCQLCredentials.
+func (mr *MockClusterServiceMockRecorder) CheckCQLCredentials(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckCQLCredentials", reflect.TypeOf((*MockClusterService)(nil).CheckCQLCredentials), arg0)
+}
+
 // DeleteCQLCredentials mocks base method.
 func (m *MockClusterService) DeleteCQLCredentials(arg0 context.Context, arg1 uuid.UUID) error {
 	m.ctrl.T.Helper()

--- a/pkg/restapi/services.go
+++ b/pkg/restapi/services.go
@@ -30,6 +30,7 @@ type ClusterService interface {
 	GetCluster(ctx context.Context, idOrName string) (*cluster.Cluster, error)
 	PutCluster(ctx context.Context, c *cluster.Cluster) error
 	DeleteCluster(ctx context.Context, id uuid.UUID) error
+	CheckCQLCredentials(id uuid.UUID) (bool, error)
 	DeleteCQLCredentials(ctx context.Context, id uuid.UUID) error
 	DeleteSSLUserCert(ctx context.Context, id uuid.UUID) error
 	ListNodes(ctx context.Context, id uuid.UUID) ([]cluster.Node, error)

--- a/pkg/service/cluster/service.go
+++ b/pkg/service/cluster/service.go
@@ -467,6 +467,14 @@ func (s *Service) DeleteCluster(ctx context.Context, clusterID uuid.UUID) error 
 	return s.notifyChangeListener(ctx, Change{ID: clusterID, Type: Delete})
 }
 
+// CheckCQLCredentials checks if associated CQLCreds exist in secrets store.
+func (s *Service) CheckCQLCredentials(id uuid.UUID) (bool, error) {
+	credentials := secrets.CQLCreds{
+		ClusterID: id,
+	}
+	return s.secretsStore.Check(&credentials)
+}
+
 // DeleteCQLCredentials removes the associated CQLCreds from secrets store.
 func (s *Service) DeleteCQLCredentials(_ context.Context, clusterID uuid.UUID) error {
 	return s.secretsStore.Delete(&secrets.CQLCreds{

--- a/pkg/service/cluster/service_integration_test.go
+++ b/pkg/service/cluster/service_integration_test.go
@@ -7,10 +7,11 @@ package cluster_test
 
 import (
 	"context"
-	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"os"
 	"strconv"
 	"testing"
+
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -277,6 +278,44 @@ func TestServiceStorageIntegration(t *testing.T) {
 		}
 
 		assertSecrets(t, c)
+	})
+
+	t.Run("check existing CQL credentials", func(t *testing.T) {
+		setup(t)
+
+		c := tlsCluster()
+		c.ID = uuid.Nil
+
+		if err := s.PutCluster(ctx, c); err != nil {
+			t.Fatal(err)
+		}
+		ok, err := s.CheckCQLCredentials(c.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatal("expected true")
+		}
+	})
+
+	t.Run("check non-existing CQL credentials", func(t *testing.T) {
+		setup(t)
+
+		c := tlsCluster()
+		c.ID = uuid.Nil
+		c.Username = ""
+		c.Password = ""
+
+		if err := s.PutCluster(ctx, c); err != nil {
+			t.Fatal(err)
+		}
+		ok, err := s.CheckCQLCredentials(c.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok {
+			t.Fatal("expected false")
+		}
 	})
 
 	t.Run("delete cluster removes secrets", func(t *testing.T) {

--- a/pkg/store/rollback_test.go
+++ b/pkg/store/rollback_test.go
@@ -48,6 +48,13 @@ func (t *testStore) Get(e Entry) error {
 	return e.UnmarshalBinary(*t)
 }
 
+func (t *testStore) Check(e Entry) (bool, error) {
+	if len(*t) == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
 const deleted = 0xf
 
 func (t *testStore) Delete(e Entry) error {

--- a/pkg/store/store_integration_test.go
+++ b/pkg/store/store_integration_test.go
@@ -75,10 +75,10 @@ func TestStorageIntegration(t *testing.T) {
 		if err := s.Get(truth); err != nil {
 			t.Fatal(err)
 		}
+
 		if cmp.Diff(truth.ClusterID, clusterID, UUIDComparer()) != "" {
 			t.Fatal("invalid cluster id")
 		}
-
 		if cmp.Diff(truth.Answer, answer) != "" {
 			t.Fatal("invalid entry value")
 		}
@@ -88,6 +88,31 @@ func TestStorageIntegration(t *testing.T) {
 		setup(t)
 		if err := s.Get(truth); err == nil || !errors.Is(err, service.ErrNotFound) {
 			t.Fatal("expected to get NotFound error")
+		}
+	})
+
+	t.Run("Check existing entry", func(t *testing.T) {
+		setup(t)
+		if err := s.Put(truth); err != nil {
+			t.Fatal(err)
+		}
+		ok, err := s.Check(truth)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatal("expected true")
+		}
+	})
+
+	t.Run("Check non-existing entry", func(t *testing.T) {
+		setup(t)
+		ok, err := s.Check(truth)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok {
+			t.Fatal("expected false")
 		}
 	})
 


### PR DESCRIPTION
Output of this command has been updated with additional column "CQL credentials" which indicates if SM have CQL credentials for given cluster. We don't want to print credentials or even directly query them (use 'COUNT(*)' instead of regular column) for security reasons.

Fixes #3531
