### PR TITLE
Restore: run post-restore repair with max intensity

### DIFF
--- a/pkg/service/backup/restore_worker_tables.go
+++ b/pkg/service/backup/restore_worker_tables.go
@@ -275,7 +275,9 @@ func (w *tablesWorker) stageRepair(ctx context.Context, run *RestoreRun, _ Resto
 		}
 	}
 	repairProps, err := json.Marshal(map[string]any{
-		"keyspace": keyspace,
+		"keyspace":  keyspace,
+		"intensity": 0,
+		"parallel":  0,
 	})
 	if err != nil {
 		return errors.Wrap(err, "parse repair properties")


### PR DESCRIPTION
As cluster shouldn't be under any load during restore procedure, this should make it run more efficient.