### PR TITLE
Collect agent memory profile

### DIFF
--- a/pkg/cmd/agent/server.go
+++ b/pkg/cmd/agent/server.go
@@ -303,7 +303,7 @@ func (s *server) saveDebugProfile(ctx context.Context, profileType string, cnt i
 }
 
 func profilePath(profileType string, cnt int) string {
-	return path.Join("/tmp/pprof/", profileType, fmt.Sprint(cnt))
+	return path.Join("/home/scyllaadm/logs/pprof", profileType, fmt.Sprint(cnt))
 }
 
 func (s *server) shutdownServers(ctx context.Context, timeout time.Duration) {


### PR DESCRIPTION
This commit allows for collecting agent memory profiles (heap, allocs, goroutines). In order to collect profiles:
- `scylla-manager-agent.yaml` has to have `debug` field specified
- profiles are saved in `/tmp/pprof/<profile-type>/<cnt>` agent files, so they have to be extracted from agent before destroying the instance

Currently profiles are collected every 30 min and only 60 newest profiles are saved. Those profiles can be analyzed separately or as a delta. 