### PR TITLE
docs: add zendesk tag to index.html

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -103,6 +103,7 @@ html_theme_options = {
     'tag_substring_removed': 'scylla-manager-',
     'versions_unstable': UNSTABLE_VERSIONS,
     'versions_deprecated': DEPRECATED_VERSIONS,
+    'zendesk_tag': 'jiigc536se3g139312rad',
 }
 
 # If not None, a 'Last updated on:' timestamp is inserted at every page


### PR DESCRIPTION
Related: https://github.com/scylladb/sphinx-scylladb-theme/pull/979

Adds the Zendesk tag to index.html page.

## How to test

1. Run `make multiversion`.
1. Open the `_build/dirhtml/index.html` file.
1. Check for the presence of the Zendesk tag associated with this project.