### PR TITLE
Bump dev version and remove warnings during build

### DIFF
--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -72,7 +72,6 @@ archives:
       - license/LICENSE*
       - scripts
       - systemd
-    rlcp: true
 
 nfpms:
   - id: server

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,5 +1,5 @@
 RELEASE      := 0.$(shell date +%Y%m%d).$(shell git describe --always)
-VERSION	     ?= 3.2.0-dev
+VERSION	     ?= 3.3.0-dev
 
 ifdef $$VERSION
 VERSION := $$VERSION

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -13,7 +13,7 @@ GORELEASER := goreleaser --clean
 .PHONY: release
 release:
 	git tag $(VERSION_NAME) || true
-	$(GORELEASER) --skip-publish --skip-validate
+	$(GORELEASER) --skip=publish --skip=validate
 
 .PHONY: snapshot
 snapshot:


### PR DESCRIPTION
This PR contains the following commits:

- 3ed75f391d3e3efb04291ffa8a78243e95e0bada - Makefile: bump dev version to 3.3.0
- a7cb3318f221fe4fbda42f9803c9b29d89962ddb - Remove warning during build