### PR TITLE
manager: Adding docker multi-arch support

### DIFF
--- a/dist/.goreleaser-docker.yaml
+++ b/dist/.goreleaser-docker.yaml
@@ -1,0 +1,97 @@
+project_name: scylla-manager
+dist: release-docker
+builds:
+- skip: true
+
+dockers:
+  - ids:
+    - server
+    - client
+    use: docker
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "scylladb/scylla-manager:{{ .Version }}-x86_64"
+    dockerfile:
+      docker/scylla-manager.dockerfile
+    extra_files:
+      - docker/scylla-manager.yaml
+      - release
+    build_flag_templates:
+    - "--build-arg=BASE_IMAGE=ubuntu:22.04"
+    - "--build-arg=ARCH=amd64"
+
+  - ids:
+    - server
+    - client
+    use: docker
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "scylladb/scylla-manager:{{ .Version }}-aarch64"
+    dockerfile:
+      docker/scylla-manager.dockerfile
+    extra_files:
+      - docker/scylla-manager.yaml
+      - release/
+    build_flag_templates:
+    - "--build-arg=BASE_IMAGE=arm64v8/ubuntu:22.04"
+    - "--build-arg=ARCH=arm64"
+
+  - ids:
+    - agent
+    use: docker
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "scylladb/scylla-manager-agent:{{ .Version }}-x86_64"
+    dockerfile:
+      docker/scylla-manager-agent.dockerfile
+    extra_files:
+      - docker/scylla-manager.yaml
+      - release
+    build_flag_templates:
+    - "--build-arg=BASE_IMAGE=ubuntu:22.04"
+    - "--build-arg=ARCH=amd64"
+
+  - ids:
+    - agent
+    use: docker
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "scylladb/scylla-manager-agent:{{ .Version }}-aarch64"
+    dockerfile:
+      docker/scylla-manager-agent.dockerfile
+    extra_files:
+      - docker/scylla-manager.yaml
+      - release
+    build_flag_templates:
+    - "--build-arg=BASE_IMAGE=arm64v8/ubuntu:22.04"
+    - "--build-arg=ARCH=arm64"
+
+docker_manifests:
+  - id: scylla-manager
+    name_template: "scylladb/scylla-manager:{{ .Version }}"
+    image_templates:
+    - "scylladb/scylla-manager:{{ .Version }}-x86_64"
+    - "scylladb/scylla-manager:{{ .Version }}-aarch64"
+    create_flags:
+    - --insecure
+    push_flags:
+    - --insecure
+    skip_push: false
+
+  - id: scylla-manager-agent
+    name_template: "scylladb/scylla-manager-agent:{{ .Version }}"
+    image_templates:
+    - "scylladb/scylla-manager-agent:{{ .Version }}-x86_64"
+    - "scylladb/scylla-manager-agent:{{ .Version }}-aarch64"
+    create_flags:
+    - --insecure
+    push_flags:
+    - --insecure
+    skip_push: false
+
+checksum:
+  name_template: 'checksums'

--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -12,6 +12,7 @@ changelog:
 
 snapshot:
     name_template: '{{ .Version }}-SNAPSHOT'
+
 builds:
   - id: server
     dir: ../pkg
@@ -228,69 +229,6 @@ nfpms:
           postinstall: rpm/scylla-manager-agent.postinst
           preremove: rpm/scylla-manager-agent.prerm
           postremove: rpm/scylla-manager-agent.postrm
-
-dockers:
-  - ids:
-    - server
-    - client
-    use: docker
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "scylladb/scylla-manager:{{ .Version }}-x86_64"
-    dockerfile:
-      docker/scylla-manager.dockerfile
-    extra_files:
-      - docker/scylla-manager.yaml
-    build_flag_templates:
-    - "--build-arg=BASE_IMAGE=ubuntu:22.04"
-    - "--build-arg=ARCH=amd64"
-
-  - ids:
-    - server
-    - client
-    use: docker
-    goos: linux
-    goarch: arm64
-    image_templates:
-      - "scylladb/scylla-manager:{{ .Version }}-aarch64"
-    dockerfile:
-      docker/scylla-manager.dockerfile
-    extra_files:
-      - docker/scylla-manager.yaml
-    build_flag_templates:
-    - "--build-arg=BASE_IMAGE=arm64v8/ubuntu:22.04"
-    - "--build-arg=ARCH=arm64"
-
-  - ids:
-    - agent
-    use: docker
-    goos: linux
-    goarch: amd64
-    image_templates:
-      - "scylladb/scylla-manager-agent:{{ .Version }}-x86_64"
-    dockerfile:
-      docker/scylla-manager-agent.dockerfile
-    extra_files:
-      - docker/scylla-manager.yaml
-    build_flag_templates:
-    - "--build-arg=BASE_IMAGE=ubuntu:22.04"
-    - "--build-arg=ARCH=amd64"
-
-  - ids:
-    - agent
-    use: docker
-    goos: linux
-    goarch: arm64
-    image_templates:
-      - "scylladb/scylla-manager-agent:{{ .Version }}-aarch64"
-    dockerfile:
-      docker/scylla-manager-agent.dockerfile
-    extra_files:
-      - docker/scylla-manager.yaml
-    build_flag_templates:
-    - "--build-arg=BASE_IMAGE=arm64v8/ubuntu:22.04"
-    - "--build-arg=ARCH=arm64"
 
 checksum:
   name_template: 'checksums'

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,11 +1,18 @@
 RELEASE      := 0.$(shell date +%Y%m%d).$(shell git describe --always)
 VERSION	     ?= 3.3.0-dev
+PUBLISH      := 0
 
 ifdef $$VERSION
 VERSION := $$VERSION
 endif
 
+ifeq ($(PUBLISH),0)
+publish = --skip=publish
 VERSION_NAME := $(VERSION)-$(RELEASE)
+else
+VERSION_NAME := v$(VERSION)
+endif
+
 $(shell echo $(VERSION) > .version)
 $(shell echo $(RELEASE) > .release)
 
@@ -13,12 +20,15 @@ GORELEASER := goreleaser --clean
 .PHONY: release
 release:
 	git tag $(VERSION_NAME) || true
-	$(GORELEASER) --skip=publish --skip=validate
+	$(GORELEASER) $(publish) --skip=validate --config .goreleaser.yaml
+	$(GORELEASER) --skip=validate --config .goreleaser-docker.yaml
 
 .PHONY: snapshot
 snapshot:
-	GORELEASER_CURRENT_TAG=$(VERSION_NAME) $(GORELEASER) --snapshot
+	GORELEASER_CURRENT_TAG=$(VERSION_NAME)
+	$(GORELEASER) --snapshot --skip=publish --skip=validate --config .goreleaser.yaml
+	$(GORELEASER) --skip=validate --config .goreleaser-docker.yaml
 
 .PHONY: clean
 clean:
-	@rm -Rf release
+	@rm -Rf release release-docker .version .release

--- a/dist/docker/scylla-manager-agent.dockerfile
+++ b/dist/docker/scylla-manager-agent.dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY scylla-manager-agent*$ARCH.deb /
+COPY release/scylla-manager-agent*$ARCH.deb /
 RUN dpkg -i scylla-manager-agent*$ARCH.deb && rm /scylla-manager-agent*.deb
 
 USER scylla-manager

--- a/dist/docker/scylla-manager.dockerfile
+++ b/dist/docker/scylla-manager.dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY scylla-manager-*$ARCH.deb /
+COPY release/scylla-manager-*$ARCH.deb /
 RUN dpkg -i scylla-manager-*$ARCH.deb && rm /scylla-manager-*.deb
 COPY docker/scylla-manager.yaml /etc/scylla-manager/
 


### PR DESCRIPTION
In this PR we moved all docker-related build processes back to goreleaser, so build, publish and manifest creation (which we need to support multi-arch images) will be done here instead of `Scylla-pkg`.

Since we always want to publish our docker images (including in master) I have created a dedicated yaml file configuration for our docker build process

As a result, for releases only, we will be able to publish the release to GitHub

Closes: https://github.com/scylladb/scylla-manager/issues/3278

**This should be merged together with https://github.com/scylladb/scylla-pkg/pull/3615**
