### PR TITLE
dockerfile: add `apt-get upgrade` during build

### DIFF
--- a/dist/docker/scylla-manager-agent.dockerfile
+++ b/dist/docker/scylla-manager-agent.dockerfile
@@ -4,6 +4,7 @@ FROM $BASE_IMAGE
 ARG ARCH
 
 RUN apt-get update && \
+    apt-get -y upgrade && \
     apt-get install -y --no-install-recommends ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean && \

--- a/dist/docker/scylla-manager.dockerfile
+++ b/dist/docker/scylla-manager.dockerfile
@@ -3,6 +3,7 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE
 ARG ARCH
 RUN apt-get update && \
+    apt-get -y upgrade && \
     apt-get install -y --no-install-recommends ca-certificates && \
     apt-get autoremove -y && \
     apt-get clean && \


### PR DESCRIPTION
Similar to https://github.com/scylladb/scylladb/issues/16222 ,we need to make sure our docker image is updated to the latest for all OS packages

Fixes: https://github.com/scylladb/scylla-manager/issues/3646
