### PR TITLE
Repair: use small_table_optimization param

### DIFF
--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -67,16 +67,15 @@ type job struct {
 	master     string
 	replicaSet []string
 	ranges     []scyllaclient.TokenRange
-	// jobs of optimized tables should merge all token ranges into one.
-	optimize bool
+	optimize   repairOpt
 	// jobs of deleted tables are sent only for progress updates.
 	deleted bool
 }
 
 // tryOptimizeRanges returns either predefined ranges
-// or one full token range for small fully replicated tables.
+// or one full token range for optimized tables.
 func (j job) tryOptimizeRanges() []scyllaclient.TokenRange {
-	if j.optimize {
+	if j.optimize == repairOptMergeRanges {
 		return []scyllaclient.TokenRange{
 			{
 				StartToken: dht.Murmur3MinToken,
@@ -131,7 +130,7 @@ func newGenerator(ctx context.Context, target Target, client *scyllaclient.Clien
 				"keyspace", kp.Keyspace,
 				"table", tp.Table,
 				"size", tp.Size,
-				"merge_ranges", tp.Optimize,
+				"optimization kind", tp.Optimize,
 			)
 		}
 	}

--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -57,7 +57,7 @@ func (w *worker) runRepair(ctx context.Context, j job) (out error) {
 		out = errors.Wrapf(out, "master %s keyspace %s table %s command %d", j.master, j.keyspace, j.table, jobID)
 	}()
 
-	jobID, err = w.client.Repair(ctx, j.keyspace, j.table, j.master, j.replicaSet, j.tryOptimizeRanges())
+	jobID, err = w.client.Repair(ctx, j.keyspace, j.table, j.master, j.replicaSet, j.tryOptimizeRanges(), j.optimize == repairOptScyllaAPI)
 	if err != nil {
 		return errors.Wrap(err, "schedule repair")
 	}

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -33,6 +33,10 @@ func TestShortVersion(t *testing.T) {
 			Version:  "i'm - not a version",
 			Expected: "i'm - not a version",
 		},
+		{
+			Version:  "2024.1.0~rc1-0.20231119.c41aeb701889",
+			Expected: "2024.1.0",
+		},
 	}
 
 	for i := range ts {
@@ -67,6 +71,10 @@ func TestTransformReleaseCandidate(t *testing.T) {
 		{
 			Version:  "i'm - not a version",
 			Expected: "i'm - not a version",
+		},
+		{
+			Version:  "2024.1.0~rc1-0.20231119.c41aeb701889",
+			Expected: "2024.1.0~rc1-0.20231119.c41aeb701889",
 		},
 	}
 
@@ -111,6 +119,16 @@ func TestCheckConstraint(t *testing.T) {
 		{
 			Version:    "3.9",
 			Constraint: ">= 4.1, < 2000",
+			Match:      false,
+		},
+		{
+			Version:    "2024.1.0~rc1-0.20231119.c41aeb701889",
+			Constraint: ">= 2024.1",
+			Match:      true,
+		},
+		{
+			Version:    "5.4.0~rc1-0.20231119.c41aeb701889",
+			Constraint: ">= 2024.1",
 			Match:      false,
 		},
 	}

--- a/swagger/gen/scylla/v1/client/operations/storage_service_repair_async_by_keyspace_post_parameters.go
+++ b/swagger/gen/scylla/v1/client/operations/storage_service_repair_async_by_keyspace_post_parameters.go
@@ -81,6 +81,11 @@ type StorageServiceRepairAsyncByKeyspacePostParams struct {
 
 	*/
 	Hosts *string
+	/*IgnoreNodes
+	  Which hosts are to ignore in this repair. Multiple hosts can be listed separated by commas.
+
+	*/
+	IgnoreNodes *string
 	/*Incremental
 	  If the value is the string 'true' with any capitalization, perform incremental repair.
 
@@ -111,6 +116,16 @@ type StorageServiceRepairAsyncByKeyspacePostParams struct {
 
 	*/
 	Ranges *string
+	/*RangesParallelism
+	  An integer specifying the number of ranges to repair in parallel by user request. If this number is bigger than the max_repair_ranges_in_parallel calculated by Scylla core, the smaller one will be used.
+
+	*/
+	RangesParallelism *string
+	/*SmallTableOptimization
+	  If the value is the string 'true' with any capitalization, perform small table optimization. When this option is enabled, user can send the repair request to any of the nodes in the cluster. There is no need to send repair requests to multiple nodes. All token ranges for the table will be repaired automatically.
+
+	*/
+	SmallTableOptimization *string
 	/*StartToken
 	  Token on which to begin repair
 
@@ -204,6 +219,17 @@ func (o *StorageServiceRepairAsyncByKeyspacePostParams) SetHosts(hosts *string) 
 	o.Hosts = hosts
 }
 
+// WithIgnoreNodes adds the ignoreNodes to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) WithIgnoreNodes(ignoreNodes *string) *StorageServiceRepairAsyncByKeyspacePostParams {
+	o.SetIgnoreNodes(ignoreNodes)
+	return o
+}
+
+// SetIgnoreNodes adds the ignoreNodes to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) SetIgnoreNodes(ignoreNodes *string) {
+	o.IgnoreNodes = ignoreNodes
+}
+
 // WithIncremental adds the incremental to the storage service repair async by keyspace post params
 func (o *StorageServiceRepairAsyncByKeyspacePostParams) WithIncremental(incremental *string) *StorageServiceRepairAsyncByKeyspacePostParams {
 	o.SetIncremental(incremental)
@@ -268,6 +294,28 @@ func (o *StorageServiceRepairAsyncByKeyspacePostParams) WithRanges(ranges *strin
 // SetRanges adds the ranges to the storage service repair async by keyspace post params
 func (o *StorageServiceRepairAsyncByKeyspacePostParams) SetRanges(ranges *string) {
 	o.Ranges = ranges
+}
+
+// WithRangesParallelism adds the rangesParallelism to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) WithRangesParallelism(rangesParallelism *string) *StorageServiceRepairAsyncByKeyspacePostParams {
+	o.SetRangesParallelism(rangesParallelism)
+	return o
+}
+
+// SetRangesParallelism adds the rangesParallelism to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) SetRangesParallelism(rangesParallelism *string) {
+	o.RangesParallelism = rangesParallelism
+}
+
+// WithSmallTableOptimization adds the smallTableOptimization to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) WithSmallTableOptimization(smallTableOptimization *string) *StorageServiceRepairAsyncByKeyspacePostParams {
+	o.SetSmallTableOptimization(smallTableOptimization)
+	return o
+}
+
+// SetSmallTableOptimization adds the smallTableOptimization to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) SetSmallTableOptimization(smallTableOptimization *string) {
+	o.SmallTableOptimization = smallTableOptimization
 }
 
 // WithStartToken adds the startToken to the storage service repair async by keyspace post params
@@ -364,6 +412,22 @@ func (o *StorageServiceRepairAsyncByKeyspacePostParams) WriteToRequest(r runtime
 
 	}
 
+	if o.IgnoreNodes != nil {
+
+		// query param ignore_nodes
+		var qrIgnoreNodes string
+		if o.IgnoreNodes != nil {
+			qrIgnoreNodes = *o.IgnoreNodes
+		}
+		qIgnoreNodes := qrIgnoreNodes
+		if qIgnoreNodes != "" {
+			if err := r.SetQueryParam("ignore_nodes", qIgnoreNodes); err != nil {
+				return err
+			}
+		}
+
+	}
+
 	if o.Incremental != nil {
 
 		// query param incremental
@@ -443,6 +507,38 @@ func (o *StorageServiceRepairAsyncByKeyspacePostParams) WriteToRequest(r runtime
 		qRanges := qrRanges
 		if qRanges != "" {
 			if err := r.SetQueryParam("ranges", qRanges); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.RangesParallelism != nil {
+
+		// query param ranges_parallelism
+		var qrRangesParallelism string
+		if o.RangesParallelism != nil {
+			qrRangesParallelism = *o.RangesParallelism
+		}
+		qRangesParallelism := qrRangesParallelism
+		if qRangesParallelism != "" {
+			if err := r.SetQueryParam("ranges_parallelism", qRangesParallelism); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.SmallTableOptimization != nil {
+
+		// query param small_table_optimization
+		var qrSmallTableOptimization string
+		if o.SmallTableOptimization != nil {
+			qrSmallTableOptimization = *o.SmallTableOptimization
+		}
+		qSmallTableOptimization := qrSmallTableOptimization
+		if qSmallTableOptimization != "" {
+			if err := r.SetQueryParam("small_table_optimization", qSmallTableOptimization); err != nil {
 				return err
 			}
 		}

--- a/swagger/scylla_v1.json
+++ b/swagger/scylla_v1.json
@@ -10414,11 +10414,32 @@
             "description": "Which hosts are to participate in this repair. Multiple hosts can be listed separated by commas."
           },
           {
+            "name": "ignore_nodes",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Which hosts are to ignore in this repair. Multiple hosts can be listed separated by commas."
+          },
+          {
             "name": "trace",
             "in": "query",
             "required": false,
             "type": "string",
             "description": "If the value is the string 'true' with any capitalization, enable tracing of the repair."
+          },
+          {
+            "name": "ranges_parallelism",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "An integer specifying the number of ranges to repair in parallel by user request. If this number is bigger than the max_repair_ranges_in_parallel calculated by Scylla core, the smaller one will be used."
+          },
+          {
+            "name": "small_table_optimization",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "If the value is the string 'true' with any capitalization, perform small table optimization. When this option is enabled, user can send the repair request to any of the nodes in the cluster. There is no need to send repair requests to multiple nodes. All token ranges for the table will be repaired automatically."
           }
         ],
         "responses": {


### PR DESCRIPTION
WIP: as small_table_optimization isn't part of 2024.1.0-rc2, we have to wait for some Scylla release that contains this new repair param for proper testing.
