### PR TITLE
Fix alternator tables with dots

### DIFF
--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -2311,7 +2311,7 @@ func TestBackupListIntegration(t *testing.T) {
 func TestBackupAlternatorIntegration(t *testing.T) {
 	const (
 		testBucket     = "backuptest-alternator"
-		testTable      = "table-with-dash"
+		testTable      = "Tab_le-With1.da_sh2-aNd.d33ot.-"
 		testKeyspace   = "alternator_" + testTable
 		alternatorPort = 8000
 	)

--- a/pkg/service/backup/worker_index.go
+++ b/pkg/service/backup/worker_index.go
@@ -50,8 +50,8 @@ func (w *worker) indexSnapshotDirs(ctx context.Context, h hostInfo) ([]snapshotD
 	var dirs []snapshotDir
 
 	nftt := w.newFilesTimeThreshold()
-	// Include '-' as valid character because of alternator tables
-	r := regexp.MustCompile("^([A-Za-z0-9_-]+)-([a-f0-9]{32})$")
+	// Include '-' and '.' as valid character because of alternator tables
+	r := regexp.MustCompile("^([A-Za-z0-9_.-]+)-([a-f0-9]{32})$")
 
 	for i, u := range w.Units {
 		w.Logger.Debug(ctx, "Finding table snapshot directories",

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -1356,7 +1356,7 @@ func restoreAllTables(t *testing.T, schemaTarget, tablesTarget Target, keyspace 
 func TestRestoreFullAlternatorIntegration(t *testing.T) {
 	testBucket, _, testUser := getBucketKeyspaceUser(t)
 	const (
-		testTable          = "table-with-dash"
+		testTable          = "Tab_le-With1.da_sh2-aNd.d33ot.-"
 		testKeyspace       = "alternator_" + testTable
 		testBatchSize      = 1
 		testParallel       = 3


### PR DESCRIPTION
Except for fixing reopened (because of dots in table names) issue, this PR also adds a small repair test which validates that alternator tables are also repaired.

Fixes #3165
