### PR TITLE
Add worker pool to repair

### DIFF
--- a/pkg/service/repair/controller_test.go
+++ b/pkg/service/repair/controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/scylladb/go-log"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/workerpool"
 	"go.uber.org/atomic"
 )
 
@@ -35,6 +36,9 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 			intensity:        atomic.NewFloat64(defaultIntensity),
 			maxParallel:      3,
 			parallel:         atomic.NewInt64(defaultParallel),
+			poolController: workerpool.New[*worker, job, jobResult](context.Background(), func(ctx context.Context, id int) *worker {
+				return &worker{}
+			}, 1024),
 		}
 	}
 

--- a/pkg/util/workerpool/pool.go
+++ b/pkg/util/workerpool/pool.go
@@ -1,0 +1,173 @@
+// Copyright (C) 2023 ScyllaDB
+
+package workerpool
+
+import (
+	"context"
+	"sync"
+)
+
+// JobHandler describes handler for tasks of type T which returns results of type R.
+type JobHandler[T, R any] interface {
+	// HandleJob is called when worker receives task from the pool.
+	HandleJob(ctx context.Context, task T) R
+	// Done is called when worker exits.
+	Done(ctx context.Context)
+}
+
+// Pool allows for executing homogenous JobHandlers with ongoing control over parallelism.
+// Use Spawn, Kill and SetSize methods to change the current amount of workers.
+// Use Submit to submit new task and Results to wait for the results.
+// Pool can be closed with Close or drained with cancelling workers context.
+type Pool[W JobHandler[T, R], T, R any] struct {
+	workerCtx   context.Context // nolint: containedctx
+	spawnWorker func(ctx context.Context, id int) W
+
+	tasks      chan T
+	results    chan R
+	killWorker chan struct{}
+	size       int
+	totalSize  int
+	wait       sync.WaitGroup
+	closed     bool
+	mu         sync.Mutex
+}
+
+// New returns newly created Pool.
+// WorkerCtx is passed to ever HandleJob execution and can be cancelled
+// to shut down the pool.
+// Spawn function is used for creating new JobHandlers with unique ID.
+// ChanSize describes the max number of unprocessed tasks and results
+// before operations start blocking.
+func New[W JobHandler[T, R], T, R any](workerCtx context.Context, spawn func(context.Context, int) W, chanSize int) *Pool[W, T, R] {
+	return &Pool[W, T, R]{
+		workerCtx:   workerCtx,
+		spawnWorker: spawn,
+		tasks:       make(chan T, chanSize),
+		results:     make(chan R, chanSize),
+		killWorker:  make(chan struct{}, chanSize),
+		size:        0,
+		totalSize:   0,
+		wait:        sync.WaitGroup{},
+		closed:      false,
+		mu:          sync.Mutex{},
+	}
+}
+
+// Spawn adds a single worker to the pool.
+func (p *Pool[_, _, _]) Spawn() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return
+	}
+	p.spawn()
+}
+
+func (p *Pool[_, _, _]) spawn() {
+	p.wait.Add(1)
+	p.size++
+	p.totalSize++
+	id := p.totalSize
+	w := p.spawnWorker(p.workerCtx, id)
+
+	go func() {
+		defer func() {
+			p.wait.Done()
+			w.Done(p.workerCtx)
+		}()
+
+		for {
+			select {
+			case <-p.killWorker:
+				return
+			default:
+			}
+			if p.workerCtx.Err() != nil {
+				return
+			}
+
+			select {
+			case <-p.workerCtx.Done():
+				return
+			case <-p.killWorker:
+				return
+			case t, ok := <-p.tasks:
+				if !ok {
+					return
+				}
+				p.results <- w.HandleJob(p.workerCtx, t)
+			}
+		}
+	}()
+}
+
+func (p *Pool[_, _, _]) kill() {
+	p.killWorker <- struct{}{}
+	p.size--
+}
+
+// Kill removes single worker from the pool.
+func (p *Pool[_, _, _]) Kill() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return
+	}
+	p.kill()
+}
+
+// SetSize spawns or kills worker to achieve desired pool size.
+func (p *Pool[_, _, _]) SetSize(size int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return
+	}
+
+	for p.size > size {
+		p.kill()
+	}
+	for p.size < size {
+		p.spawn()
+	}
+}
+
+// Submit queues task to be picked up by a free worker.
+// Might block when chanSize is too little.
+func (p *Pool[_, T, _]) Submit(task T) {
+	p.tasks <- task
+}
+
+// Results returns channel that can be used to wait for
+// the results of submitted tasks.
+func (p *Pool[_, _, R]) Results() chan R {
+	return p.results
+}
+
+// Size returns the current number of workers.
+func (p *Pool[_, _, _]) Size() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.size
+}
+
+// Close kills all workers and makes submitting new tasks panic.
+func (p *Pool[_, _, _]) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return
+	}
+	close(p.killWorker)
+	close(p.tasks)
+	p.size = 0
+	p.closed = true
+}
+
+// Wait returns when all workers have exited.
+func (p *Pool[_, _, _]) Wait() {
+	p.wait.Wait()
+}

--- a/pkg/util/workerpool/pool_test.go
+++ b/pkg/util/workerpool/pool_test.go
@@ -1,0 +1,144 @@
+// Copyright (C) 2023 ScyllaDB
+
+package workerpool
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"go.uber.org/atomic"
+)
+
+var (
+	totalCtr = atomic.NewInt64(0)
+	currCtr  = atomic.NewInt64(0)
+	chanSize = 1024
+)
+
+type task time.Duration
+type result int
+
+type worker struct {
+	id int
+}
+
+func spawn(ctx context.Context, i int) *worker {
+	return &worker{i}
+}
+func (w *worker) HandleJob(_ context.Context, t task) result {
+	totalCtr.Inc()
+	currCtr.Inc()
+	time.Sleep(time.Duration(t))
+	currCtr.Dec()
+	return result(w.id)
+}
+
+func (w *worker) Done(_ context.Context) {}
+
+func TestPoolSmoke(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		workerCnt = 200
+		p         = New[*worker, task, result](ctx, spawn, chanSize)
+	)
+	p.SetSize(workerCnt)
+
+	for i := 0; i < workerCnt; i++ {
+		p.Submit(task(time.Second))
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	// Assert that all workers are processing jobs in parallel
+	if v := currCtr.Load(); v != int64(workerCnt) {
+		t.Fatalf("All workers should be working, expected: %d, got: %d", workerCnt, v)
+	}
+
+	time.Sleep(time.Second)
+	m := make(map[result]struct{})
+	for len(p.Results()) > 0 {
+		m[<-p.Results()] = struct{}{}
+	}
+	// Assert that all workers produced results
+	for i := 1; i <= workerCnt; i++ {
+		if _, ok := m[result(i)]; !ok {
+			t.Fatalf("Missing finished worker: %d", i)
+		}
+	}
+
+	p.SetSize(0)
+
+	time.Sleep(time.Second)
+	// Assert that all workers are killed
+	if v := p.Size(); v != 0 {
+		t.Fatalf("No worker should be working, expected: %d, got: %d", workerCnt, v)
+	}
+}
+
+func TestPoolSpawnKill(t *testing.T) {
+	var (
+		ctx              = context.Background()
+		remainingWorkers = 100
+		killCnt          = remainingWorkers
+		workerCnt        = 2 * killCnt
+		p                = New[*worker, task, result](ctx, spawn, chanSize)
+	)
+
+	// Spawn and kill workers in random order
+	for 0 < workerCnt || 0 < killCnt {
+		if killCnt == 0 || (workerCnt > 0 && rand.Int()%2 == 0) {
+			workerCnt--
+			p.spawn()
+		} else {
+			killCnt--
+			p.kill()
+		}
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	// Assert that the correct number of workers is still alive
+	if v := p.Size(); v != remainingWorkers {
+		t.Fatalf("Half of the workers should be alive, expected: %d, got: %d", remainingWorkers, v)
+	}
+}
+
+func TestPoolCtxCancel(t *testing.T) {
+	var (
+		ctx, cancel = context.WithCancel(context.Background())
+		workerCnt   = 50
+		taskCnt     = chanSize
+		p           = New[*worker, task, result](ctx, spawn, chanSize)
+	)
+
+	total := totalCtr.Load()
+	p.SetSize(workerCnt)
+	for i := 0; i < taskCnt; i++ {
+		if i == workerCnt {
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+		}
+		p.Submit(task(100 * time.Millisecond))
+	}
+
+	p.Wait()
+	// Assert that tasks submitted after context cancel weren't executed
+	if v := totalCtr.Load() - total; v != int64(workerCnt) {
+		t.Fatalf("Tasks executed after cotext cancel, expected: %d, got: %d", workerCnt, v)
+	}
+}
+
+func TestPoolClose(t *testing.T) {
+	var (
+		ctx       = context.Background()
+		workerCnt = 50
+		p         = New[*worker, task, result](ctx, spawn, chanSize)
+	)
+
+	p.SetSize(workerCnt)
+	for i := 0; i < 2*workerCnt; i++ {
+		p.Submit(task(100 * time.Millisecond))
+	}
+	p.Close()
+	p.Wait()
+}


### PR DESCRIPTION
This is the first step in implementing #3611, as changing the approach to repair parallelism (while still integrating it with `sctool repair control`) requires freely control the size of the worker pool, which was lacking in the current implementation.