### PR TITLE
fix(tasks): list tasks with better formatting

### DIFF
--- a/pkg/command/flag/flag.go
+++ b/pkg/command/flag/flag.go
@@ -146,7 +146,6 @@ func (w Wrapper) interval(p *Duration) {
 
 func (w Wrapper) startDate(p *StartDate) {
 	w.fs.VarP(p, "start-date", "s", usage["start-date"])
-	w.MustMarkDeprecated("start-date", "use cron instead")
 }
 
 func (w Wrapper) numRetries(p *int, def int) {

--- a/pkg/restapi/task.go
+++ b/pkg/restapi/task.go
@@ -151,6 +151,9 @@ func (h *taskHandler) parseTask(r *http.Request) (*scheduler.Task, error) {
 	if err := render.DecodeJSON(r.Body, &t); err != nil {
 		return nil, err
 	}
+	if !t.Sched.StartDate.IsZero() && t.Sched.Cron.Spec != "" {
+		t.Sched.Cron.StartDate = t.Sched.StartDate
+	}
 	t.ClusterID = mustClusterIDFromCtx(r)
 	return &t, nil
 }

--- a/pkg/service/scheduler/model.go
+++ b/pkg/service/scheduler/model.go
@@ -70,11 +70,13 @@ func (t *TaskType) UnmarshalText(text []byte) error {
 // Cron implements a trigger based on cron expression.
 // It supports the extended syntax including @monthly, @weekly, @daily, @midnight, @hourly, @every <time.Duration>.
 type Cron struct {
-	cronSpecification
+	CronSpecification
 	inner scheduler.Trigger
 }
 
-type cronSpecification struct {
+// CronSpecification combines specification for cron together with the start dates
+// that defines the moment when the cron is being started.
+type CronSpecification struct {
 	Spec      string    `json:"spec"`
 	StartDate time.Time `json:"start_date"`
 }
@@ -86,7 +88,7 @@ func NewCron(spec string, startDate time.Time) (Cron, error) {
 	}
 
 	return Cron{
-		cronSpecification: cronSpecification{
+		CronSpecification: CronSpecification{
 			Spec:      spec,
 			StartDate: startDate,
 		},
@@ -120,9 +122,9 @@ func (c Cron) Next(now time.Time) time.Time {
 }
 
 func (c Cron) MarshalText() (text []byte, err error) {
-	bytes, err := json.Marshal(c.cronSpecification)
+	bytes, err := json.Marshal(c.CronSpecification)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot json marshal {%v}", c.cronSpecification)
+		return nil, errors.Wrapf(err, "cannot json marshal {%v}", c.CronSpecification)
 	}
 	return bytes, nil
 }
@@ -132,11 +134,11 @@ func (c *Cron) UnmarshalText(text []byte) error {
 		return nil
 	}
 
-	var cronSpec cronSpecification
+	var cronSpec CronSpecification
 	err := json.Unmarshal(text, &cronSpec)
 	if err != nil {
 		// fallback to the < 3.2.6 approach where cron was not coupled with start date
-		cronSpec = cronSpecification{
+		cronSpec = CronSpecification{
 			Spec: string(text),
 		}
 	}

--- a/pkg/service/scheduler/model_test.go
+++ b/pkg/service/scheduler/model_test.go
@@ -66,12 +66,12 @@ func TestCronMarshalUnmarshal(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
 		data         []byte
-		expectedSpec cronSpecification
+		expectedSpec CronSpecification
 	}{
 		{
 			name: "(3.2.6 backward compatibility) unmarshal spec",
 			data: []byte("@every 15s"),
-			expectedSpec: cronSpecification{
+			expectedSpec: CronSpecification{
 				Spec:      "@every 15s",
 				StartDate: time.Time{},
 			},
@@ -79,7 +79,7 @@ func TestCronMarshalUnmarshal(t *testing.T) {
 		{
 			name: "unmarshal spec full struct zero time",
 			data: []byte(`{"spec": "@every 15s", "start_date": "0001-01-01T00:00:00Z"}`),
-			expectedSpec: cronSpecification{
+			expectedSpec: CronSpecification{
 				Spec:      "@every 15s",
 				StartDate: time.Time{},
 			},
@@ -87,7 +87,7 @@ func TestCronMarshalUnmarshal(t *testing.T) {
 		{
 			name: "unmarshal spec full struct non-zero time",
 			data: []byte(`{"spec": "@every 15s", "start_date": "` + nonZeroTimeString + `"}`),
-			expectedSpec: cronSpecification{
+			expectedSpec: CronSpecification{
 				Spec:      "@every 15s",
 				StartDate: nonZeroTime,
 			},


### PR DESCRIPTION
Fixed #3750 

Current output:
```
│ repair/2e3c9d7c-28aa-45ab-9c33-be14c1bdc5a1 │ 0 23 * * SAT; starts: 2024-08-24 23:00:00 UTC │        │ Europe/Warsaw │ 0       │ 0     │                        │                        │ NEW    │ 25 Aug 24 01:00:00 CEST │
│ repair/5954b6b0-0b17-498e-9db4-39ee25c59f9a │ 0 23 * * SAT                                  │        │ Europe/Warsaw │ 0       │ 0     │                        │                        │ NEW    │ 30 Mar 24 23:00:00 CET  │

```

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
