### PR TITLE
[release workflow]:modify publish args

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           version: latest
           workdir: dist
-          args: release --skip-publish
+          args: release --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
release workflow suppose to skip publish when new tags are being pushed
but we get the following warning
```
/opt/hostedtoolcache/goreleaser-action/1.21.2/x64/goreleaser release --skip-publish
  • starting release...
  • loading                                          path=.goreleaser.yaml
  • DEPRECATED: --skip-publish was deprecated in favor of --skip=publish, check https://goreleaser.com/deprecations#-skip for more details
  • skipping announce and publish...
```

Modify the workflow so we will skip the publish part