### PR TITLE
Fix repair schedule

### DIFF
--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -762,7 +762,10 @@ func (c *Client) TableDiskSize(ctx context.Context, host, keyspace, table string
 }
 
 // TableExists returns true iff table exists.
-func (c *Client) TableExists(ctx context.Context, keyspace, table string) (bool, error) {
+func (c *Client) TableExists(ctx context.Context, host, keyspace, table string) (bool, error) {
+	if host != "" {
+		ctx = forceHost(ctx, host)
+	}
 	resp, err := c.scyllaOps.ColumnFamilyNameGet(&operations.ColumnFamilyNameGetParams{Context: ctx})
 	if err != nil {
 		return false, err

--- a/pkg/scyllaclient/client_scylla_integration_test.go
+++ b/pkg/scyllaclient/client_scylla_integration_test.go
@@ -208,7 +208,7 @@ func TestClientTableExistsIntegration(t *testing.T) {
 	for i := range table {
 		test := table[i]
 
-		exists, err := client.TableExists(ctx, test.Keyspace, test.Table)
+		exists, err := client.TableExists(ctx, "", test.Keyspace, test.Table)
 		if err != nil {
 			t.Fatalf("TableExists failed: %s", err)
 		}

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 	"go.uber.org/atomic"
+	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -301,11 +302,7 @@ func (s *Service) Repair(ctx context.Context, clusterID, taskID, runID uuid.UUID
 		s.putRunLogError(ctx, run)
 	}
 
-	// Prefer repair error to ctx error
-	if err != nil {
-		return err
-	}
-	return ctx.Err()
+	return multierr.Append(err, ctx.Err())
 }
 
 func (s *Service) killAllRepairs(ctx context.Context, client *scyllaclient.Client, hosts []string) {

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -297,7 +297,7 @@ func (s *Service) Repair(ctx context.Context, clusterID, taskID, runID uuid.UUID
 	close(done)
 
 	// Check if repair is fully finished
-	if ok := gen.plan.UpdateIdx(); !ok {
+	if err == nil && ctx.Err() == nil {
 		run.EndTime = timeutc.Now()
 		s.putRunLogError(ctx, run)
 	}

--- a/pkg/service/repair/testdata/AggregateProgressIntegration/empty_progress_list.golden.json
+++ b/pkg/service/repair/testdata/AggregateProgressIntegration/empty_progress_list.golden.json
@@ -8,6 +8,8 @@
   "duration_ms": 0,
   "hosts": null,
   "tables": null,
+  "max_intensity": 777,
   "intensity": 666,
+  "max_parallel": 99,
   "parallel": 6
 }

--- a/pkg/service/repair/testdata/AggregateProgressIntegration/multiple_progress_multi_host.golden.json
+++ b/pkg/service/repair/testdata/AggregateProgressIntegration/multiple_progress_multi_host.golden.json
@@ -6,7 +6,9 @@
   "started_at": "2019-01-01T00:00:00Z",
   "completed_at": "2019-01-01T00:02:00Z",
   "duration_ms": 120000,
+  "max_intensity": 777,
   "intensity": 666,
+  "max_parallel": 99,
   "parallel": 6,
   "hosts": [
     {

--- a/pkg/service/repair/testdata/AggregateProgressIntegration/single_progress_single_host.golden.json
+++ b/pkg/service/repair/testdata/AggregateProgressIntegration/single_progress_single_host.golden.json
@@ -6,7 +6,9 @@
   "started_at": "2019-01-01T00:00:00Z",
   "completed_at": "2019-01-01T00:01:00Z",
   "duration_ms": 60000,
+  "max_intensity": 777,
   "intensity": 666,
+  "max_parallel": 99,
   "parallel": 6,
   "hosts": [
     {

--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -136,7 +136,7 @@ func (w *worker) handleRunningStatus(ctx context.Context, j job) error {
 
 	// Table deletion is visible only after a short while
 	op := func() error {
-		exists, err := w.client.TableExists(ctx, j.keyspace, j.table)
+		exists, err := w.client.TableExists(ctx, j.master, j.keyspace, j.table)
 		if err != nil {
 			return retry.Permanent(err)
 		}
@@ -155,7 +155,7 @@ func (w *worker) handleRunningStatus(ctx context.Context, j job) error {
 }
 
 func (w *worker) isTableDeleted(ctx context.Context, j job) bool {
-	exists, err := w.client.TableExists(ctx, j.keyspace, j.table)
+	exists, err := w.client.TableExists(ctx, j.master, j.keyspace, j.table)
 	if err != nil {
 		w.logger.Error(ctx, "Couldn't check for table deletion",
 			"keyspace", j.keyspace,

--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -20,7 +20,7 @@ type worker struct {
 	// We want to limit the usage of handleRunningStatus to once per table
 	// in order to avoid long waiting time on failed ranges.
 	stopTrying map[string]struct{}
-	progress   progressManager
+	progress   ProgressManager
 	logger     log.Logger
 }
 


### PR DESCRIPTION
This PR fixes situations when repair task created before SM 3.2 and started after upgrading to 3.2 displayed wrong progress. With those changes, it should work fine even for paused repair tasks resumed after the upgrade.

Fixes #3534