### PR TITLE
Fix alternator backups

### DIFF
--- a/pkg/service/backup/worker_index.go
+++ b/pkg/service/backup/worker_index.go
@@ -50,7 +50,8 @@ func (w *worker) indexSnapshotDirs(ctx context.Context, h hostInfo) ([]snapshotD
 	var dirs []snapshotDir
 
 	nftt := w.newFilesTimeThreshold()
-	r := regexp.MustCompile("^([A-Za-z0-9_]+)-([a-f0-9]{32})$")
+	// Include '-' as valid character because of alternator tables
+	r := regexp.MustCompile("^([A-Za-z0-9_-]+)-([a-f0-9]{32})$")
 
 	for i, u := range w.Units {
 		w.Logger.Debug(ctx, "Finding table snapshot directories",

--- a/pkg/testutils/db/db.go
+++ b/pkg/testutils/db/db.go
@@ -170,7 +170,7 @@ func dropAllKeyspaces(tb testing.TB, session gocqlx.Session) {
 func dropKeyspace(tb testing.TB, session gocqlx.Session, keyspace string) {
 	tb.Helper()
 
-	ExecStmt(tb, session, "DROP KEYSPACE IF EXISTS "+keyspace)
+	ExecStmt(tb, session, fmt.Sprintf("DROP KEYSPACE IF EXISTS %q", keyspace))
 }
 
 // ExecStmt executes given statement.


### PR DESCRIPTION
Alternator tables with dashes in their name weren't backed-up, because of incorrect regex in backup index stage.
This PR fixes that and add tests for:
- backup with alternator table
- restore schema and tables with alternator table

Fixes #3165
