### PR TITLE
Fix repair float intensity

### DIFF
--- a/pkg/command/flag/type.go
+++ b/pkg/command/flag/type.go
@@ -238,7 +238,7 @@ func (fl *Intensity) String() string {
 
 // Set implements pflag.Value.
 func (fl *Intensity) Set(s string) error {
-	errValidation := errors.New("intensity must be an integer >= 1 or a decimal between (0,1)")
+	errValidation := errors.New("intensity must be a non-negative integer")
 
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {

--- a/pkg/service/repair/controller.go
+++ b/pkg/service/repair/controller.go
@@ -5,16 +5,16 @@ package repair
 // controller informs generator about the amount of ranges that can be repaired
 // on a given replica set. Returns 0 ranges when repair shouldn't be scheduled.
 type controller interface {
-	TryBlock(replicaSet []string) (ranges int)
+	TryBlock(replicaSet []string) (ranges Intensity)
 	Unblock(replicaSet []string)
 	Busy() bool
 }
 
 type intensityChecker interface {
-	Intensity() int
+	Intensity() Intensity
 	Parallel() int
 	MaxParallel() int
-	ReplicaSetMaxIntensity(replicaSet []string) int
+	ReplicaSetMaxIntensity(replicaSet []string) Intensity
 }
 
 // rowLevelRepairController is a specialised controller for row-level repair.
@@ -37,15 +37,15 @@ func newRowLevelRepairController(i intensityChecker) *rowLevelRepairController {
 	}
 }
 
-func (c *rowLevelRepairController) TryBlock(replicaSet []string) int {
+func (c *rowLevelRepairController) TryBlock(replicaSet []string) Intensity {
 	if !c.shouldBlock(replicaSet) {
 		return 0
 	}
 	c.block(replicaSet)
 
 	i := c.intensity.Intensity()
-	if max := c.intensity.ReplicaSetMaxIntensity(replicaSet); i == maxIntensity || max < i {
-		i = max
+	if maxI := c.intensity.ReplicaSetMaxIntensity(replicaSet); i == maxIntensity || maxI < i {
+		i = maxI
 	}
 	return i
 }

--- a/pkg/service/repair/controller_test.go
+++ b/pkg/service/repair/controller_test.go
@@ -21,7 +21,7 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		node6 = "192.168.1.6"
 	)
 
-	maxRangesPerHost := map[string]int{
+	maxRangesPerHost := map[string]Intensity{
 		node1: 20,
 		node2: 19,
 		node3: 18,
@@ -33,7 +33,7 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		return &intensityHandler{
 			logger:           log.Logger{},
 			maxHostIntensity: maxRangesPerHost,
-			intensity:        atomic.NewFloat64(defaultIntensity),
+			intensity:        atomic.NewInt64(int64(defaultIntensity)),
 			maxParallel:      3,
 			parallel:         atomic.NewInt64(defaultParallel),
 			poolController: workerpool.New[*worker, job, jobResult](context.Background(), func(ctx context.Context, id int) *worker {
@@ -69,9 +69,7 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		ih.maxParallel = maxParallel
 		c := newRowLevelRepairController(ih)
 
-		if err := ih.SetIntensity(context.Background(), expectedNrOfRanges); err != nil {
-			t.Fatalf("unexpected error = {%v}", err)
-		}
+		ih.SetIntensity(context.Background(), expectedNrOfRanges)
 		if rangesCount := c.TryBlock(replicaSet); rangesCount != expectedNrOfRanges {
 			t.Fatalf("expected to return {%d} ranges to repair, but got {%d}", expectedNrOfRanges, rangesCount)
 		}
@@ -87,9 +85,7 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		ih.maxParallel = maxParallel
 		c := newRowLevelRepairController(ih)
 
-		if err := ih.SetIntensity(context.Background(), float64(expectedNrOfRanges)); err != nil {
-			t.Fatalf("unexpected error = {%v}", err)
-		}
+		ih.SetIntensity(context.Background(), expectedNrOfRanges)
 		if rangesCount := c.TryBlock(replicaSet); rangesCount != expectedNrOfRanges {
 			t.Fatalf("expected to return {%d} ranges to repair, but got {%d}", expectedNrOfRanges, rangesCount)
 		}
@@ -106,9 +102,7 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		ih.maxParallel = maxParallel
 		c := newRowLevelRepairController(ih)
 
-		if err := ih.SetIntensity(context.Background(), intensity); err != nil {
-			t.Fatalf("unexpected error = {%v}", err)
-		}
+		ih.SetIntensity(context.Background(), intensity)
 		if rangesCount := c.TryBlock(replicaSet); rangesCount != minRangesInParallel {
 			t.Fatalf("expected to return {%d} ranges to repair, but got {%d}", minRangesInParallel, rangesCount)
 		}
@@ -122,9 +116,7 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		ih.maxParallel = maxParallel
 		c := newRowLevelRepairController(ih)
 
-		if err := ih.SetParallel(context.Background(), 1); err != nil {
-			t.Fatalf("unexpected error {%v}", err)
-		}
+		ih.SetParallel(context.Background(), 1)
 		if rangesCount := c.TryBlock(replicaSet1); rangesCount == 0 {
 			t.Fatal("expected to let in, but was denied")
 		}

--- a/pkg/service/repair/model.go
+++ b/pkg/service/repair/model.go
@@ -13,17 +13,33 @@ import (
 // Unit represents keyspace and its tables.
 type Unit = ksfilter.Unit
 
+// Intensity represents parsed internal intensity.
+type Intensity int
+
+// NewIntensity returns Intensity.
+func NewIntensity(i int) Intensity {
+	return Intensity(i)
+}
+
+// NewIntensityFromDeprecated returns Intensity parsed from deprecated float value.
+func NewIntensityFromDeprecated(i float64) Intensity {
+	if 0 < i && i < 1 {
+		return defaultIntensity
+	}
+	return Intensity(i)
+}
+
 // Target specifies what shall be repaired.
 type Target struct {
-	Units               []Unit   `json:"units"`
-	DC                  []string `json:"dc"`
-	Host                string   `json:"host,omitempty"`
-	IgnoreHosts         []string `json:"ignore_hosts,omitempty"`
-	FailFast            bool     `json:"fail_fast"`
-	Continue            bool     `json:"continue"`
-	Intensity           float64  `json:"intensity"`
-	Parallel            int      `json:"parallel"`
-	SmallTableThreshold int64    `json:"small_table_threshold"`
+	Units               []Unit    `json:"units"`
+	DC                  []string  `json:"dc"`
+	Host                string    `json:"host,omitempty"`
+	IgnoreHosts         []string  `json:"ignore_hosts,omitempty"`
+	FailFast            bool      `json:"fail_fast"`
+	Continue            bool      `json:"continue"`
+	Intensity           Intensity `json:"intensity"`
+	Parallel            int       `json:"parallel"`
+	SmallTableThreshold int64     `json:"small_table_threshold"`
 	// Cache for repair plan so that it does not have to be generated
 	// in both GetTarget and Repair functions.
 	plan *plan `json:"-"`
@@ -48,7 +64,7 @@ func defaultTaskProperties() *taskProperties {
 		Keyspace: []string{"*", "!system_traces"},
 
 		Continue:  true,
-		Intensity: defaultIntensity,
+		Intensity: float64(defaultIntensity),
 
 		// Consider 1GB table as small by default.
 		SmallTableThreshold: 1 * 1024 * 1024 * 1024,
@@ -64,7 +80,7 @@ type Run struct {
 	DC        []string
 	Host      string
 	Parallel  int
-	Intensity int
+	Intensity Intensity
 	PrevID    uuid.UUID
 	StartTime time.Time
 	EndTime   time.Time
@@ -169,8 +185,8 @@ type Progress struct {
 	Host              string          `json:"host"`
 	Hosts             []HostProgress  `json:"hosts"`
 	Tables            []TableProgress `json:"tables"`
-	MaxIntensity      float64         `json:"max_intensity"`
-	Intensity         float64         `json:"intensity"`
+	MaxIntensity      Intensity       `json:"max_intensity"`
+	Intensity         Intensity       `json:"intensity"`
 	MaxParallel       int             `json:"max_parallel"`
 	Parallel          int             `json:"parallel"`
 }


### PR DESCRIPTION
There are still some bugs (one described in the issue below) regarding using float intensity. In order to get rid of them, we should only tolerate float intensity at the entrypoint, but completely remove it from SM repair internals (both in service and progress display).

We keep float intensity in task properties and in swagger endpoint parameters, but we convert it to int intensity as a first thing in internals, which happens in:
- GetTarget (from task properties)
- sctool repair control endpoint (from query param)

Fixes #3665
