### PR TITLE
fix(backup): generate a proper UUIDv1 for sstable identifier

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/gocql/gocql v1.5.2
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.5
+	github.com/google/uuid v1.1.2
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed
 	github.com/hashicorp/go-version v1.2.0
 	github.com/hbollon/go-edlib v1.5.0
@@ -78,7 +79,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect


### PR DESCRIPTION
before this change, `RandomSSTableUUID()` just return a serial of random bits formatted like 'xxxx_xxxx_xxxxxxxxxxxxxxxxxx', where 'x' is picked from the alphabet of
"abcdefghijklmnopqrstuvwxyz0123456789".
but the generated UUID cannot be decoded by scylla, as it does not encode a UUID v1 (as per RFC4122). that's why scylla chokes when parsing the UUID created by scylla-manager, and throws `std::out_of_range (stoull)`.

in this change, we

* add github.com/google/uuid as an explicit dependency
* leverage github.com/google/uuid to generate a UUID V1, and format it with the same encoding used by scylla's `generation_type`.

Fixes https://github.com/scylladb/scylladb/issues/15226
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
