### PR TITLE
feat(scylladb): increase memory limit for ScyllaDB to 500M

### DIFF
--- a/dist/scripts/scyllamgr_setup
+++ b/dist/scripts/scyllamgr_setup
@@ -120,7 +120,7 @@ if command -v scylla_setup > /dev/null && [[ ${SETUP_SCYLLA} == 1 ]]; then
         f=/etc/sysconfig/scylla-server
     fi
     if [[ "$f" != "" ]]; then
-      sed -i -e 's/^SCYLLA_ARGS=.*/SCYLLA_ARGS="--memory 250M --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --network-stack posix"/g' ${f}
+      sed -i -e 's/^SCYLLA_ARGS=.*/SCYLLA_ARGS="--memory 500M --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --network-stack posix"/g' ${f}
     fi
 fi
 


### PR DESCRIPTION
When testing ScyllaDB 2023.1.0 and Scylla Manager 3.2.0 I've encountered and issue of insufficient memory being available to ScyllaDB used by Scylla Manager to store its internal data, this resulted in ScyllaDB not being able to start up properly. I propose to change it to `500M` according to https://github.com/scylladb/siren/pull/9602#issuecomment-1694659667
