### PR TITLE
Reduce agent log spam

### DIFF
--- a/pkg/cmd/agent/log.go
+++ b/pkg/cmd/agent/log.go
@@ -1,0 +1,59 @@
+// Copyright (C) 2023 ScyllaDB
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/scylladb/go-log"
+)
+
+// RequestLogger populates metrics on all responses but logs only on errors.
+func RequestLogger(logger log.Logger, metrics AgentMetrics) func(next http.Handler) http.Handler {
+	return middleware.RequestLogger(&logFormatter{logger: logger, metrics: metrics})
+}
+
+type logFormatter struct {
+	logger  log.Logger
+	metrics AgentMetrics
+}
+
+func (lf logFormatter) NewLogEntry(r *http.Request) middleware.LogEntry {
+	return &logEntry{
+		r: r,
+		l: lf.logger,
+		m: lf.metrics,
+	}
+}
+
+type logEntry struct {
+	r *http.Request
+	l log.Logger
+	m AgentMetrics
+}
+
+func (le *logEntry) Write(status, bytes int, _ http.Header, elapsed time.Duration, _ interface{}) {
+	le.m.RecordStatusCode(le.r.Method, le.r.URL.EscapedPath(), status)
+
+	ctx := le.r.Context()
+	uri := le.r.Method + " " + le.r.URL.RequestURI()
+	f := []any{
+		"from", le.r.RemoteAddr,
+		"status", status,
+		"bytes", bytes,
+		"duration", fmt.Sprintf("%dms", elapsed.Milliseconds()),
+	}
+
+	if status < 400 {
+		le.l.Debug(ctx, uri, f...)
+	} else {
+		le.l.Error(ctx, uri, f...)
+	}
+}
+
+func (le *logEntry) Panic(v interface{}, stack []byte) {
+	le.l.Error(le.r.Context(), "Panic", "panic", v, "stack", stack)
+}

--- a/pkg/cmd/agent/metrics.go
+++ b/pkg/cmd/agent/metrics.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 ScyllaDB
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type AgentMetrics struct {
+	StatusCode *prometheus.CounterVec
+}
+
+func NewAgentMetrics() AgentMetrics {
+	return AgentMetrics{
+		StatusCode: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "scylla_manager_agent",
+			Subsystem: "http",
+			Name:      "status_code",
+			Help:      "Total count of http requests with response status code.",
+		}, []string{"method", "path", "code"}),
+	}
+}
+
+// MustRegister shall be called to make the metrics visible by prometheus client.
+func (m AgentMetrics) MustRegister() AgentMetrics {
+	prometheus.MustRegister(m.StatusCode)
+	return m
+}
+
+// RecordStatusCode increases counter of "status_code" metric.
+func (m AgentMetrics) RecordStatusCode(method, path string, status int) {
+	m.StatusCode.WithLabelValues(method, path, fmt.Sprint(status)).Inc()
+}

--- a/pkg/cmd/agent/router.go
+++ b/pkg/cmd/agent/router.go
@@ -11,21 +11,19 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/scylladb/go-log"
-
 	"github.com/scylladb/scylla-manager/v3/pkg/auth"
 	"github.com/scylladb/scylla-manager/v3/pkg/config/agent"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/httphandler"
-	"github.com/scylladb/scylla-manager/v3/pkg/util/httplog"
 )
 
 var unauthorizedErrorBody = json.RawMessage(`{"message":"unauthorized","code":401}`)
 
-func newRouter(c agent.Config, rclone http.Handler, logger log.Logger) http.Handler {
+func newRouter(c agent.Config, metrics AgentMetrics, rclone http.Handler, logger log.Logger) http.Handler {
 	r := chi.NewRouter()
 
 	// Common middleware
 	r.Use(
-		httplog.RequestLogger(logger),
+		RequestLogger(logger, metrics),
 	)
 	// Common endpoints
 	r.Get("/ping", httphandler.Heartbeat())

--- a/pkg/cmd/agent/router_test.go
+++ b/pkg/cmd/agent/router_test.go
@@ -25,7 +25,7 @@ func TestRcloneRouting(t *testing.T) {
 	c := agent.Config{}
 	rclone := assertURLPath(t, "/foo")
 
-	h := newRouter(c, rclone, log.NewDevelopment())
+	h := newRouter(c, NewAgentMetrics(), rclone, log.NewDevelopment())
 	r := httptest.NewRequest(http.MethodGet, "/agent/rclone/foo", nil)
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, r)
@@ -52,7 +52,7 @@ func TestProxyRouting(t *testing.T) {
 		},
 	}
 
-	h := newRouter(c, nil, log.NewDevelopment())
+	h := newRouter(c, NewAgentMetrics(), nil, log.NewDevelopment())
 
 	r := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
Logging all requests overpopulates logs, so it's better to log only log requests with error status code. In order to make up for this loss of information, agent populates `scylla_manager_agent_http_status_code` metric with counter of http requests with their response status code.

Fixes #3451
Fixes #3125