### PR TITLE
docs: Add Zendesk tag 

### DIFF
--- a/docs/source/_templates/local-scripts.html
+++ b/docs/source/_templates/local-scripts.html
@@ -1,0 +1,1 @@
+<meta name='zd-site-verification' content='jiigc536se3g139312rad' />


### PR DESCRIPTION
Related https://github.com/scylladb/sphinx-scylladb-theme/pull/949

Adds the Zendesk tag for the docs.

## How to test

1. Build the docs.
1. Open them in the browser.
1. Inspect the code.
1. You should see the project-specific tag loaded:

![image](https://github.com/scylladb/scylla-manager/assets/9107969/85db1e8a-1230-411d-b051-5ddcb5cdc21e)
