### PR TITLE
Testing: disable agent log sampling

### DIFF
--- a/testing/scylla-manager-agent/scylla-manager-agent-ipv6.yaml
+++ b/testing/scylla-manager-agent/scylla-manager-agent-ipv6.yaml
@@ -4,6 +4,7 @@ debug: :5112
 
 logger:
   level: debug
+  sampling: null
 
 s3:
   access_key_id: miniouser

--- a/testing/scylla-manager-agent/scylla-manager-agent.yaml
+++ b/testing/scylla-manager-agent/scylla-manager-agent.yaml
@@ -4,6 +4,7 @@ debug: :5112
 
 logger:
   level: debug
+  sampling: null
 
 s3:
   access_key_id: miniouser


### PR DESCRIPTION
By default, agent samples logs, so it only saves first occurrence of a similar log message in a given time frame.
I believe that it would be better to disable it for testing, so that we don't miss any logs there. 
