### PR TITLE
Repair: describe ring per table and without cache

### DIFF
--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -875,8 +875,14 @@ func (t HostKeyspaceTables) Hosts() []string {
 	return s.List()
 }
 
+// SizeReport extends HostKeyspaceTable with Size information.
+type SizeReport struct {
+	HostKeyspaceTable
+	Size int64
+}
+
 // TableDiskSizeReport returns total on disk size of tables in bytes.
-func (c *Client) TableDiskSizeReport(ctx context.Context, hostKeyspaceTables HostKeyspaceTables) ([]int64, error) {
+func (c *Client) TableDiskSizeReport(ctx context.Context, hostKeyspaceTables HostKeyspaceTables) ([]SizeReport, error) {
 	// Get shard count of a first node to estimate parallelism limit
 	shards, err := c.ShardCount(ctx, "")
 	if err != nil {
@@ -885,7 +891,7 @@ func (c *Client) TableDiskSizeReport(ctx context.Context, hostKeyspaceTables Hos
 
 	var (
 		limit  = len(hostKeyspaceTables.Hosts()) * int(shards)
-		report = make([]int64, len(hostKeyspaceTables))
+		report = make([]SizeReport, len(hostKeyspaceTables))
 	)
 
 	f := func(i int) error {
@@ -902,7 +908,10 @@ func (c *Client) TableDiskSizeReport(ctx context.Context, hostKeyspaceTables Hos
 			"size", size,
 		)
 
-		report[i] = size
+		report[i] = SizeReport{
+			HostKeyspaceTable: v,
+			Size:              size,
+		}
 		return nil
 	}
 

--- a/pkg/scyllaclient/model.go
+++ b/pkg/scyllaclient/model.go
@@ -179,6 +179,8 @@ type Ring struct {
 	ReplicaTokens []ReplicaTokenRanges
 	HostDC        map[string]string
 	Replication   ReplicationStrategy
+	RF            int
+	DCrf          map[string]int // initialized only for NetworkTopologyStrategy
 }
 
 // Datacenters returns a list of datacenters the keyspace is replicated in.

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -409,8 +409,8 @@ func (s *Service) GetTargetSize(ctx context.Context, clusterID uuid.UUID, target
 	}
 
 	var total int64
-	for _, size := range report {
-		total += size
+	for _, sr := range report {
+		total += sr.Size
 	}
 
 	return total, err

--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -4,8 +4,6 @@ package repair
 
 import (
 	"context"
-	"math"
-	"sort"
 	"strings"
 	"sync/atomic"
 
@@ -14,46 +12,7 @@ import (
 	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-manager/v3/pkg/dht"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
-	"github.com/scylladb/scylla-manager/v3/pkg/util/slice"
 )
-
-// masterSelector describes each host priority for being repair master.
-// Repair master is first chosen by smallest shard count,
-// then by smallest dc RTT from SM.
-type masterSelector map[string]int
-
-func newMasterSelector(shards map[string]uint, hostDC map[string]string, closestDC []string) masterSelector {
-	hosts := make([]string, 0, len(shards))
-	for h := range shards {
-		hosts = append(hosts, h)
-	}
-
-	sort.Slice(hosts, func(i, j int) bool {
-		if shards[hosts[i]] != shards[hosts[j]] {
-			return shards[hosts[i]] < shards[hosts[j]]
-		}
-		return slice.Index(closestDC, hostDC[hosts[i]]) < slice.Index(closestDC, hostDC[hosts[j]])
-	})
-
-	ms := make(masterSelector)
-	for i, h := range hosts {
-		ms[h] = i
-	}
-	return ms
-}
-
-// Select returns repair master from replica set.
-func (ms masterSelector) Select(replicas []string) string {
-	var master string
-	p := math.MaxInt64
-	for _, r := range replicas {
-		if ms[r] < p {
-			p = ms[r]
-			master = r
-		}
-	}
-	return master
-}
 
 type submitter[T, R any] interface {
 	Submit(task T)

--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -4,15 +4,48 @@ package repair
 
 import (
 	"context"
-	"strings"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
 	"github.com/scylladb/go-log"
-	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-manager/v3/pkg/dht"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 )
+
+// generator is responsible for creating and orchestrating tableGenerators.
+type generator struct {
+	generatorTools
+
+	target Target
+	plan   *plan
+	pm     ProgressManager
+	client *scyllaclient.Client
+}
+
+// tableGenerator is responsible for generating and orchestrating
+// repair jobs of given table.
+type tableGenerator struct {
+	generatorTools
+
+	Keyspace     string
+	Table        string
+	Ring         scyllaclient.Ring
+	TodoRanges   map[scyllaclient.TokenRange]struct{}
+	DoneReplicas map[uint64]struct{}
+	Optimize     bool
+	Deleted      bool
+	Err          error
+}
+
+// Tools shared between generator and tableGenerator.
+type generatorTools struct {
+	target    Target
+	ctl       controller
+	ms        masterSelector
+	submitter submitter[job, jobResult]
+	stop      *atomic.Bool
+	logger    log.Logger
+}
 
 type submitter[T, R any] interface {
 	Submit(task T)
@@ -32,6 +65,237 @@ type job struct {
 	deleted bool
 }
 
+type jobResult struct {
+	job
+	err error
+}
+
+func newGenerator(ctx context.Context, target Target, client *scyllaclient.Client, i intensityChecker,
+	s submitter[job, jobResult], plan *plan, pm ProgressManager, logger log.Logger,
+) (*generator, error) {
+	status, err := client.Status(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "get status")
+	}
+	closestDC, err := client.ClosestDC(ctx, status.DatacenterMap(target.DC))
+	if err != nil {
+		return nil, errors.Wrap(err, "calculate closest dc")
+	}
+
+	shards, err := client.HostsShardCount(ctx, plan.Hosts)
+	if err != nil {
+		return nil, err
+	}
+
+	return &generator{
+		generatorTools: generatorTools{
+			target:    target,
+			ctl:       newRowLevelRepairController(i),
+			ms:        newMasterSelector(shards, status.HostDC(), closestDC),
+			submitter: s,
+			stop:      &atomic.Bool{},
+			logger:    logger,
+		},
+		target: target,
+		plan:   plan,
+		pm:     pm,
+		client: client,
+	}, nil
+}
+
+func (g *generator) Run(ctx context.Context) error {
+	g.logger.Info(ctx, "Start generator")
+	var genErr error
+
+	for _, ksp := range g.plan.Keyspaces {
+		if !g.shouldGenerate() {
+			break
+		}
+
+		ring, err := g.client.DescribeRing(ctx, ksp.Keyspace)
+		if err != nil {
+			return errors.Wrap(err, "describe ring")
+		}
+
+		for _, tp := range ksp.Tables {
+			if !g.shouldGenerate() {
+				break
+			}
+
+			tg := g.newTableGenerator(ksp.Keyspace, tp, ring)
+			// All errors are logged, so in order to reduce clutter,
+			// return only the first one.
+			if err := tg.Run(ctx); err != nil && genErr == nil {
+				genErr = err
+			}
+		}
+	}
+
+	g.logger.Info(ctx, "Close generator")
+	g.submitter.Close() // Free workers waiting on next
+	return errors.Wrap(genErr, "see more errors in logs")
+}
+
+func (g *generator) newTableGenerator(keyspace string, tp tablePlan, ring scyllaclient.Ring) *tableGenerator {
+	todoRanges := make(map[scyllaclient.TokenRange]struct{})
+	for _, rt := range ring.ReplicaTokens {
+		for _, r := range rt.Ranges {
+			todoRanges[r] = struct{}{}
+		}
+	}
+	done := g.pm.GetCompletedRanges(keyspace, tp.Table)
+	for _, r := range done {
+		delete(todoRanges, r)
+	}
+
+	tg := &tableGenerator{
+		generatorTools: g.generatorTools,
+		Keyspace:       keyspace,
+		Table:          tp.Table,
+		Ring:           ring,
+		TodoRanges:     todoRanges,
+		DoneReplicas:   make(map[uint64]struct{}),
+		Optimize:       tp.Optimize,
+	}
+	tg.logger = tg.logger.Named(keyspace + "." + tp.Table)
+	return tg
+}
+
+func (g *generator) shouldGenerate() bool {
+	return !g.stop.Load()
+}
+
+func (tg *tableGenerator) Run(ctx context.Context) error {
+	tg.logger.Info(ctx, "Start table generator")
+	tg.generateJobs()
+	for !tg.shouldExit() {
+		if ctx.Err() != nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+		case r := <-tg.submitter.Results():
+			tg.processResult(ctx, r)
+			tg.generateJobs()
+		}
+	}
+	tg.logger.Info(ctx, "Close table generator")
+	return tg.Err
+}
+
+func (tg *tableGenerator) generateJobs() {
+	for {
+		j, ok := tg.newJob()
+		if !ok {
+			return
+		}
+		tg.submitter.Submit(j)
+	}
+}
+
+// newJob tries to return job passing controller restrictions.
+func (tg *tableGenerator) newJob() (job, bool) {
+	if !tg.shouldGenerate() {
+		return job{}, false
+	}
+
+	for _, rt := range tg.Ring.ReplicaTokens {
+		// Calculate replica hash on not filtered replica set
+		// because different replica sets might be the same after filtering.
+		repHash := scyllaclient.ReplicaHash(rt.ReplicaSet)
+		if _, ok := tg.DoneReplicas[repHash]; ok {
+			continue
+		}
+
+		filtered := filterReplicaSet(rt.ReplicaSet, tg.Ring.HostDC, tg.target)
+		if len(filtered) == 0 {
+			tg.DoneReplicas[repHash] = struct{}{}
+			for _, r := range rt.Ranges {
+				delete(tg.TodoRanges, r)
+			}
+			continue
+		}
+
+		if cnt := tg.ctl.TryBlock(filtered); cnt > 0 {
+			ranges := tg.getRangesToRepair(rt.Ranges, cnt)
+			if len(ranges) == 0 {
+				tg.DoneReplicas[repHash] = struct{}{}
+				tg.ctl.Unblock(filtered)
+				continue
+			}
+
+			return job{
+				keyspace:   tg.Keyspace,
+				table:      tg.Table,
+				master:     tg.ms.Select(filtered),
+				replicaSet: filtered,
+				ranges:     ranges,
+				optimize:   tg.Optimize,
+				deleted:    tg.Deleted,
+			}, true
+		}
+	}
+
+	return job{}, false
+}
+
+func (tg *tableGenerator) getRangesToRepair(allRanges []scyllaclient.TokenRange, cnt Intensity) []scyllaclient.TokenRange {
+	if tg.Optimize || tg.Deleted {
+		cnt = NewIntensity(len(allRanges))
+	}
+
+	var ranges []scyllaclient.TokenRange
+	for _, r := range allRanges {
+		if _, ok := tg.TodoRanges[r]; !ok {
+			continue
+		}
+		delete(tg.TodoRanges, r)
+		ranges = append(ranges, r)
+		if NewIntensity(len(ranges)) >= cnt {
+			break
+		}
+	}
+
+	return ranges
+}
+
+func (tg *tableGenerator) processResult(ctx context.Context, jr jobResult) {
+	// Don't record context errors
+	if errors.Is(jr.err, context.Canceled) {
+		return
+	}
+
+	if jr.err != nil && errors.Is(jr.err, errTableDeleted) {
+		tg.logger.Info(ctx, "Detected table deletion", "keyspace", jr.keyspace, "table", jr.table)
+		tg.Deleted = true
+	}
+
+	if !jr.Success() {
+		tg.logger.Error(ctx, "Repair failed", "error", jr.err)
+		// All errors are logged, so in order to reduce clutter,
+		// return only the first one.
+		if tg.Err == nil {
+			tg.Err = jr.err
+		}
+		if tg.target.FailFast {
+			tg.stopGenerating()
+		}
+	}
+	tg.ctl.Unblock(jr.replicaSet)
+}
+
+func (gt generatorTools) stopGenerating() {
+	gt.stop.Store(true)
+}
+
+func (tg *tableGenerator) shouldGenerate() bool {
+	return !tg.stop.Load() && len(tg.TodoRanges) > 0
+}
+
+func (tg *tableGenerator) shouldExit() bool {
+	return !tg.ctl.Busy() && !tg.shouldGenerate()
+}
+
 // tryOptimizeRanges returns either predefined ranges
 // or one full token range for small fully replicated tables.
 func (j job) tryOptimizeRanges() []scyllaclient.TokenRange {
@@ -46,203 +310,7 @@ func (j job) tryOptimizeRanges() []scyllaclient.TokenRange {
 	return j.ranges
 }
 
-type jobResult struct {
-	job
-	err error
-}
-
 func (r jobResult) Success() bool {
 	// jobs of deleted tables are considered to by successful
 	return r.err == nil || errors.Is(r.err, errTableDeleted)
-}
-
-type generator struct {
-	plan   *plan
-	ctl    controller
-	ms     masterSelector
-	client *scyllaclient.Client
-
-	logger   log.Logger
-	failFast bool
-
-	// Responsible for submitting jobs and receiving results.
-	submitter submitter[job, jobResult]
-	// Determines if generator should keep on generating new jobs.
-	stop atomic.Bool
-
-	// Statistics for logging purposes.
-	count       int
-	success     int
-	failed      int
-	lastPercent int
-}
-
-func newGenerator(ctx context.Context, target Target, client *scyllaclient.Client,
-	i intensityChecker, s submitter[job, jobResult], logger log.Logger,
-) (*generator, error) {
-	var ord, cnt int
-	for _, kp := range target.plan.Keyspaces {
-		for _, tp := range kp.Tables {
-			cnt += len(kp.TokenRepIdx)
-			ord++
-			logger.Info(ctx, "Repair order",
-				"order", ord,
-				"keyspace", kp.Keyspace,
-				"table", tp.Table,
-				"size", tp.Size,
-				"merge_ranges", tp.Optimize,
-			)
-		}
-	}
-
-	hosts := target.plan.Hosts()
-	status, err := client.Status(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "get status")
-	}
-	if down := strset.New(status.Down().Hosts()...); down.HasAny(hosts...) {
-		return nil, errors.Errorf("ensure nodes are up, down nodes: %s", strings.Join(down.List(), ","))
-	}
-	closestDC, err := client.ClosestDC(ctx, status.DatacenterMap(target.DC))
-	if err != nil {
-		return nil, errors.Wrap(err, "calculate closest dc")
-	}
-
-	shards, err := client.HostsShardCount(ctx, hosts)
-	if err != nil {
-		return nil, err
-	}
-
-	return &generator{
-		plan:        target.plan,
-		ctl:         newRowLevelRepairController(i),
-		ms:          newMasterSelector(shards, status.HostDC(), closestDC),
-		client:      client,
-		logger:      logger,
-		failFast:    target.FailFast,
-		submitter:   s,
-		count:       cnt,
-		lastPercent: -1,
-	}, nil
-}
-
-func (g *generator) Run(ctx context.Context) error {
-	g.logger.Info(ctx, "Start generator")
-	running := true
-
-	g.generateJobs()
-	if g.shouldExit() {
-		running = false
-	}
-
-	for running {
-		if ctx.Err() != nil {
-			break
-		}
-		select {
-		case <-ctx.Done():
-			running = false
-		case r := <-g.submitter.Results():
-			g.processResult(ctx, r)
-			g.generateJobs()
-			if g.shouldExit() {
-				running = false
-			}
-		}
-	}
-
-	g.logger.Info(ctx, "Close generator")
-	g.submitter.Close() // Free workers waiting on next
-
-	// Don't return ctx error as graceful ctx is handled from service level
-	if g.failed > 0 {
-		return errors.Errorf("repair %d token ranges out of %d", g.failed, g.count)
-	}
-	return nil
-}
-
-func (g *generator) processResult(ctx context.Context, r jobResult) {
-	// Don't record context errors
-	if errors.Is(r.err, context.Canceled) {
-		return
-	}
-
-	if r.err != nil && errors.Is(r.err, errTableDeleted) {
-		g.logger.Info(ctx, "Detected table deletion", "keyspace", r.keyspace, "table", r.table)
-		g.plan.MarkDeleted(r.keyspace, r.table)
-	}
-
-	g.plan.MarkDoneRanges(r.keyspace, r.table, len(r.ranges))
-	if r.Success() {
-		g.success += len(r.ranges)
-	} else {
-		g.logger.Error(ctx, "Repair failed", "error", r.err)
-		g.failed += len(r.ranges)
-		if g.failFast {
-			g.stopGenerating()
-		}
-	}
-
-	if percent := 100 * (g.success + g.failed) / g.count; percent > g.lastPercent {
-		g.logger.Info(ctx, "Progress", "percent", percent, "count", g.count, "success", g.success, "failed", g.failed)
-		g.lastPercent = percent
-	}
-	g.ctl.Unblock(r.replicaSet)
-}
-
-func (g *generator) generateJobs() {
-	for {
-		j, ok := g.newJob()
-		if !ok {
-			return
-		}
-		g.submitter.Submit(j)
-	}
-}
-
-// newJob tries to return job passing controller restrictions.
-func (g *generator) newJob() (job, bool) {
-	if ok := g.plan.UpdateIdx(); !ok {
-		g.stopGenerating()
-	}
-	if !g.shouldGenerate() {
-		return job{}, false
-	}
-
-	ksIdx := g.plan.Idx
-	kp := g.plan.Keyspaces[ksIdx]
-	tabIdx := kp.Idx
-	tp := kp.Tables[tabIdx]
-
-	for repIdx, rep := range kp.Replicas {
-		if kp.IsReplicaMarked(repIdx, tabIdx) {
-			continue
-		}
-
-		if ranges := g.ctl.TryBlock(rep.ReplicaSet); ranges > 0 {
-			return job{
-				keyspace:   kp.Keyspace,
-				table:      tp.Table,
-				master:     g.ms.Select(rep.ReplicaSet),
-				replicaSet: rep.ReplicaSet,
-				ranges:     kp.GetRangesToRepair(repIdx, tabIdx, ranges),
-				optimize:   tp.Optimize,
-				deleted:    tp.Deleted,
-			}, true
-		}
-	}
-
-	return job{}, false
-}
-
-func (g *generator) stopGenerating() {
-	g.stop.Store(true)
-}
-
-func (g *generator) shouldGenerate() bool {
-	return !g.stop.Load()
-}
-
-func (g *generator) shouldExit() bool {
-	return !g.ctl.Busy() && !g.shouldGenerate()
 }

--- a/pkg/service/repair/master_selector.go
+++ b/pkg/service/repair/master_selector.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2024 ScyllaDB
+
+package repair
+
+import (
+	"math"
+	"sort"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/util/slice"
+)
+
+// masterSelector describes each host priority for being repair master.
+// Repair master is first chosen by smallest shard count,
+// then by smallest dc RTT from SM.
+type masterSelector map[string]int
+
+func newMasterSelector(shards map[string]uint, hostDC map[string]string, closestDC []string) masterSelector {
+	hosts := make([]string, 0, len(shards))
+	for h := range shards {
+		hosts = append(hosts, h)
+	}
+
+	sort.Slice(hosts, func(i, j int) bool {
+		if shards[hosts[i]] != shards[hosts[j]] {
+			return shards[hosts[i]] < shards[hosts[j]]
+		}
+		return slice.Index(closestDC, hostDC[hosts[i]]) < slice.Index(closestDC, hostDC[hosts[j]])
+	})
+
+	ms := make(masterSelector)
+	for i, h := range hosts {
+		ms[h] = i
+	}
+	return ms
+}
+
+// Select returns repair master from replica set.
+func (ms masterSelector) Select(replicas []string) string {
+	var master string
+	p := math.MaxInt64
+	for _, r := range replicas {
+		if ms[r] < p {
+			p = ms[r]
+			master = r
+		}
+	}
+	return master
+}

--- a/pkg/service/repair/model.go
+++ b/pkg/service/repair/model.go
@@ -40,9 +40,6 @@ type Target struct {
 	Intensity           Intensity `json:"intensity"`
 	Parallel            int       `json:"parallel"`
 	SmallTableThreshold int64     `json:"small_table_threshold"`
-	// Cache for repair plan so that it does not have to be generated
-	// in both GetTarget and Repair functions.
-	plan *plan `json:"-"`
 }
 
 // taskProperties is the main data structure of the runner.Properties blob.

--- a/pkg/service/repair/plan.go
+++ b/pkg/service/repair/plan.go
@@ -222,14 +222,14 @@ func (p *plan) FillSize(ctx context.Context, client *scyllaclient.Client, smallT
 	ksSize := make(map[string]int64)
 	tableSize := make(map[string]int64)
 	p.HostTableSize = make(map[scyllaclient.HostKeyspaceTable]int64, len(hkts))
-	for i, size := range report {
-		ksSize[hkts[i].Keyspace] += size
-		tableSize[hkts[i].Keyspace+"."+hkts[i].Table] += size
+	for _, sr := range report {
+		ksSize[sr.Keyspace] += sr.Size
+		tableSize[sr.Keyspace+"."+sr.Table] += sr.Size
 		p.HostTableSize[scyllaclient.HostKeyspaceTable{
-			Host:     hkts[i].Host,
-			Keyspace: hkts[i].Keyspace,
-			Table:    hkts[i].Table,
-		}] = size
+			Host:     sr.Host,
+			Keyspace: sr.Keyspace,
+			Table:    sr.Table,
+		}] = sr.Size
 	}
 
 	for i, kp := range p.Keyspaces {

--- a/pkg/service/repair/repair_test.go
+++ b/pkg/service/repair/repair_test.go
@@ -106,3 +106,186 @@ func TestMaxRingParallel(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldRepairRing(t *testing.T) {
+	hostDC := map[string]string{
+		// dc1 -> 1
+		"h1": "dc1",
+		// dc2 -> 1
+		"h2": "dc2",
+		// dc3 -> 3
+		"h3": "dc3",
+		"h4": "dc3",
+		"h5": "dc3",
+		// dc3 -> 4
+		"h6": "dc4",
+		"h7": "dc4",
+		"h8": "dc4",
+		"h9": "dc4",
+	}
+
+	testCases := []struct {
+		Ring     scyllaclient.Ring
+		DCs      []string
+		Host     string
+		Expected bool
+	}{
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.LocalStrategy,
+				RF:          1,
+			},
+			DCs:      []string{"dc1", "dc2", "dc3", "dc4"},
+			Expected: false,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.SimpleStrategy,
+				RF:          1,
+			},
+			DCs:      []string{"dc1", "dc2", "dc3", "dc4"},
+			Expected: false,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.SimpleStrategy,
+				RF:          2,
+			},
+			DCs:      []string{"dc1", "dc2", "dc3", "dc4"},
+			Expected: true,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.SimpleStrategy,
+				RF:          3,
+			},
+			DCs:      []string{"dc3", "dc4"},
+			Expected: false,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.SimpleStrategy,
+				RF:          4,
+			},
+			DCs:      []string{"dc3", "dc4"},
+			Expected: true,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.SimpleStrategy,
+				RF:          4,
+			},
+			DCs:      []string{"dc4"},
+			Expected: false,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.NetworkTopologyStrategy,
+				RF:          4,
+				DCrf: map[string]int{
+					"dc1": 1,
+					"dc2": 1,
+					"dc3": 1,
+					"dc4": 1,
+				},
+			},
+			DCs:      []string{"dc1", "dc2", "dc3", "dc4"},
+			Expected: true,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.NetworkTopologyStrategy,
+				RF:          4,
+				DCrf: map[string]int{
+					"dc1": 1,
+					"dc2": 1,
+					"dc3": 1,
+					"dc4": 1,
+				},
+			},
+			DCs:      []string{"dc1"},
+			Expected: false,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.NetworkTopologyStrategy,
+				RF:          8,
+				DCrf: map[string]int{
+					"dc1": 1,
+					"dc2": 1,
+					"dc3": 2,
+					"dc4": 2,
+				},
+			},
+			DCs:      []string{"dc3"},
+			Expected: true,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.NetworkTopologyStrategy,
+				RF:          8,
+				DCrf: map[string]int{
+					"dc1": 1,
+					"dc2": 1,
+					"dc3": 3,
+					"dc4": 4,
+				},
+			},
+			DCs:      []string{"dc4"},
+			Host:     "h6",
+			Expected: true,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.NetworkTopologyStrategy,
+				RF:          8,
+				DCrf: map[string]int{
+					"dc1": 1,
+					"dc2": 1,
+					"dc3": 3,
+					"dc4": 4,
+				},
+			},
+			DCs:      []string{"dc4"},
+			Host:     "h2",
+			Expected: false,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.NetworkTopologyStrategy,
+				RF:          8,
+				DCrf: map[string]int{
+					"dc1": 1,
+					"dc2": 1,
+					"dc3": 3,
+					"dc4": 4,
+				},
+			},
+			DCs:      []string{"dc1", "dc2", "dc3", "dc4"},
+			Host:     "h1",
+			Expected: true,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run("test "+fmt.Sprint(i), func(t *testing.T) {
+			t.Parallel()
+			if out := repair.ShouldRepairRing(tc.Ring, tc.DCs, tc.Host); out != tc.Expected {
+				t.Fatalf("Expected %v, got %v", tc.Expected, out)
+			}
+		})
+	}
+}

--- a/pkg/service/repair/repair_test.go
+++ b/pkg/service/repair/repair_test.go
@@ -1,0 +1,108 @@
+// Copyright (C) 2024 ScyllaDB
+
+package repair_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/repair"
+)
+
+func TestMaxRingParallel(t *testing.T) {
+	hostDC := map[string]string{
+		// dc1 -> 3
+		"h1": "dc1",
+		"h2": "dc1",
+		"h3": "dc1",
+		// dc2 -> 4
+		"h4": "dc2",
+		"h5": "dc2",
+		"h6": "dc2",
+		"h7": "dc2",
+		// dc3 -> 5
+		"h8":  "dc3",
+		"h9":  "dc3",
+		"h10": "dc3",
+		"h11": "dc3",
+		"h12": "dc3",
+	}
+
+	testCases := []struct {
+		Ring     scyllaclient.Ring
+		DCs      []string
+		Expected int
+	}{
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.SimpleStrategy,
+				RF:          4,
+			},
+			DCs:      []string{"dc1", "dc2", "dc3"},
+			Expected: 3,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.SimpleStrategy,
+				RF:          3,
+			},
+			DCs:      []string{"dc1", "dc2"},
+			Expected: 2,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.NetworkTopologyStrategy,
+				RF:          5,
+				DCrf: map[string]int{
+					"dc1": 1,
+					"dc2": 2,
+					"dc3": 2,
+				},
+			},
+			DCs:      []string{"dc1", "dc2", "dc3"},
+			Expected: 2,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.NetworkTopologyStrategy,
+				RF:          8,
+				DCrf: map[string]int{
+					"dc1": 1,
+					"dc2": 2,
+					"dc3": 5,
+				},
+			},
+			DCs:      []string{"dc1", "dc2"},
+			Expected: 2,
+		},
+		{
+			Ring: scyllaclient.Ring{
+				HostDC:      hostDC,
+				Replication: scyllaclient.NetworkTopologyStrategy,
+				RF:          4,
+				DCrf: map[string]int{
+					"dc1": 2,
+					"dc2": 1,
+					"dc3": 1,
+				},
+			},
+			DCs:      []string{"dc1", "dc3"},
+			Expected: 1,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run("test "+fmt.Sprint(i), func(t *testing.T) {
+			t.Parallel()
+			if out := repair.MaxRingParallel(tc.Ring, tc.DCs); out != tc.Expected {
+				t.Fatalf("Expected %d, got %d", tc.Expected, out)
+			}
+		})
+	}
+}

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1648,7 +1648,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		h.assertProgress(IPFromTestNet("12"), 60, longWait)
 
 		Print("And: repair contains error")
-		h.assertErrorContains("token ranges out of", longWait)
+		h.assertErrorContains("logs", longWait)
 	})
 
 	t.Run("repair error fail fast", func(t *testing.T) {

--- a/pkg/util/maputil/map.go
+++ b/pkg/util/maputil/map.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2024 ScyllaDB
+
+package maputil
+
+// Equal checks if m1 and m2 are the same mapping.
+func Equal[K, V comparable](m1, m2 map[K]V) bool {
+	if len(m1) != len(m2) {
+		return false
+	}
+	for k, v1 := range m1 {
+		if v2, ok := m2[k]; !ok || v1 != v2 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Right now, repair plan contains descriptions of all repaired rings which are stored at the keyspace level. This has two main  issues:
- unnecessary memory consumption
- it makes it difficult to move to a per table ring description required for tablets

The main goal of this PR is remove ring descriptions from plan and query them when needed during an actual repair. 
In order to achieve that, generator responsibility is passed to generator and tableGenerator. Generator is responsible for querying ring description and creating tableGenerators, which take care of repairing given table.

This introduces a lot of code refactoring, so in order to make repair logic more comprehensible I added:
- MaxRingParallel
- ShouldRepairRing

Currently, determining max parallel or if a keyspace should be repaired is convoluted as it requires traversing all token ranges. The changes to DescribeRing replication strategy calculation make it possible to do it by looking at the replication strategy and replication factor, which is easier to understand, explain and test.

This PR tried not to touch repair progress manager, but it might be good to refactor it as well.

Fixes #3745