### PR TITLE
fix(systemd-files): make it restart on non-zero exit

### DIFF
--- a/dist/systemd/scylla-manager-agent.service
+++ b/dist/systemd/scylla-manager-agent.service
@@ -4,6 +4,8 @@ Wants=scylla-server.service
 Wants=scylla-helper.slice
 After=scylla-server.service
 After=network-online.target
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -13,7 +15,6 @@ ExecStart=/usr/bin/scylla-manager-agent
 TimeoutStartSec=900
 KillMode=process
 Restart=on-failure
-RestartPreventExitStatus=1
 StandardOutput=journal
 StandardError=journal
 SyslogLevelPrefix=false

--- a/dist/systemd/scylla-manager.service
+++ b/dist/systemd/scylla-manager.service
@@ -3,6 +3,8 @@ Description=Scylla Manager Server
 Wants=scylla-server.service
 After=scylla-server.service
 After=network-online.target
+StartLimitIntervalSec=120
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -13,7 +15,6 @@ LimitNOFILE=100000
 TimeoutStartSec=900
 KillMode=process
 Restart=on-failure
-RestartPreventExitStatus=1
 StandardOutput=journal
 StandardError=journal
 SyslogLevelPrefix=false


### PR DESCRIPTION
Closes #3561 

Time to time it can happen that agent and server are failing on the start.
To exclude all temporary cases `RestartPreventExitStatus` is removed to make systemd restart them automatically
And `StartLimitBurst` is set, to make systemd not to start them if problem is not going away
