### PR TITLE
Require certificate registered within cluster before choosing CQL SSL

### DIFF
--- a/pkg/scyllaclient/client_agent_test.go
+++ b/pkg/scyllaclient/client_agent_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
-	"go.uber.org/atomic"
 )
 
 const fallback = "4.3.2.1"
@@ -80,26 +79,6 @@ func TestNodeInfoCQLAddr(t *testing.T) {
 			},
 			GoldenAddress: net.JoinHostPort(fallback, "1234"),
 		},
-		{
-			Name: "Native Transport Port SSL with client encryption enabled without server listening on",
-			NodeInfo: &scyllaclient.NodeInfo{
-				NativeTransportPort:     "4321",
-				NativeTransportPortSsl:  "1234",
-				ListenAddress:           "1.2.3.4",
-				ClientEncryptionEnabled: true,
-			},
-			GoldenAddress: net.JoinHostPort("1.2.3.4", "4321"),
-		},
-		{
-			Name: "Native Transport Port SSL with client encryption disabled",
-			NodeInfo: &scyllaclient.NodeInfo{
-				NativeTransportPort:     "4321",
-				NativeTransportPortSsl:  "1234",
-				ListenAddress:           "1.2.3.4",
-				ClientEncryptionEnabled: false,
-			},
-			GoldenAddress: net.JoinHostPort("1.2.3.4", "4321"),
-		},
 	}
 
 	for i := range table {
@@ -115,51 +94,85 @@ func TestNodeInfoCQLAddr(t *testing.T) {
 	}
 }
 
-// Test workaround used in NodeInfo.CQLPort().
-func TestNodeInfoCQLAddrNativeTransportPortSSL(t *testing.T) {
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer l.Close()
+func TestNodeInfoCQLSSLAddr(t *testing.T) {
+	t.Parallel()
 
-	address, port, err := net.SplitHostPort(l.Addr().String())
-	if err != nil {
-		t.Fatal(err)
+	table := []struct {
+		Name          string
+		NodeInfo      *scyllaclient.NodeInfo
+		GoldenAddress string
+	}{
+		{
+			Name: "Broadcast RPC address is set",
+			NodeInfo: &scyllaclient.NodeInfo{
+				BroadcastRPCAddress:    "1.2.3.4",
+				RPCAddress:             "1.2.3.5",
+				ListenAddress:          "1.2.3.6",
+				NativeTransportPortSsl: "1234",
+			},
+			GoldenAddress: "1.2.3.4:1234",
+		},
+		{
+			Name: "RPC address is set",
+			NodeInfo: &scyllaclient.NodeInfo{
+				NativeTransportPortSsl: "1234",
+				RPCAddress:             "1.2.3.5",
+				ListenAddress:          "1.2.3.6",
+			},
+			GoldenAddress: "1.2.3.5:1234",
+		},
+		{
+			Name: "Listen Address is set",
+			NodeInfo: &scyllaclient.NodeInfo{
+				NativeTransportPortSsl: "1234",
+				ListenAddress:          "1.2.3.6",
+			},
+			GoldenAddress: "1.2.3.6:1234",
+		},
+		{
+			Name: "Fallback is returned when RPC Address is IPv4 zero",
+			NodeInfo: &scyllaclient.NodeInfo{
+				NativeTransportPortSsl: "1234",
+				RPCAddress:             "0.0.0.0",
+			},
+			GoldenAddress: net.JoinHostPort(fallback, "1234"),
+		},
+		{
+			Name: "Fallback is returned when RPC Address is IPv6 zero",
+			NodeInfo: &scyllaclient.NodeInfo{
+				NativeTransportPortSsl: "1234",
+				RPCAddress:             "::0",
+			},
+			GoldenAddress: net.JoinHostPort(fallback, "1234"),
+		},
+		{
+			Name: "Fallback is returned when Listen Address is IPv4 zero",
+			NodeInfo: &scyllaclient.NodeInfo{
+				NativeTransportPortSsl: "1234",
+				ListenAddress:          "0.0.0.0",
+			},
+			GoldenAddress: net.JoinHostPort(fallback, "1234"),
+		},
+		{
+			Name: "Fallback is returned when Listen Address is IPv6 zero",
+			NodeInfo: &scyllaclient.NodeInfo{
+				NativeTransportPortSsl: "1234",
+				ListenAddress:          "::0",
+			},
+			GoldenAddress: net.JoinHostPort(fallback, "1234"),
+		},
 	}
 
-	var (
-		connections atomic.Int64
-		ready       = make(chan struct{})
-	)
-	go func() {
-		for {
-			c, err := l.Accept()
-			if err != nil {
-				return
+	for i := range table {
+		test := table[i]
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+
+			addr := test.NodeInfo.CQLSSLAddr(fallback)
+			if addr != test.GoldenAddress {
+				t.Errorf("expected %s address, got %s", test.GoldenAddress, addr)
 			}
-			connections.Inc()
-			_ = c.Close()
-			close(ready)
-			break
-		}
-	}()
-
-	ni := &scyllaclient.NodeInfo{
-		NativeTransportPort:     "4321",
-		NativeTransportPortSsl:  port,
-		ListenAddress:           address,
-		ClientEncryptionEnabled: true,
-	}
-	addr := ni.CQLAddr(fallback)
-	golden := net.JoinHostPort(ni.ListenAddress, ni.NativeTransportPortSsl)
-	if addr != golden {
-		t.Errorf("expected %s address, got %s", golden, addr)
-	}
-
-	<-ready
-	if c := connections.Load(); c == 0 {
-		t.Errorf("expected connection during figuring out CQL port got %d", c)
+		})
 	}
 }
 


### PR DESCRIPTION
Previously, SSL was preferred when client_encryption_options.enabled
coming from ScyllaDB configuration was true and SSL port is open,
even when Scylla Manager did not have any client certificate registered
for particular cluster.

This caused issues when ScyllaDB cluster was exposing both CQL and CQL
SSL with mTLS, because even when Manager was not registered with
certificates, it still insisted to establish sessions using SSL port.
CQL healthchecks was also affected.

It can be further improved by implementing #3679 which will add a switch deciding whether user wants to use either SSL or non SSL port.

Fixes https://github.com/scylladb/scylla-manager/issues/3698