### PR TITLE
fix(client): validate all known_hosts on ScyllaAPI client creation

### DIFF
--- a/dist/etc/scylla-manager.yaml
+++ b/dist/etc/scylla-manager.yaml
@@ -34,6 +34,10 @@ http: 127.0.0.1:5080
 # Debug server that allows to run pporf profiling on demand on a live system.
 #debug: 127.0.0.1:5112
 
+# Set the validity timeout for Scylla Manager Agent API clients cached by Scylla Manager.
+# Use 0 to disable the cache.
+#client_cache_timeout: 15m
+
 # Logging configuration.
 #logger:
 # Where to print logs, stderr or stdout.

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -71,7 +71,8 @@ func (s *server) makeServices() error {
 	drawerStore := store.NewTableStore(s.session, table.Drawer)
 	secretsStore := store.NewTableStore(s.session, table.Secrets)
 
-	s.clusterSvc, err = cluster.NewService(s.session, metrics.NewClusterMetrics().MustRegister(), secretsStore, s.config.TimeoutConfig, s.logger.Named("cluster"))
+	s.clusterSvc, err = cluster.NewService(s.session, metrics.NewClusterMetrics().MustRegister(), secretsStore, s.config.TimeoutConfig,
+		s.config.ClientCacheTimeout, s.logger.Named("cluster"))
 	if err != nil {
 		return errors.Wrapf(err, "cluster service")
 	}

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -46,22 +46,23 @@ type SSLConfig struct {
 
 // Config contains configuration structure for scylla manager.
 type Config struct {
-	HTTP          string                     `yaml:"http"`
-	HTTPS         string                     `yaml:"https"`
-	TLSVersion    config.TLSVersion          `yaml:"tls_version"`
-	TLSCertFile   string                     `yaml:"tls_cert_file"`
-	TLSKeyFile    string                     `yaml:"tls_key_file"`
-	TLSCAFile     string                     `yaml:"tls_ca_file"`
-	Prometheus    string                     `yaml:"prometheus"`
-	Debug         string                     `yaml:"debug"`
-	Logger        config.LogConfig           `yaml:"logger"`
-	Database      DBConfig                   `yaml:"database"`
-	SSL           SSLConfig                  `yaml:"ssl"`
-	Healthcheck   healthcheck.Config         `yaml:"healthcheck"`
-	Backup        backup.Config              `yaml:"backup"`
-	Restore       restore.Config             `yaml:"restore"`
-	Repair        repair.Config              `yaml:"repair"`
-	TimeoutConfig scyllaclient.TimeoutConfig `yaml:"agent_client"`
+	HTTP               string                     `yaml:"http"`
+	HTTPS              string                     `yaml:"https"`
+	TLSVersion         config.TLSVersion          `yaml:"tls_version"`
+	TLSCertFile        string                     `yaml:"tls_cert_file"`
+	TLSKeyFile         string                     `yaml:"tls_key_file"`
+	TLSCAFile          string                     `yaml:"tls_ca_file"`
+	Prometheus         string                     `yaml:"prometheus"`
+	Debug              string                     `yaml:"debug"`
+	ClientCacheTimeout time.Duration              `yaml:"client_cache_timeout"`
+	Logger             config.LogConfig           `yaml:"logger"`
+	Database           DBConfig                   `yaml:"database"`
+	SSL                SSLConfig                  `yaml:"ssl"`
+	Healthcheck        healthcheck.Config         `yaml:"healthcheck"`
+	Backup             backup.Config              `yaml:"backup"`
+	Restore            restore.Config             `yaml:"restore"`
+	Repair             repair.Config              `yaml:"repair"`
+	TimeoutConfig      scyllaclient.TimeoutConfig `yaml:"agent_client"`
 }
 
 func DefaultConfig() Config {
@@ -83,11 +84,12 @@ func DefaultConfig() Config {
 		SSL: SSLConfig{
 			Validate: true,
 		},
-		Healthcheck:   healthcheck.DefaultConfig(),
-		Backup:        backup.DefaultConfig(),
-		Restore:       restore.DefaultConfig(),
-		Repair:        repair.DefaultConfig(),
-		TimeoutConfig: scyllaclient.DefaultTimeoutConfig(),
+		Healthcheck:        healthcheck.DefaultConfig(),
+		ClientCacheTimeout: 15 * time.Minute,
+		Backup:             backup.DefaultConfig(),
+		Restore:            restore.DefaultConfig(),
+		Repair:             repair.DefaultConfig(),
+		TimeoutConfig:      scyllaclient.DefaultTimeoutConfig(),
 	}
 }
 

--- a/pkg/config/server/server_test.go
+++ b/pkg/config/server/server_test.go
@@ -37,14 +37,15 @@ func TestConfigModification(t *testing.T) {
 	}
 
 	golden := server.Config{
-		HTTP:        "127.0.0.1:80",
-		HTTPS:       "127.0.0.1:443",
-		TLSVersion:  "TLSv1.3",
-		TLSCertFile: "tls.cert",
-		TLSKeyFile:  "tls.key",
-		TLSCAFile:   "ca.cert",
-		Prometheus:  "127.0.0.1:9090",
-		Debug:       "127.0.0.1:112",
+		HTTP:               "127.0.0.1:80",
+		HTTPS:              "127.0.0.1:443",
+		TLSVersion:         "TLSv1.3",
+		TLSCertFile:        "tls.cert",
+		TLSKeyFile:         "tls.key",
+		TLSCAFile:          "ca.cert",
+		Prometheus:         "127.0.0.1:9090",
+		Debug:              "127.0.0.1:112",
+		ClientCacheTimeout: 15 * time.Minute,
 		Logger: config.LogConfig{
 			Config: log.Config{
 				Mode:  log.StderrMode,

--- a/pkg/schema/table/table.go
+++ b/pkg/schema/table/table.go
@@ -70,6 +70,7 @@ var (
 			"port",
 			"force_tls_disabled",
 			"force_non_ssl_session_port",
+			"host",
 		},
 		PartKey: []string{
 			"id",

--- a/pkg/scyllaclient/client_scylla_test.go
+++ b/pkg/scyllaclient/client_scylla_test.go
@@ -127,36 +127,6 @@ func TestHostIDs(t *testing.T) {
 	}
 }
 
-func TestCheckHostsChanged(t *testing.T) {
-	t.Parallel()
-
-	client, closeServer := scyllaclienttest.NewFakeScyllaServer(t, "testdata/scylla_api/host_id_map.json")
-	defer closeServer()
-
-	b, err := client.CheckHostsChanged(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !b {
-		t.Fatal(b)
-	}
-}
-
-func TestCheckHostsNotChanged(t *testing.T) {
-	t.Parallel()
-
-	client, closeServer := scyllaclienttest.NewFakeScyllaServer(t, "testdata/scylla_api/host_id_map_localhost.json")
-	defer closeServer()
-
-	b, err := client.CheckHostsChanged(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if b {
-		t.Fatal(b)
-	}
-}
-
 func TestClientTokens(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/scyllaclient/context.go
+++ b/pkg/scyllaclient/context.go
@@ -31,6 +31,12 @@ func isInteractive(ctx context.Context) bool {
 	return ok
 }
 
+// ClientContextWithSelectedHost is a public method that returns copy of the given context,
+// but extended with the selected host that will be hit with client calls.
+func ClientContextWithSelectedHost(ctx context.Context, host string) context.Context {
+	return forceHost(ctx, host)
+}
+
 // forceHost makes hostPool middleware use the given host instead of selecting
 // one.
 func forceHost(ctx context.Context, host string) context.Context {

--- a/pkg/scyllaclient/provider_test.go
+++ b/pkg/scyllaclient/provider_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/scylladb/go-log"
+	"github.com/scylladb/scylla-manager/v3/pkg/config/server"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient/scyllaclienttest"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
@@ -28,8 +30,7 @@ func TestCachedProvider(t *testing.T) {
 
 	id := uuid.MustRandom()
 	m := mockProvider{}
-	p := scyllaclient.NewCachedProvider(m.Client)
-	p.SetValidity(0)
+	p := scyllaclient.NewCachedProvider(m.Client, server.DefaultConfig().ClientCacheTimeout, log.Logger{})
 
 	// Error
 	m.err = errors.New("mock")

--- a/pkg/service/cluster/model.go
+++ b/pkg/service/cluster/model.go
@@ -15,7 +15,7 @@ import (
 type Cluster struct {
 	ID         uuid.UUID `json:"id"`
 	Name       string    `json:"name"`
-	Host       string    `json:"host" db:"-"`
+	Host       string    `json:"host"`
 	KnownHosts []string  `json:"-"`
 	Port       int       `json:"port,omitempty"`
 	AuthToken  string    `json:"auth_token"`

--- a/pkg/service/cluster/service.go
+++ b/pkg/service/cluster/service.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
@@ -56,7 +57,9 @@ type Service struct {
 	onChangeListener func(ctx context.Context, c Change) error
 }
 
-func NewService(session gocqlx.Session, metrics metrics.ClusterMetrics, secretsStore store.Store, timeoutConfig scyllaclient.TimeoutConfig, l log.Logger) (*Service, error) {
+func NewService(session gocqlx.Session, metrics metrics.ClusterMetrics, secretsStore store.Store, timeoutConfig scyllaclient.TimeoutConfig,
+	cacheInvalidationTimeout time.Duration, l log.Logger,
+) (*Service, error) {
 	if session.Session == nil || session.Closed() {
 		return nil, errors.New("invalid session")
 	}
@@ -68,7 +71,7 @@ func NewService(session gocqlx.Session, metrics metrics.ClusterMetrics, secretsS
 		logger:        l,
 		timeoutConfig: timeoutConfig,
 	}
-	s.clientCache = scyllaclient.NewCachedProvider(s.createClient)
+	s.clientCache = scyllaclient.NewCachedProvider(s.createClient, cacheInvalidationTimeout, l)
 
 	return s, nil
 }

--- a/pkg/service/cluster/service.go
+++ b/pkg/service/cluster/service.go
@@ -132,7 +132,7 @@ func (s *Service) createClient(ctx context.Context, clusterID uuid.UUID) (*scyll
 		config.Port = fmt.Sprint(c.Port)
 	}
 	config.AuthToken = c.AuthToken
-	config.Hosts = c.KnownHosts
+	config.Hosts = append([]string{c.Host}, c.KnownHosts...)
 
 	client, err := scyllaclient.NewClient(config, s.logger.Named("client"))
 	if err != nil {

--- a/pkg/service/cluster/service_integration_test.go
+++ b/pkg/service/cluster/service_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	"github.com/scylladb/go-log"
+	"github.com/scylladb/scylla-manager/v3/pkg/config/server"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
@@ -35,7 +36,8 @@ func TestClientIntegration(t *testing.T) {
 
 	session := CreateScyllaManagerDBSession(t)
 	secretsStore := store.NewTableStore(session, table.Secrets)
-	s, err := cluster.NewService(session, metrics.NewClusterMetrics(), secretsStore, scyllaclient.DefaultTimeoutConfig(), log.NewDevelopment())
+	s, err := cluster.NewService(session, metrics.NewClusterMetrics(), secretsStore, scyllaclient.DefaultTimeoutConfig(),
+		server.DefaultConfig().ClientCacheTimeout, log.NewDevelopment())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +105,8 @@ func TestServiceStorageIntegration(t *testing.T) {
 
 	secretsStore := store.NewTableStore(session, table.Secrets)
 
-	s, err := cluster.NewService(session, metrics.NewClusterMetrics(), secretsStore, scyllaclient.DefaultTimeoutConfig(), log.NewDevelopment())
+	s, err := cluster.NewService(session, metrics.NewClusterMetrics(), secretsStore, scyllaclient.DefaultTimeoutConfig(),
+		server.DefaultConfig().ClientCacheTimeout, log.NewDevelopment())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/service/healthcheck/service_integration_test.go
+++ b/pkg/service/healthcheck/service_integration_test.go
@@ -42,7 +42,8 @@ func TestStatusIntegration(t *testing.T) {
 	defer session.Close()
 
 	s := store.NewTableStore(session, table.Secrets)
-	clusterSvc, err := cluster.NewService(session, metrics.NewClusterMetrics(), s, scyllaclient.DefaultTimeoutConfig(), log.NewDevelopment())
+	clusterSvc, err := cluster.NewService(session, metrics.NewClusterMetrics(), s, scyllaclient.DefaultTimeoutConfig(),
+		15*time.Minute, log.NewDevelopment())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +70,8 @@ func TestStatusWithCQLCredentialsIntegration(t *testing.T) {
 	defer session.Close()
 
 	s := store.NewTableStore(session, table.Secrets)
-	clusterSvc, err := cluster.NewService(session, metrics.NewClusterMetrics(), s, scyllaclient.DefaultTimeoutConfig(), log.NewDevelopment())
+	clusterSvc, err := cluster.NewService(session, metrics.NewClusterMetrics(), s, scyllaclient.DefaultTimeoutConfig(),
+		15*time.Minute, log.NewDevelopment())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/schema/v3.2.6.cql
+++ b/schema/v3.2.6.cql
@@ -1,2 +1,3 @@
 ALTER TABLE cluster ADD force_tls_disabled BOOLEAN;
 ALTER TABLE cluster ADD force_non_ssl_session_port BOOLEAN;
+ALTER TABLE cluster ADD host text;


### PR DESCRIPTION
Fixes #3707

This PR changes how the Scylla API client is created.

Previously, as Scylla Manager stores all known hosts in the DB, it was passing all of them to the API client initially upon creation. The client then called one of the endpoints to discover available hosts. This approach could lead to non-existing IPs being passed during client creation, and failure when calling the specified endpoint would later indicate that the host doesn't exist.

The client created at this first step is expected to call the Scylla API to retrieve information about existing/available nodes and their IPs, and update this information in the DB. To avoid a situation where the client selects a non-existing IP from the pool, this PR iterates through all known hosts and creates the initial client with just a single IP. If calling the discover hosts endpoint fails, it proceeds to the next host.

The host used when adding the cluster to Scylla Manager is included in the hosts that will be checked against the discover hosts endpoint.

Scylla Manager caches Scylla API clients and invalidates them after 15 minutes. This PR makes the timeout configurable and includes it as part of the `scylla-manager.yaml` configuration. It defaults to 15 minutes.
 

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
