### PR TITLE
Better explanation on host down

### DIFF
--- a/pkg/command/repair/cmd.go
+++ b/pkg/command/repair/cmd.go
@@ -4,9 +4,9 @@ package repair
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-manager/v3/pkg/command/flag"
 	"github.com/scylladb/scylla-manager/v3/pkg/managerclient"
 	"github.com/spf13/cobra"

--- a/pkg/managerclient/error.go
+++ b/pkg/managerclient/error.go
@@ -16,6 +16,9 @@ func PrintError(w io.Writer, err error) {
 	if ok {
 		p := v.GetPayload()
 
+		if len(p.Details) > 0 {
+			fmt.Fprintf(w, "%s\n\n", p.Details)
+		}
 		fmt.Fprintf(w, "Error: %s\n", FormatError(p.Message))
 		fmt.Fprintf(w, "Trace ID: %s (grep in scylla-manager logs)\n", p.TraceID)
 	} else {

--- a/pkg/restapi/error_test.go
+++ b/pkg/restapi/error_test.go
@@ -20,7 +20,7 @@ func TestRespondError(t *testing.T) {
 		response := httptest.NewRecorder()
 
 		respondError(response, request, errors.Wrap(err, "specific_msg"))
-		expected := `{"message":"get resource: specific_msg: wrapped: not found","trace_id":""}` + "\n"
+		expected := `{"message":"get resource: specific_msg: wrapped: not found","details":"","trace_id":""}` + "\n"
 		if diff := cmp.Diff(response.Body.String(), expected); diff != "" {
 			t.Fatal(diff)
 		}
@@ -34,7 +34,7 @@ func TestRespondError(t *testing.T) {
 		response := httptest.NewRecorder()
 
 		respondError(response, request, errors.Wrap(err, "specific_msg"))
-		expected := `{"message":"specific_msg: some problem","trace_id":""}` + "\n"
+		expected := `{"message":"specific_msg: some problem","details":"","trace_id":""}` + "\n"
 		if diff := cmp.Diff(response.Body.String(), expected); diff != "" {
 			t.Fatal(diff)
 		}
@@ -48,7 +48,7 @@ func TestRespondError(t *testing.T) {
 		response := httptest.NewRecorder()
 
 		respondError(response, request, errors.Wrap(err, "specific_msg"))
-		expected := `{"message":"specific_msg: wrapped: unknown problem","trace_id":""}` + "\n"
+		expected := `{"message":"specific_msg: wrapped: unknown problem","details":"","trace_id":""}` + "\n"
 		if diff := cmp.Diff(response.Body.String(), expected); diff != "" {
 			t.Fatal(diff)
 		}

--- a/swagger/gen/scylla-manager/models/error_response.go
+++ b/swagger/gen/scylla-manager/models/error_response.go
@@ -15,6 +15,9 @@ import (
 // swagger:model ErrorResponse
 type ErrorResponse struct {
 
+	// Human readable description
+	Details string `json:"details,omitempty"`
+
 	// Error description
 	Message string `json:"message,omitempty"`
 

--- a/swagger/scylla-manager.json
+++ b/swagger/scylla-manager.json
@@ -1113,6 +1113,10 @@
     "ErrorResponse": {
       "type": "object",
       "properties": {
+        "details": {
+          "description": "Human readable description",
+          "type": "string"
+        },
         "message": {
           "description": "Error description",
           "type": "string"


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-manager/issues/3568

CLI error message is extended and contains information about the reason why task creation failed.

```
One of the nodes is down. Task cannot be created.
Check --ignore-down-hosts flag if you wish to exclude the node from the repair.

Error: create repair target: create repair plan: calculate tables size: fetch table disk size report
 192.168.200.12: giving up after 2 attempts: agent [HTTP 502] 
invalid response from host
Trace ID: Qs_yl1nOSXiWTwr0J7Oh6Q (grep in scylla-manager logs)
```

---

"Only the Best is Good Enough." - LEGO company motto

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
