### PR TITLE
Deprecate interval and mix start_date with cron

### DIFF
--- a/docs/source/sctool/partials/sctool_backup.yaml
+++ b/docs/source/sctool/partials/sctool_backup.yaml
@@ -126,8 +126,6 @@ options:
 - name: start-date
   shorthand: s
   usage: |
-    --start-date is deprecated, please use `--cron` instead
-
     The date can be expressed relatively to now or as a RFC3339 formatted string.
     To run the task in 2 hours use 'now+2h'. The supported units are:
 

--- a/docs/source/sctool/partials/sctool_backup_update.yaml
+++ b/docs/source/sctool/partials/sctool_backup_update.yaml
@@ -127,8 +127,6 @@ options:
 - name: start-date
   shorthand: s
   usage: |
-    --start-date is deprecated, please use `--cron` instead
-
     The date can be expressed relatively to now or as a RFC3339 formatted string.
     To run the task in 2 hours use 'now+2h'. The supported units are:
 

--- a/docs/source/sctool/partials/sctool_backup_validate.yaml
+++ b/docs/source/sctool/partials/sctool_backup_validate.yaml
@@ -72,8 +72,6 @@ options:
 - name: start-date
   shorthand: s
   usage: |
-    --start-date is deprecated, please use `--cron` instead
-
     The date can be expressed relatively to now or as a RFC3339 formatted string.
     To run the task in 2 hours use 'now+2h'. The supported units are:
 

--- a/docs/source/sctool/partials/sctool_backup_validate_update.yaml
+++ b/docs/source/sctool/partials/sctool_backup_validate_update.yaml
@@ -69,8 +69,6 @@ options:
 - name: start-date
   shorthand: s
   usage: |
-    --start-date is deprecated, please use `--cron` instead
-
     The date can be expressed relatively to now or as a RFC3339 formatted string.
     To run the task in 2 hours use 'now+2h'. The supported units are:
 

--- a/docs/source/sctool/partials/sctool_repair.yaml
+++ b/docs/source/sctool/partials/sctool_repair.yaml
@@ -126,8 +126,6 @@ options:
 - name: start-date
   shorthand: s
   usage: |
-    --start-date is deprecated, please use `--cron` instead
-
     The date can be expressed relatively to now or as a RFC3339 formatted string.
     To run the task in 2 hours use 'now+2h'. The supported units are:
 

--- a/docs/source/sctool/partials/sctool_repair_update.yaml
+++ b/docs/source/sctool/partials/sctool_repair_update.yaml
@@ -127,8 +127,6 @@ options:
 - name: start-date
   shorthand: s
   usage: |
-    --start-date is deprecated, please use `--cron` instead
-
     The date can be expressed relatively to now or as a RFC3339 formatted string.
     To run the task in 2 hours use 'now+2h'. The supported units are:
 

--- a/docs/source/sctool/partials/sctool_restore.yaml
+++ b/docs/source/sctool/partials/sctool_restore.yaml
@@ -125,8 +125,6 @@ options:
 - name: start-date
   shorthand: s
   usage: |
-    --start-date is deprecated, please use `--cron` instead
-
     The date can be expressed relatively to now or as a RFC3339 formatted string.
     To run the task in 2 hours use 'now+2h'. The supported units are:
 

--- a/docs/source/sctool/partials/sctool_restore_update.yaml
+++ b/docs/source/sctool/partials/sctool_restore_update.yaml
@@ -123,8 +123,6 @@ options:
 - name: start-date
   shorthand: s
   usage: |
-    --start-date is deprecated, please use `--cron` instead
-
     The date can be expressed relatively to now or as a RFC3339 formatted string.
     To run the task in 2 hours use 'now+2h'. The supported units are:
 

--- a/docs/source/sctool/partials/sctool_suspend.yaml
+++ b/docs/source/sctool/partials/sctool_suspend.yaml
@@ -66,8 +66,6 @@ options:
 - name: start-date
   shorthand: s
   usage: |
-    --start-date is deprecated, please use `--cron` instead
-
     The date can be expressed relatively to now or as a RFC3339 formatted string.
     To run the task in 2 hours use 'now+2h'. The supported units are:
 

--- a/docs/source/sctool/partials/sctool_suspend_update.yaml
+++ b/docs/source/sctool/partials/sctool_suspend_update.yaml
@@ -58,8 +58,6 @@ options:
 - name: start-date
   shorthand: s
   usage: |
-    --start-date is deprecated, please use `--cron` instead
-
     The date can be expressed relatively to now or as a RFC3339 formatted string.
     To run the task in 2 hours use 'now+2h'. The supported units are:
 

--- a/pkg/cmd/scylla-manager/tasks.go
+++ b/pkg/cmd/scylla-manager/tasks.go
@@ -35,7 +35,7 @@ func makeAutoHealthCheckTasks(clusterID uuid.UUID) []*scheduler.Task {
 			Enabled:   true,
 			Name:      "cql",
 			Sched: scheduler.Schedule{
-				Cron:     scheduler.NewCronEvery(15 * time.Second),
+				Cron:     scheduler.NewCronEvery(15*time.Second, time.Time{}),
 				Timezone: localTimezone(),
 			},
 			Properties: healthCheckModeProperties(healthcheck.CQLMode),
@@ -46,7 +46,7 @@ func makeAutoHealthCheckTasks(clusterID uuid.UUID) []*scheduler.Task {
 			Enabled:   true,
 			Name:      "rest",
 			Sched: scheduler.Schedule{
-				Cron:     scheduler.NewCronEvery(1 * time.Minute),
+				Cron:     scheduler.NewCronEvery(1*time.Minute, time.Time{}),
 				Timezone: localTimezone(),
 			},
 			Properties: healthCheckModeProperties(healthcheck.RESTMode),
@@ -57,7 +57,7 @@ func makeAutoHealthCheckTasks(clusterID uuid.UUID) []*scheduler.Task {
 			Enabled:   true,
 			Name:      "alternator",
 			Sched: scheduler.Schedule{
-				Cron:     scheduler.NewCronEvery(15 * time.Second),
+				Cron:     scheduler.NewCronEvery(15*time.Second, time.Time{}),
 				Timezone: localTimezone(),
 			},
 			Properties: healthCheckModeProperties(healthcheck.AlternatorMode),
@@ -74,7 +74,7 @@ func makeAutoRepairTask(clusterID uuid.UUID) *scheduler.Task {
 		Enabled:   true,
 		Name:      "all-weekly",
 		Sched: scheduler.Schedule{
-			Cron:       scheduler.MustCron("0 23 * * SAT"),
+			Cron:       scheduler.MustCron("0 23 * * SAT", time.Time{}),
 			Timezone:   localTimezone(),
 			NumRetries: 3,
 		},

--- a/pkg/command/flag/task.go
+++ b/pkg/command/flag/task.go
@@ -15,11 +15,12 @@ type TaskBase struct {
 	cobra.Command
 	update bool
 
-	enabled    bool
-	name       string
-	cron       Cron
-	window     []string
-	timezone   Timezone
+	enabled  bool
+	name     string
+	cron     Cron
+	window   []string
+	timezone Timezone
+	// Deprecated: use cron instead
 	interval   Duration
 	startDate  StartDate
 	numRetries int

--- a/pkg/command/flag/task.yaml
+++ b/pkg/command/flag/task.yaml
@@ -36,8 +36,6 @@ interval: |
   For example, if you select ``--interval 7d`` task would run weekly at the ``--start-date`` time.
 
 start-date: |
-  --start-date is deprecated, please use `--cron` instead
-  
   The date can be expressed relatively to now or as a RFC3339 formatted string.
   To run the task in 2 hours use 'now+2h'. The supported units are:
   

--- a/pkg/service/scheduler/model.go
+++ b/pkg/service/scheduler/model.go
@@ -261,10 +261,11 @@ func (tz Timezone) Location() *time.Location {
 type Schedule struct {
 	gocqlx.UDT `json:"-"`
 
-	Cron       Cron              `json:"cron"`
-	Window     Window            `json:"window"`
-	Timezone   Timezone          `json:"timezone"`
-	StartDate  time.Time         `json:"start_date"`
+	Cron      Cron      `json:"cron"`
+	Window    Window    `json:"window"`
+	Timezone  Timezone  `json:"timezone"`
+	StartDate time.Time `json:"start_date"`
+	// deprecated: use cron instead
 	Interval   duration.Duration `json:"interval" db:"interval_seconds"`
 	NumRetries int               `json:"num_retries"`
 	RetryWait  duration.Duration `json:"retry_wait"`

--- a/pkg/service/scheduler/model_test.go
+++ b/pkg/service/scheduler/model_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/duration"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 )
 
 func TestTaskType(t *testing.T) {
@@ -56,22 +57,116 @@ func TestStatus(t *testing.T) {
 }
 
 func TestCronMarshalUnmarshal(t *testing.T) {
-	spec := "@every 15s"
-
-	var cron Cron
-	if err := cron.UnmarshalText([]byte(spec)); err != nil {
+	nonZeroTimeString := "2024-02-23T01:12:00Z"
+	nonZeroTime, err := timeutc.Parse(time.RFC3339, nonZeroTimeString)
+	if err != nil {
 		t.Fatal(err)
 	}
-	b, _ := cron.MarshalText()
-	if string(b) != spec {
-		t.Fatalf("MarshalText() = %s, expected %s", string(b), spec)
+
+	for _, tc := range []struct {
+		name         string
+		data         []byte
+		expectedSpec cronSpecification
+	}{
+		{
+			name: "(3.2.6 backward compatibility) unmarshal spec",
+			data: []byte("@every 15s"),
+			expectedSpec: cronSpecification{
+				Spec:      "@every 15s",
+				StartDate: time.Time{},
+			},
+		},
+		{
+			name: "unmarshal spec full struct zero time",
+			data: []byte(`{"spec": "@every 15s", "start_date": "0001-01-01T00:00:00Z"}`),
+			expectedSpec: cronSpecification{
+				Spec:      "@every 15s",
+				StartDate: time.Time{},
+			},
+		},
+		{
+			name: "unmarshal spec full struct non-zero time",
+			data: []byte(`{"spec": "@every 15s", "start_date": "` + nonZeroTimeString + `"}`),
+			expectedSpec: cronSpecification{
+				Spec:      "@every 15s",
+				StartDate: nonZeroTime,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var cron, finalCron Cron
+			if err := cron.UnmarshalText(tc.data); err != nil {
+				t.Fatal(err)
+			}
+			b, err := cron.MarshalText()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := finalCron.UnmarshalText(b); err != nil {
+				t.Fatal(err)
+			}
+
+			if finalCron.Spec != tc.expectedSpec.Spec {
+				t.Fatalf("MarshalText() = %s, expected spec %s", finalCron.Spec, tc.expectedSpec.Spec)
+			}
+			if finalCron.StartDate != tc.expectedSpec.StartDate {
+				t.Fatalf("MarshalText() = %s, expected startDate %s", finalCron.StartDate, tc.expectedSpec.StartDate)
+			}
+
+		})
 	}
 }
 
 func TestNewCronEvery(t *testing.T) {
-	c := NewCronEvery(15 * time.Second)
+	c := NewCronEvery(15*time.Second, time.Time{})
 	if c.IsZero() {
 		t.Fatal()
+	}
+}
+
+func TestNewCronWithNonZeroStartDate(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		nowRFC3339          string
+		startDateRFC3339    string
+		cronExpression      string
+		expectedNextRFC3339 string
+	}{
+		{
+			name:                "current time couple of rounds before start date",
+			nowRFC3339:          "2024-01-01T03:00:00Z",
+			startDateRFC3339:    "2024-02-23T03:00:00Z",
+			cronExpression:      "0 2 * * *",
+			expectedNextRFC3339: "2024-02-24T02:00:00Z",
+		},
+		{
+			name:                "current time couple of rounds before start date",
+			nowRFC3339:          "2024-01-01T03:00:00Z",
+			startDateRFC3339:    "0000-01-01T00:00:00Z",
+			cronExpression:      "0 2 * * *",
+			expectedNextRFC3339: "2024-01-02T02:00:00Z",
+		},
+	} {
+		parsedStart, err := timeutc.Parse(time.RFC3339, tc.startDateRFC3339)
+		if err != nil {
+			t.Fatal(err)
+		}
+		parsedExpected, err := timeutc.Parse(time.RFC3339, tc.expectedNextRFC3339)
+		if err != nil {
+			t.Fatal(err)
+		}
+		parsedNow, err := timeutc.Parse(time.RFC3339, tc.nowRFC3339)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c, err := NewCron(tc.cronExpression, parsedStart)
+		if err != nil {
+			t.Fatal(err)
+		}
+		next := c.Next(parsedNow)
+		if !next.Equal(parsedExpected) {
+			t.Fatalf("expected next schedule %v, but got %v", parsedExpected, next)
+		}
 	}
 }
 

--- a/pkg/service/scheduler/service.go
+++ b/pkg/service/scheduler/service.go
@@ -286,7 +286,7 @@ func (s *Service) PutTask(ctx context.Context, t *Task) error {
 			if t.Sched.Cron.IsZero() {
 				run = true
 			}
-		} else if t.Sched.StartDate.Before(now()) {
+		} else if t.Sched.StartDate.Before(now()) && t.Sched.Interval != 0 {
 			return errors.New("start date of scheduled task cannot be in the past")
 		}
 

--- a/swagger/gen/scylla-manager/models/schedule.go
+++ b/swagger/gen/scylla-manager/models/schedule.go
@@ -20,7 +20,7 @@ type Schedule struct {
 	// cron
 	Cron string `json:"cron,omitempty"`
 
-	// interval
+	// This field is DEPRECATED. Use cron instead.
 	Interval string `json:"interval,omitempty"`
 
 	// num retries

--- a/swagger/scylla-manager.json
+++ b/swagger/scylla-manager.json
@@ -285,7 +285,8 @@
           "x-nullable": true
         },
         "interval": {
-          "type": "string"
+          "type": "string",
+          "description": "This field is DEPRECATED. Use cron instead."
         },
         "num_retries": {
           "type": "number",


### PR DESCRIPTION
Fixes #3701 
Fixes #3700 

This PR deprecates the `interval` param in swagger, `interval` flag in SM codebase.

Besides that, this PR extends Cron to include start date.
`start_date` mixed with `cron` is interpreted as "Run the task frequently according to cron spec, but the first execution must happen after `start_date`".

Fixes #3702 

This PR removes check on start_date when the interval flag is not introduced. More details https://github.com/scylladb/scylla-manager/issues/3702#issuecomment-1952938525

**How it was tested ?**

Integration tests (part of CI) (expected 4 to fail, schema restore in 5.4 and its enterprise equivalent)
Added unit tests to cover new functionality.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
