### PR TITLE
fix(codeowners): dist part for release engineering

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
 *   @karol-kokoszka @Michal-Leszczynski
+
+/dist/* @yaronkaikov


### PR DESCRIPTION
Give the ownership of /dist to release engineering.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
