### PR TITLE
Remove hint about recreating MV and SI from restore schema

### DIFF
--- a/docs/source/restore/restore-schema.rst
+++ b/docs/source/restore/restore-schema.rst
@@ -25,10 +25,6 @@ After successful restore it is important to perform necessary follow-up action. 
 you should make a `rolling restart <https://docs.scylladb.com/stable/operating-scylla/procedures/config-change/rolling-restart.html>`_ of an entire cluster.
 Without the restart, the restored schema might not be visible, and querying it can return various errors.
 
-It is recommended to drop all materialized views and secondary indexes that are part of the restored schema.
-The next step, ``--restore-tables``, does not restore materialized views or secondary indexes.
-It is the end user's responsibility to drop and recreate them after the tables have been successfully restored.
-
 Process
 =======
 


### PR DESCRIPTION
There is no need to do that as it is performed automatically.
Actually, this has been a part of SM for quite some time already.

In response to [comment](https://github.com/scylladb/scylla-enterprise/issues/3706#issuecomment-1864611316).
Fixes #3676
