### PR TITLE
docs: remove 404 redirect

### DIFF
--- a/docs/source/_templates/404.html
+++ b/docs/source/_templates/404.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>Redirecting to https://manager.docs.scylladb.com/stable/</title>
-    <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; URL=https://manager.docs.scylladb.com/stable/index.html">
-    <link rel="canonical" href="https://manager.docs.scylladb.com/stable/index.html">
-  </head>
-</html>


### PR DESCRIPTION
## Motivation

When users navigate to a non-existent page in the docs, they are currently redirected to the homepage instead of the 404 error page. This approach was initially adopted when we activated the multiversion feature to prevent generating lots of broken links.

However, we now have the capability to configure [page-specific redirects](https://sphinx-theme.scylladb.com/stable/configuration/redirects.html) redirects, and have passed some time since [we implemented that redirection](https://github.com/scylladb/scylla-manager/commit/6cc0b510508c8664f4c90b397a0c22b70ef627fe).

Considering this, we could remove the custom redirect,  allowing the 404 error page to display like in every other project.

## How to test

1. Clone the PR.
2. Build the docs locally.
2. Enter http://127.0.0.1:5500/404.html, you should see the 404 page.