### PR TITLE
Update docker setup example

### DIFF
--- a/docs/source/docker/Dockerfile
+++ b/docs/source/docker/Dockerfile
@@ -2,14 +2,14 @@ FROM scylladb/scylla-manager-agent:latest as agent
 FROM scylladb/scylla:latest
 
 COPY --from=agent /usr/bin/scylla-manager-agent /usr/bin/
-RUN echo -e "[program:scylla-manager-agent]\n\
+RUN echo "[program:scylla-manager-agent]\n\
 command=/usr/bin/scylla-manager-agent\n\
 autorestart=true\n\
 stdout_logfile=/dev/stdout\n\
 stdout_logfile_maxbytes=0\n\
 stderr_logfile=/dev/stderr\n\
 stderr_logfile_maxbytes=0" > /etc/supervisord.conf.d/scylla-manager-agent.conf
-RUN mkdir -p /etc/scylla-manager-agent && echo -e "auth_token: token\n\
+RUN mkdir -p /etc/scylla-manager-agent && echo "auth_token: token\n\
 s3:\n\
     access_key_id: minio\n\
     secret_access_key: minio123\n\

--- a/docs/source/docker/docker-compose.yaml
+++ b/docs/source/docker/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       - scylla_manager_db_data:/var/lib/scylla
     networks:
       public:
-    command: --smp 1 --memory 100M
+    command: --smp 1 --memory 1G
 
   scylla:
     build:


### PR DESCRIPTION
Previously I wasn't able to follow our docker setup [example](https://manager.docs.scylladb.com/stable/docker/index.html) because of two reasons:
- too little memory assigned to SM DB
- incorrect `echo` behavior when writing config files

Now it should work fine.
Fixes #3672