### PR TITLE
Switch from docker-compose to docker compose

### DIFF
--- a/docs/source/docker/index.rst
+++ b/docs/source/docker/index.rst
@@ -13,7 +13,7 @@ Note that `Scylla Kubernetes Operator <https://github.com/scylladb/scylla-operat
 
 **Prerequisites**
 
-Docker and docker-compose commands installed.
+Docker command installed.
 
 **Procedure**
 
@@ -34,8 +34,8 @@ Docker and docker-compose commands installed.
 
    .. code-block:: none
 
-      docker-compose up --build -d
-      docker-compose logs -f scylla-manager
+      docker compose up --build -d
+      docker compose logs -f scylla-manager
 
 #. Wait until the server is started, you should see something like
 
@@ -52,7 +52,7 @@ Docker and docker-compose commands installed.
 
    .. code-block:: none
 
-      docker-compose exec scylla-manager bash
+      docker compose exec scylla-manager bash
 
 #. Add the cluster to Scylla Manager
 
@@ -84,7 +84,7 @@ container, run the following:
 
    .. code-block:: none
 
-      docker-compose exec minio sh -c "mkdir /data/docker"
+      docker compose exec minio sh -c "mkdir /data/docker"
 
 Afterwards you can schedule backups in Scylla Manager using "s3:docker" as the
 backup location.

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -5,7 +5,7 @@
 
 set -eu -o pipefail
 
-LINUX_PKGS="docker-compose jq make moreutils openssl"
+LINUX_PKGS="jq make moreutils openssl"
 
 source ./env
 mkdir -p ${LOCAL_BIN}

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -1,6 +1,6 @@
 all: help
 
-COMPOSE      := docker-compose
+COMPOSE      := docker compose
 CQLSH        := $(COMPOSE) exec scylla-manager-db cqlsh
 CQLSH_NODE   := $(COMPOSE) exec -T dc1_node_1 cqlsh
 NODETOOL     := $(COMPOSE) exec -T dc1_node_1 nodetool

--- a/testing/corrupt
+++ b/testing/corrupt
@@ -5,7 +5,7 @@
 
 set -eu -o pipefail -x
 
-COMPOSE=docker-compose
+COMPOSE=docker compose
 
 NODE=
 KEYSPACE="test_keyspace_rf3"

--- a/testing/docker-compose-ipv4.yaml
+++ b/testing/docker-compose-ipv4.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   dc1_node_1:
     command: ${SCYLLA_ARGS} --rpc-address 192.168.100.11 --alternator-address 192.168.200.11 --listen-address 192.168.200.11

--- a/testing/docker-compose-ipv6.yaml
+++ b/testing/docker-compose-ipv6.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   dc1_node_1:
     command: ${SCYLLA_ARGS} --rpc-address 2001:0DB9:100::11 --alternator-address 2001:0DB9:200::11 --listen-address 2001:0DB9:200::11

--- a/testing/docker-compose.yaml
+++ b/testing/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 services:
   dc1_node_1:
     image: scylladb/agent-${SCYLLA_VERSION}


### PR DESCRIPTION
This PR switches the usage of `docker-compose` to `docker compose`.
Outdated `docker-compose` has been the reason why some gh actions jobs were failing.