### PR TITLE
fix(healtcheck): make native cql to retry if connection is failed

### DIFF
--- a/pkg/ping/cqlping/cqlping_integration_test.go
+++ b/pkg/ping/cqlping/cqlping_integration_test.go
@@ -36,7 +36,7 @@ func TestPingIntegration(t *testing.T) {
 	}
 
 	t.Run("simple", func(t *testing.T) {
-		d, err := NativeCQLPing(context.Background(), config)
+		d, err := NativeCQLPing(context.Background(), config, log.NopLogger)
 		if err != nil {
 			t.Error(err)
 		}
@@ -75,7 +75,7 @@ func TestPingTLSIntegration(t *testing.T) {
 	}
 
 	t.Run("simple", func(t *testing.T) {
-		d, err := NativeCQLPing(context.Background(), config)
+		d, err := NativeCQLPing(context.Background(), config, log.NopLogger)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/ping/cqlping/cqlping_test.go
+++ b/pkg/ping/cqlping/cqlping_test.go
@@ -4,6 +4,7 @@ package cqlping
 
 import (
 	"context"
+	"github.com/scylladb/go-log"
 	"net"
 	"testing"
 	"time"
@@ -42,7 +43,7 @@ func TestPingTimeout(t *testing.T) {
 	}
 
 	t.Run("simple", func(t *testing.T) {
-		d, err := NativeCQLPing(context.Background(), config)
+		d, err := NativeCQLPing(context.Background(), config, log.NopLogger)
 		if err != ping.ErrTimeout {
 			t.Errorf("NativeCQLPing() error %s, expected timeout", err)
 		}

--- a/pkg/service/healthcheck/service.go
+++ b/pkg/service/healthcheck/service.go
@@ -244,11 +244,7 @@ func (s *Service) parallelCQLPingFunc(ctx context.Context, clusterID uuid.UUID, 
 
 			ni, err := s.nodeInfo(ctx, clusterID, status[i].Addr)
 			if err != nil {
-				s.logger.Error(ctx, "Unable to fetch node information",
-					"cluster_id", clusterID,
-					"host", status[i].Addr,
-					"error", err,
-				)
+				s.logger.Error(ctx, "Unable to fetch node information", "error", err)
 				o.SSL = false
 			} else {
 				o.SSL = ni.hasTLSConfig(cqlPing)
@@ -361,7 +357,11 @@ func (s *Service) pingCQL(ctx context.Context, clusterID uuid.UUID, host string,
 	if c := s.cqlCreds(ctx, clusterID); c != nil {
 		rtt, err = cqlping.QueryPing(ctx, config, c.Username, c.Password)
 	} else {
-		rtt, err = cqlping.NativeCQLPing(ctx, config)
+		logger := s.logger.With(
+			"cluster_id", clusterID,
+			"host", host,
+		)
+		rtt, err = cqlping.NativeCQLPing(ctx, config, logger)
 	}
 
 	return rtt, err


### PR DESCRIPTION
Fixes #3550 

Customers complain that healthcheck fails on cqlping having almost no load on the cluster and network working perfectly fine.
