### PR TITLE
Repair: small table optimization improvements

### DIFF
--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -126,6 +126,7 @@ func newGenerator(ctx context.Context, target Target,
 				"order", ord,
 				"keyspace", kp.Keyspace,
 				"table", tp.Table,
+				"size", tp.Size,
 				"merge_ranges", tp.Optimize,
 			)
 		}

--- a/pkg/service/repair/plan.go
+++ b/pkg/service/repair/plan.go
@@ -228,7 +228,7 @@ func (p *plan) FillSize(ctx context.Context, client *scyllaclient.Client, smallT
 		for j := range kp.Tables {
 			kp.Tables[j].Size = tableSize[kp.Keyspace+"."+kp.Tables[j].Table]
 			// Return merged ranges for small, fully replicated table (#3128)
-			if kp.Tables[j].Size <= smallTableThreshold && len(kp.Replicas) == 1 {
+			if kp.Tables[j].Size < smallTableThreshold && len(kp.Replicas) == 1 {
 				kp.Tables[j].Optimize = true
 			}
 		}


### PR DESCRIPTION
This PR improves observability  and control over repair small table optimization.
Those changes seems to be useful when dealing with #3584.