### PR TITLE
Repair test: extend duration cmp limit (#3573)

### DIFF
--- a/pkg/service/repair/progress_integration_test.go
+++ b/pkg/service/repair/progress_integration_test.go
@@ -30,7 +30,7 @@ func TestProgressManagerIntegration(t *testing.T) {
 		cmpopts.IgnoreUnexported(RunProgress{}),
 		UUIDComparer(),
 		NearTimeComparer(5 * time.Millisecond),
-		NearDurationComparer(1 * time.Millisecond),
+		NearDurationComparer(5 * time.Millisecond),
 	}
 
 	t.Run("progress update sequence (Init,OnJobStart,OnJobEnd)", func(t *testing.T) {


### PR DESCRIPTION
As we can see in the issue, this test can sometimes fail on duration comparison limit. Those tests were originally written for local testing envs and were rekicked in case of failures, so I think that simply increasing the timeout should do the trick.

Fixes #3573
