### PR TITLE
.goreleaser: add support for arm based docker image

### DIFF
--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -231,19 +231,66 @@ nfpms:
 
 dockers:
   - ids:
-      - server
-      - client
+    - server
+    - client
+    use: docker
+    goos: linux
+    goarch: amd64
     image_templates:
-      - "scylladb/scylla-manager:{{ .Version }}"
-    dockerfile: docker/scylla-manager.dockerfile
+      - "scylladb/scylla-manager:{{ .Version }}-x86_64"
+    dockerfile:
+      docker/scylla-manager.dockerfile
     extra_files:
       - docker/scylla-manager.yaml
+    build_flag_templates:
+    - "--build-arg=BASE_IMAGE=ubuntu:22.04"
+    - "--build-arg=ARCH=amd64"
 
   - ids:
-      - agent
+    - server
+    - client
+    use: docker
+    goos: linux
+    goarch: arm64
     image_templates:
-      - "scylladb/scylla-manager-agent:{{ .Version }}"
-    dockerfile: docker/scylla-manager-agent.dockerfile
+      - "scylladb/scylla-manager:{{ .Version }}-aarch64"
+    dockerfile:
+      docker/scylla-manager.dockerfile
+    extra_files:
+      - docker/scylla-manager.yaml
+    build_flag_templates:
+    - "--build-arg=BASE_IMAGE=arm64v8/ubuntu:22.04"
+    - "--build-arg=ARCH=arm64"
+
+  - ids:
+    - agent
+    use: docker
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "scylladb/scylla-manager-agent:{{ .Version }}-x86_64"
+    dockerfile:
+      docker/scylla-manager-agent.dockerfile
+    extra_files:
+      - docker/scylla-manager.yaml
+    build_flag_templates:
+    - "--build-arg=BASE_IMAGE=ubuntu:22.04"
+    - "--build-arg=ARCH=amd64"
+
+  - ids:
+    - agent
+    use: docker
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "scylladb/scylla-manager-agent:{{ .Version }}-aarch64"
+    dockerfile:
+      docker/scylla-manager-agent.dockerfile
+    extra_files:
+      - docker/scylla-manager.yaml
+    build_flag_templates:
+    - "--build-arg=BASE_IMAGE=arm64v8/ubuntu:22.04"
+    - "--build-arg=ARCH=arm64"
 
 checksum:
   name_template: 'checksums'

--- a/dist/docker/scylla-manager-agent.dockerfile
+++ b/dist/docker/scylla-manager-agent.dockerfile
@@ -1,4 +1,7 @@
-FROM ubuntu:22.04
+ARG BASE_IMAGE
+
+FROM $BASE_IMAGE
+ARG ARCH
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
@@ -6,8 +9,8 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY scylla-manager-agent*.deb /
-RUN dpkg -i scylla-manager-agent*.deb && rm /scylla-manager-agent*.deb
+COPY scylla-manager-agent*$ARCH.deb /
+RUN dpkg -i scylla-manager-agent*$ARCH.deb && rm /scylla-manager-agent*.deb
 
 USER scylla-manager
 ENV HOME /var/lib/scylla-manager/

--- a/dist/docker/scylla-manager.dockerfile
+++ b/dist/docker/scylla-manager.dockerfile
@@ -1,13 +1,15 @@
-FROM ubuntu:22.04
+ARG BASE_IMAGE
 
+FROM $BASE_IMAGE
+ARG ARCH
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY scylla-manager-*.deb /
-RUN dpkg -i scylla-manager-*.deb && rm /scylla-manager-*.deb
+COPY scylla-manager-*$ARCH.deb /
+RUN dpkg -i scylla-manager-*$ARCH.deb && rm /scylla-manager-*.deb
 COPY docker/scylla-manager.yaml /etc/scylla-manager/
 
 USER scylla-manager


### PR DESCRIPTION
Adding arm support to our Scylla-manager docker image

This will only build additional docker image, the publish part will be done as part of https://github.com/scylladb/scylla-pkg/issues/3239

Closes: https://github.com/scylladb/scylla-manager/issues/3278

