### PR TITLE
Fix timeouts in RepairStatus and LoadSSTables

### DIFF
--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -899,6 +899,8 @@ func (c *Client) TableDiskSizeReport(ctx context.Context, hostKeyspaceTables Hos
 	return report, err
 }
 
+const loadSSTablesTimeout = time.Hour
+
 // LoadSSTables that are already downloaded to host's table upload directory.
 // Used API endpoint has the following properties:
 // - It is synchronous - response is received only after the loading has finished
@@ -909,7 +911,7 @@ func (c *Client) LoadSSTables(ctx context.Context, host, keyspace, table string,
 	const WIPError = "Already loading SSTables"
 
 	_, err := c.scyllaOps.StorageServiceSstablesByKeyspacePost(&operations.StorageServiceSstablesByKeyspacePostParams{
-		Context:            forceHost(ctx, host),
+		Context:            customTimeout(forceHost(ctx, host), loadSSTablesTimeout),
 		Keyspace:           keyspace,
 		Cf:                 table,
 		LoadAndStream:      &loadAndStream,

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -513,9 +513,12 @@ func repairStatusShouldRetryHandler(err error) *bool {
 	return nil
 }
 
+const repairStatusTimeout = 30 * time.Minute
+
 // RepairStatus waits for repair job to finish and returns its status.
 func (c *Client) RepairStatus(ctx context.Context, host string, id int32) (CommandStatus, error) {
 	ctx = forceHost(ctx, host)
+	ctx = customTimeout(ctx, repairStatusTimeout)
 	ctx = withShouldRetryHandler(ctx, repairStatusShouldRetryHandler)
 	var (
 		resp interface {

--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -49,7 +49,7 @@ func (w *worker) runRepair(ctx context.Context, j job) (out error) {
 	)
 	// Decorate returned error
 	defer func() {
-		w.logger.Info(ctx, "Repair done")
+		w.logger.Info(ctx, "Repair done", "job_id", jobID)
 		// Try to justify error by checking table deletion
 		if out != nil && w.isTableDeleted(ctx, j) {
 			out = errTableDeleted


### PR DESCRIPTION
Both of those calls return from Scylla only when the job is done. Because of that SM shouldn't timeout them on its side (even though it usually works when backoff retry is used).
This PR also includes a small improvement of repair logs mentioned in [here](https://github.com/scylladb/scylla-manager/issues/3671#issuecomment-1870061453).

Fixes #3675
