### PR TITLE
Feature branch for Config Cache Service

### DIFF
--- a/pkg/cmd/scylla-manager/root.go
+++ b/pkg/cmd/scylla-manager/root.go
@@ -144,7 +144,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return errors.Wrapf(err, "server init")
 		}
-		if err := s.makeServices(); err != nil {
+		if err := s.makeServices(ctx); err != nil {
 			return errors.Wrapf(err, "server init")
 		}
 		if err := s.makeServers(ctx); err != nil {

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -88,6 +88,7 @@ func (s *server) makeServices(ctx context.Context) error {
 		s.clusterSvc.Client,
 		secretsStore,
 		s.clusterSvc.GetClusterByID,
+		s.configCacheSvc,
 		s.logger.Named("healthcheck"),
 	)
 	if err != nil {

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/schema/table"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/configcache"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/healthcheck"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/repair"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/restore"
@@ -35,12 +36,13 @@ type server struct {
 	session gocqlx.Session
 	logger  log.Logger
 
-	clusterSvc *cluster.Service
-	healthSvc  *healthcheck.Service
-	backupSvc  *backup.Service
-	restoreSvc *restore.Service
-	repairSvc  *repair.Service
-	schedSvc   *scheduler.Service
+	clusterSvc     *cluster.Service
+	healthSvc      *healthcheck.Service
+	backupSvc      *backup.Service
+	restoreSvc     *restore.Service
+	repairSvc      *repair.Service
+	schedSvc       *scheduler.Service
+	configCacheSvc configcache.ConfigCacher
 
 	httpServer       *http.Server
 	httpsServer      *http.Server
@@ -65,7 +67,7 @@ func newServer(c config.Config, logger log.Logger) (*server, error) {
 	}, nil
 }
 
-func (s *server) makeServices() error {
+func (s *server) makeServices(ctx context.Context) error {
 	var err error
 
 	drawerStore := store.NewTableStore(s.session, table.Drawer)
@@ -77,6 +79,9 @@ func (s *server) makeServices() error {
 		return errors.Wrapf(err, "cluster service")
 	}
 	s.clusterSvc.SetOnChangeListener(s.onClusterChange)
+
+	s.configCacheSvc = configcache.NewService(s.clusterSvc, s.clusterSvc.CreateClientNoCache, secretsStore, s.logger)
+	s.initConfigCacheSvc(ctx)
 
 	s.healthSvc, err = healthcheck.NewService(
 		s.config.Healthcheck,
@@ -234,6 +239,39 @@ func (s *server) makeServers(ctx context.Context) error {
 	return nil
 }
 
+func (s *server) initConfigCacheSvc(ctx context.Context) {
+	s.logger.Info(ctx, "Initializing the clusters configuration cache")
+	defer s.logger.Info(ctx, "Clusters config cache initialized")
+
+	s.configCacheSvc.Init(ctx)
+}
+
+func (s *server) startConfigCacheSvcAsync(ctx context.Context) {
+	go func() {
+		logger := s.logger.Named("Config cache goroutine")
+
+		for {
+			select {
+			case <-ctx.Done():
+				logger.Info(ctx, "Shutdown")
+				return
+			default:
+				func() {
+					defer func() {
+						if r := recover(); r != nil {
+							logger.Error(ctx, "Recovered from panic:", "recover", r)
+						}
+
+						s.configCacheSvc.Init(ctx)
+					}()
+
+					s.configCacheSvc.Run(ctx)
+				}()
+			}
+		}
+	}()
+}
+
 func (s *server) tlsConfig(ctx context.Context) (*tls.Config, error) {
 	var (
 		cert tls.Certificate
@@ -288,6 +326,9 @@ func (s *server) startServices(ctx context.Context) error {
 	if err := s.schedSvc.LoadTasks(ctx); err != nil {
 		return errors.Wrapf(err, "schedule service")
 	}
+
+	s.startConfigCacheSvcAsync(ctx)
+
 	return nil
 }
 

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -80,7 +80,8 @@ func (s *server) makeServices(ctx context.Context) error {
 	}
 	s.clusterSvc.SetOnChangeListener(s.onClusterChange)
 
-	s.configCacheSvc = configcache.NewService(s.clusterSvc, s.clusterSvc.CreateClientNoCache, secretsStore, s.logger)
+	s.configCacheSvc = configcache.NewService(s.config.ConfigCache, s.clusterSvc, s.clusterSvc.CreateClientNoCache,
+		secretsStore, s.logger)
 	s.initConfigCacheSvc(ctx)
 
 	s.healthSvc, err = healthcheck.NewService(

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -191,8 +191,6 @@ func (s *server) onClusterChange(ctx context.Context, c cluster.Change) error {
 		}
 	}
 
-	s.healthSvc.InvalidateCache(c.ID)
-
 	return nil
 }
 

--- a/pkg/config/server/server.go
+++ b/pkg/config/server/server.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/configcache"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/restore"
 
 	"github.com/scylladb/scylla-manager/v3/pkg/config"
@@ -59,6 +60,7 @@ type Config struct {
 	Database           DBConfig                   `yaml:"database"`
 	SSL                SSLConfig                  `yaml:"ssl"`
 	Healthcheck        healthcheck.Config         `yaml:"healthcheck"`
+	ConfigCache        configcache.Config         `yaml:"config_cache"`
 	Backup             backup.Config              `yaml:"backup"`
 	Restore            restore.Config             `yaml:"restore"`
 	Repair             repair.Config              `yaml:"repair"`
@@ -90,6 +92,7 @@ func DefaultConfig() Config {
 		Restore:            restore.DefaultConfig(),
 		Repair:             repair.DefaultConfig(),
 		TimeoutConfig:      scyllaclient.DefaultTimeoutConfig(),
+		ConfigCache:        configcache.DefaultConfig(),
 	}
 }
 

--- a/pkg/config/server/server_test.go
+++ b/pkg/config/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/scylladb/go-log"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/configcache"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/restore"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -109,6 +110,9 @@ func TestConfigModification(t *testing.T) {
 				MaxRetries: 4,
 			},
 			PoolDecayDuration: time.Hour,
+		},
+		ConfigCache: configcache.Config{
+			UpdateFrequency: 5 * time.Minute,
 		},
 	}
 

--- a/pkg/service/cluster/service.go
+++ b/pkg/service/cluster/service.go
@@ -47,6 +47,20 @@ type Change struct {
 	WithoutRepair bool
 }
 
+// Servicer interface defines the responsibilities of the cluster service.
+// It's a duplicate of the restapi.ClusterService, but I want to avoid doing bigger refactor
+// and removing the interface from restapi package (although nothing prevents us from doing so).
+type Servicer interface {
+	ListClusters(ctx context.Context, f *Filter) ([]*Cluster, error)
+	GetCluster(ctx context.Context, idOrName string) (*Cluster, error)
+	PutCluster(ctx context.Context, c *Cluster) error
+	DeleteCluster(ctx context.Context, id uuid.UUID) error
+	CheckCQLCredentials(id uuid.UUID) (bool, error)
+	DeleteCQLCredentials(ctx context.Context, id uuid.UUID) error
+	DeleteSSLUserCert(ctx context.Context, id uuid.UUID) error
+	ListNodes(ctx context.Context, id uuid.UUID) ([]Node, error)
+}
+
 // Service manages cluster configurations.
 type Service struct {
 	session          gocqlx.Session

--- a/pkg/service/configcache/config.go
+++ b/pkg/service/configcache/config.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2024 ScyllaDB
+
+package configcache
+
+import "time"
+
+// Config specifies the cache service configuration.
+type Config struct {
+	// UpdateFrequency specifies how often to call Scylla for its configuration.
+	UpdateFrequency time.Duration `yaml:"update_frequency"`
+}
+
+func DefaultConfig() Config {
+	return Config{
+		UpdateFrequency: 5 * time.Minute,
+	}
+}

--- a/pkg/service/configcache/errors.go
+++ b/pkg/service/configcache/errors.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2024 ScyllaDB
+
+package configcache
+
+import "errors"
+
+var (
+	// ErrNoClusterConfig is thrown when there is no config for given cluster in cache.
+	ErrNoClusterConfig = errors.New("no cluster config available")
+	// ErrNoHostConfig is thrown when there is no config for given host in cache.
+	ErrNoHostConfig = errors.New("no host config available")
+)

--- a/pkg/service/configcache/nodeconfig.go
+++ b/pkg/service/configcache/nodeconfig.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2024 ScyllaDB
+
+package configcache
+
+import (
+	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	"github.com/scylladb/scylla-manager/v3/pkg/store"
+)
+
+// NodeConfig keeps the node current node configuration together with the TLS details per different type of connection.
+type NodeConfig struct {
+	*scyllaclient.NodeInfo
+
+	cqlTLSConfig        *TLSConfigWithAddress
+	alternatorTLSConfig *TLSConfigWithAddress
+}
+
+// NewNodeConfig creates and initializes new node configuration struct containing TLS configuration of CQL and Alternator.
+func NewNodeConfig(c *cluster.Cluster, nodeInfo *scyllaclient.NodeInfo, secretsStore store.Store, host string) (config NodeConfig, err error) {
+	cqlTLS, err := newCQLTLSConfigIfEnabled(c, nodeInfo, secretsStore, host)
+	if err != nil {
+		return NodeConfig{}, errors.Wrap(err, "building node config")
+	}
+	alternatorTLS, err := newAlternatorTLSConfigIfEnabled(c, nodeInfo, secretsStore, host)
+	if err != nil {
+		return NodeConfig{}, errors.Wrap(err, "building node config")
+	}
+	return NodeConfig{
+		NodeInfo:            nodeInfo,
+		cqlTLSConfig:        cqlTLS,
+		alternatorTLSConfig: alternatorTLS,
+	}, nil
+}
+
+// CQLTLSConfig is a getter of TLS configuration for CQL session.
+func (nc NodeConfig) CQLTLSConfig() *TLSConfigWithAddress {
+	return nc.cqlTLSConfig
+}
+
+// AlternatorTLSConfig is a getter of TLS configuration for Alternator session.
+func (nc NodeConfig) AlternatorTLSConfig() *TLSConfigWithAddress {
+	return nc.alternatorTLSConfig
+}

--- a/pkg/service/configcache/service.go
+++ b/pkg/service/configcache/service.go
@@ -1,0 +1,288 @@
+// Copyright (C) 2024 ScyllaDB
+
+package configcache
+
+import (
+	"context"
+	"crypto/tls"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/go-log"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/secrets"
+	"github.com/scylladb/scylla-manager/v3/pkg/service"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	"github.com/scylladb/scylla-manager/v3/pkg/store"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+)
+
+// ConnectionType defines an enum for different types of configuration.
+type ConnectionType int
+
+const (
+	// CQL defines cql connection type.
+	CQL ConnectionType = iota
+	// Alternator defines alternator connection type.
+	Alternator
+
+	updateFrequency = 5 * time.Minute
+)
+
+type tlsConfigWithAddress struct {
+	*tls.Config
+	Address string
+}
+
+// NodeConfig keeps the node current node configuration together with the TLS details per different type of connection.
+type NodeConfig struct {
+	*scyllaclient.NodeInfo
+	TLSConfig map[ConnectionType]*tlsConfigWithAddress
+}
+
+// ConfigCacher is the interface defining the cache behavior.
+type ConfigCacher interface {
+	// Read returns either the host configuration that is currently stored in the cache,
+	// ErrNoClusterConfig if config for the whole cluster doesn't exist,
+	// or ErrNoHostConfig if config of the particular host doesn't exist.
+	Read(clusterID uuid.UUID, host string) (NodeConfig, error)
+
+	// ForceUpdateCluster updates single cluster config in cache and does it outside the background process.
+	ForceUpdateCluster(ctx context.Context, clusterID uuid.UUID) bool
+
+	// RemoveCluster removes cluster data of a given uuid from cache.
+	RemoveCluster(clusterID uuid.UUID)
+
+	// Init updates cache with config of all currently managed clusters.
+	Init(ctx context.Context)
+
+	// Run starts the infinity loop responsible for updating the clusters configuration periodically.
+	Run(ctx context.Context, skipFirst bool)
+}
+
+// Service is responsible for handling all cluster configuration cache related operations.
+// Use svc.Read(clusterID, host) to read the configuration of particular host in given cluster.
+// Use svc.Run() to let the cache update itself periodically with the current configuration.
+type Service struct {
+	clusterSvc   cluster.Servicer
+	scyllaClient scyllaclient.ProviderFunc
+	secretsStore store.Store
+
+	configs sync.Map
+	logger  log.Logger
+}
+
+// NewService is the constructor for the cluster config cache service.
+func NewService(clusterSvc cluster.Servicer, client scyllaclient.ProviderFunc, secretsStore store.Store, logger log.Logger) ConfigCacher {
+	return &Service{
+		clusterSvc:   clusterSvc,
+		scyllaClient: client,
+		secretsStore: secretsStore,
+		configs:      sync.Map{},
+		logger:       logger,
+	}
+}
+
+func (svc *Service) Init(ctx context.Context) {
+	svc.updateAll(ctx)
+}
+
+func (svc *Service) Read(clusterID uuid.UUID, host string) (NodeConfig, error) {
+	emptyConfig := NodeConfig{}
+
+	clusterConfig, err := svc.readClusterConfig(clusterID)
+	if err != nil {
+		return emptyConfig, err
+	}
+
+	rawHostConfig, ok := clusterConfig.Load(host)
+	if !ok {
+		return emptyConfig, ErrNoHostConfig
+	}
+	hostConfig, ok := rawHostConfig.(NodeConfig)
+	if !ok {
+		panic("cluster host emptyConfig cache stores unexpected type")
+	}
+	return hostConfig, nil
+}
+
+// Run starts the infinity loop responsible for updating the clusters configuration periodically.
+func (svc *Service) Run(ctx context.Context, skipFirst bool) {
+	if skipFirst {
+		time.Sleep(updateFrequency)
+	}
+	freq := time.NewTicker(updateFrequency)
+
+	for {
+		// make sure to shut down when the context is cancelled
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		select {
+		case <-freq.C:
+			svc.updateAll(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// RemoveCluster removes cluster data of a given uuid from cache.
+func (svc *Service) RemoveCluster(clusterID uuid.UUID) {
+	svc.configs.Delete(clusterID.String())
+}
+
+// ForceUpdateCluster updates single cluster config in cache and does it outside the background process.
+func (svc *Service) ForceUpdateCluster(ctx context.Context, clusterID uuid.UUID) bool {
+	logger := svc.logger.Named("Force update cluster").With("cluster", clusterID)
+
+	c, err := svc.clusterSvc.GetCluster(ctx, clusterID.String())
+	if err != nil {
+		logger.Error(ctx, "Update failed", "error", err)
+	}
+
+	return svc.updateSingle(ctx, c)
+}
+
+func (svc *Service) updateSingle(ctx context.Context, c *cluster.Cluster) bool {
+	logger := svc.logger.Named("Cluster config update").With("cluster", c.ID)
+
+	clusterConfig := &sync.Map{}
+
+	client, err := svc.scyllaClient(ctx, c.ID)
+	if err != nil {
+		logger.Error(ctx, "Couldn't create scylla client", "cluster", c.ID, "error", err)
+		return false
+	}
+
+	// Hosts that are going to be asked about the configuration are exactly the same as
+	// the ones used by the scylla client.
+	hostsWg := sync.WaitGroup{}
+
+	for _, host := range client.Config().Hosts {
+		hostsWg.Add(1)
+
+		host := host
+		perHostLogger := logger.Named("Cluster host config update").With("host", host)
+		go func() {
+			defer hostsWg.Done()
+
+			config, err := svc.retrieveNodeConfig(ctx, host, client, c)
+			if err != nil {
+				perHostLogger.Error(ctx, "Couldn't read cluster host config", "error", err)
+				return
+			}
+			clusterConfig.Store(host, config)
+		}()
+	}
+	hostsWg.Wait()
+	svc.configs.Store(c.ID.String(), clusterConfig)
+
+	return true
+}
+
+func (svc *Service) updateAll(ctx context.Context) {
+	clusters, err := svc.clusterSvc.ListClusters(ctx, &cluster.Filter{})
+	if err != nil {
+		svc.logger.Error(ctx, "Couldn't list clusters", "error", err)
+		return
+	}
+
+	clustersWg := sync.WaitGroup{}
+	for _, c := range clusters {
+		c := c
+		clustersWg.Add(1)
+		go func() {
+			defer clustersWg.Done()
+
+			svc.updateSingle(ctx, c)
+		}()
+	}
+	clustersWg.Wait()
+}
+
+func (svc *Service) readClusterConfig(clusterID uuid.UUID) (*sync.Map, error) {
+	emptyConfig := &sync.Map{}
+
+	rawClusterConfig, ok := svc.configs.Load(clusterID.String())
+	if !ok {
+		return emptyConfig, ErrNoClusterConfig
+	}
+	clusterConfig, ok := rawClusterConfig.(*sync.Map)
+	if !ok {
+		panic("cluster cache emptyConfig stores unexpected type")
+	}
+	return clusterConfig, nil
+}
+
+func (svc *Service) retrieveNodeConfig(ctx context.Context, host string, client *scyllaclient.Client,
+	c *cluster.Cluster,
+) (NodeConfig, error) {
+	config := NodeConfig{}
+
+	nodeInfoResp, err := client.NodeInfo(ctx, host)
+	if err != nil {
+		return config, errors.Wrap(err, "fetch node info")
+	}
+
+	config.NodeInfo = nodeInfoResp
+	config.TLSConfig = make(map[ConnectionType]*tlsConfigWithAddress, 2)
+	for _, p := range []ConnectionType{CQL, Alternator} {
+		var tlsEnabled, clientCertAuth bool
+		var address string
+		if p == CQL {
+			address = nodeInfoResp.CQLAddr(host)
+			tlsEnabled, clientCertAuth = nodeInfoResp.CQLTLSEnabled()
+			tlsEnabled = tlsEnabled && !c.ForceTLSDisabled
+			if tlsEnabled && !c.ForceNonSSLSessionPort {
+				address = nodeInfoResp.CQLSSLAddr(host)
+			}
+		} else if p == Alternator {
+			tlsEnabled, clientCertAuth = nodeInfoResp.AlternatorTLSEnabled()
+			address = nodeInfoResp.AlternatorAddr(host)
+		}
+		if tlsEnabled {
+			tlsConfig, err := svc.tlsConfig(c.ID, clientCertAuth)
+			if err != nil && !errors.Is(err, service.ErrNotFound) {
+				return config, errors.Wrap(err, "fetch TLS config")
+			}
+			if clientCertAuth && errors.Is(err, service.ErrNotFound) {
+				return config, errors.Wrap(err, "client encryption is enabled, but certificate is missing")
+			}
+			config.TLSConfig[p] = &tlsConfigWithAddress{
+				Config:  tlsConfig,
+				Address: address,
+			}
+		} else {
+			delete(config.TLSConfig, p)
+		}
+	}
+
+	return config, nil
+}
+
+func (svc *Service) tlsConfig(clusterID uuid.UUID, clientCertAuth bool) (*tls.Config, error) {
+	cfg := tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	if clientCertAuth {
+		id := &secrets.TLSIdentity{
+			ClusterID: clusterID,
+		}
+		if err := svc.secretsStore.Get(id); err != nil {
+			return nil, errors.Wrap(err, "get SSL user cert from secrets store")
+		}
+		keyPair, err := tls.X509KeyPair(id.Cert, id.PrivateKey)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid SSL user key pair")
+		}
+		cfg.Certificates = []tls.Certificate{keyPair}
+	}
+
+	return &cfg, nil
+}

--- a/pkg/service/configcache/service.go
+++ b/pkg/service/configcache/service.go
@@ -69,7 +69,7 @@ type Service struct {
 	scyllaClient scyllaclient.ProviderFunc
 	secretsStore store.Store
 
-	configs sync.Map
+	configs *sync.Map
 	logger  log.Logger
 }
 
@@ -79,13 +79,13 @@ func NewService(clusterSvc cluster.Servicer, client scyllaclient.ProviderFunc, s
 		clusterSvc:   clusterSvc,
 		scyllaClient: client,
 		secretsStore: secretsStore,
-		configs:      sync.Map{},
+		configs:      &sync.Map{},
 		logger:       logger,
 	}
 }
 
 func (svc *Service) Init(ctx context.Context) {
-	svc.configs = sync.Map{}
+	svc.configs = &sync.Map{}
 	svc.updateAll(ctx)
 }
 

--- a/pkg/service/configcache/service_test.go
+++ b/pkg/service/configcache/service_test.go
@@ -85,7 +85,7 @@ func TestService_Read(t *testing.T) {
 				clusterSvc:   &mockClusterServicer{},
 				scyllaClient: mockProviderFunc,
 				secretsStore: &mockStore{},
-				configs:      *tc.state,
+				configs:      tc.state,
 			}
 
 			// When
@@ -112,7 +112,7 @@ func TestService_Run(t *testing.T) {
 			clusterSvc:   &mockClusterServicer{},
 			scyllaClient: mockProviderFunc,
 			secretsStore: &mockStore{},
-			configs:      sync.Map{},
+			configs:      &sync.Map{},
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/service/configcache/service_test.go
+++ b/pkg/service/configcache/service_test.go
@@ -121,7 +121,7 @@ func TestService_Run(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			svc.Run(ctx, false)
+			svc.Run(ctx)
 		}()
 
 		time.Sleep(3 * time.Second)

--- a/pkg/service/configcache/service_test.go
+++ b/pkg/service/configcache/service_test.go
@@ -82,6 +82,7 @@ func TestService_Read(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Given
 			svc := Service{
+				svcConfig:    DefaultConfig(),
 				clusterSvc:   &mockClusterServicer{},
 				scyllaClient: mockProviderFunc,
 				secretsStore: &mockStore{},
@@ -109,6 +110,7 @@ func TestService_Read(t *testing.T) {
 func TestService_Run(t *testing.T) {
 	t.Run("validate context cancellation handling", func(t *testing.T) {
 		svc := Service{
+			svcConfig:    DefaultConfig(),
 			clusterSvc:   &mockClusterServicer{},
 			scyllaClient: mockProviderFunc,
 			secretsStore: &mockStore{},

--- a/pkg/service/configcache/service_test.go
+++ b/pkg/service/configcache/service_test.go
@@ -1,0 +1,229 @@
+// Copyright (C) 2024 ScyllaDB
+
+package configcache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	"github.com/scylladb/scylla-manager/v3/pkg/store"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+)
+
+// Servicer.ForceUpdateCluster() and Servicer.Init(ctx context.Context) are expected to be covered with the
+// integration tests.
+
+func TestService_Read(t *testing.T) {
+	emptyConfigHash, err := NodeConfig{}.sha256hash()
+	if err != nil {
+		t.Fatalf("unable to create sha256 hash out of empty NodeConfig, err = {%v}", err)
+	}
+	host1NodeConfig := NodeConfig{
+		NodeInfo: &scyllaclient.NodeInfo{
+			AgentVersion: "expectedVersion",
+		},
+	}
+	host1ConfigHash, err := host1NodeConfig.sha256hash()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cluster1UUID := uuid.MustRandom()
+	host1ID := "host1"
+	initialState := convertMapToSyncMap(
+		map[any]any{
+			cluster1UUID.String(): convertMapToSyncMap(
+				map[any]any{
+					host1ID: host1NodeConfig,
+				},
+			),
+		},
+	)
+
+	for _, tc := range []struct {
+		name             string
+		cluster          uuid.UUID
+		host             string
+		state            *sync.Map
+		resultErr        error
+		resultConfigHash [32]byte
+	}{
+		{
+			name:             "host configuration doesn't exist",
+			host:             "host_that_does_not_exist",
+			cluster:          cluster1UUID,
+			state:            initialState,
+			resultErr:        ErrNoHostConfig,
+			resultConfigHash: emptyConfigHash,
+		},
+		{
+			name:             "cluster configuration doesn't exist",
+			host:             host1ID,
+			cluster:          uuid.Nil,
+			state:            initialState,
+			resultErr:        ErrNoClusterConfig,
+			resultConfigHash: emptyConfigHash,
+		},
+		{
+			name:             "retrieves the config",
+			host:             host1ID,
+			cluster:          cluster1UUID,
+			state:            initialState,
+			resultErr:        nil,
+			resultConfigHash: host1ConfigHash,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Given
+			svc := Service{
+				clusterSvc:   &mockClusterServicer{},
+				scyllaClient: mockProviderFunc,
+				secretsStore: &mockStore{},
+				configs:      *tc.state,
+			}
+
+			// When
+			conf, err := svc.Read(tc.cluster, tc.host)
+
+			// Then
+			if err != tc.resultErr {
+				t.Fatalf("expected error = {%v}, but got {%v}", tc.resultErr, err)
+			}
+			confHash, err := conf.sha256hash()
+			if err != nil {
+				t.Fatalf("unable to create hash out of NodeConf, err = {%v}", err)
+			}
+			if confHash != tc.resultConfigHash {
+				t.Fatalf("expected hash = {%s}, but got {%s}", tc.resultConfigHash, confHash)
+			}
+		})
+	}
+}
+
+func TestService_Run(t *testing.T) {
+	t.Run("validate context cancellation handling", func(t *testing.T) {
+		svc := Service{
+			clusterSvc:   &mockClusterServicer{},
+			scyllaClient: mockProviderFunc,
+			secretsStore: &mockStore{},
+			configs:      sync.Map{},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			svc.Run(ctx, false)
+		}()
+
+		time.Sleep(3 * time.Second)
+		cancel()
+
+		wg.Wait()
+	})
+}
+
+func (nc NodeConfig) sha256hash() (hash [32]byte, err error) {
+	data, err := json.Marshal(nc)
+	if err != nil {
+		return hash, err
+	}
+
+	return sha256.Sum256(data), nil
+}
+
+// utility functions
+func convertMapToSyncMap(m map[any]any) *sync.Map {
+	syncM := sync.Map{}
+	for k, v := range m {
+		syncM.Store(k, v)
+	}
+	return &syncM
+}
+
+// internal mock implementation of interfaces
+
+// mockClusterServicer implements the Servicer interface as a mock for testing purposes.
+type mockClusterServicer struct{}
+
+// ListClusters mocks the ListClusters method of Servicer.
+func (s *mockClusterServicer) ListClusters(ctx context.Context, f *cluster.Filter) ([]*cluster.Cluster, error) {
+	return nil, nil
+}
+
+// GetCluster mocks the GetCluster method of Servicer.
+func (s *mockClusterServicer) GetCluster(ctx context.Context, idOrName string) (*cluster.Cluster, error) {
+	return nil, nil
+}
+
+// PutCluster mocks the PutCluster method of Servicer.
+func (s *mockClusterServicer) PutCluster(ctx context.Context, c *cluster.Cluster) error {
+	return nil
+}
+
+// DeleteCluster mocks the DeleteCluster method of Servicer.
+func (s *mockClusterServicer) DeleteCluster(ctx context.Context, id uuid.UUID) error {
+	return nil
+}
+
+// CheckCQLCredentials mocks the CheckCQLCredentials method of Servicer.
+func (s *mockClusterServicer) CheckCQLCredentials(id uuid.UUID) (bool, error) {
+	return false, nil
+}
+
+// DeleteCQLCredentials mocks the DeleteCQLCredentials method of Servicer.
+func (s *mockClusterServicer) DeleteCQLCredentials(ctx context.Context, id uuid.UUID) error {
+	return nil
+}
+
+// DeleteSSLUserCert mocks the DeleteSSLUserCert method of Servicer.
+func (s *mockClusterServicer) DeleteSSLUserCert(ctx context.Context, id uuid.UUID) error {
+	return nil
+}
+
+// ListNodes mocks the ListNodes method of Servicer.
+func (s *mockClusterServicer) ListNodes(ctx context.Context, id uuid.UUID) ([]cluster.Node, error) {
+	return nil, nil
+}
+
+// mockStore implements the Store interface as a mock for testing purposes.
+type mockStore struct{}
+
+// Put mocks the Put method of Store.
+func (s *mockStore) Put(v store.Entry) error {
+	return nil
+}
+
+// Get mocks the Get method of Store.
+func (s *mockStore) Get(v store.Entry) error {
+	return nil
+}
+
+// Check mocks the Check method of Store.
+func (s *mockStore) Check(v store.Entry) (bool, error) {
+	return false, nil
+}
+
+// Delete mocks the Delete method of Store.
+func (s *mockStore) Delete(v store.Entry) error {
+	return nil
+}
+
+// DeleteAll mocks the DeleteAll method of Store.
+func (s *mockStore) DeleteAll(clusterID uuid.UUID) error {
+	return nil
+}
+
+var (
+	mockProviderFunc = func(ctx context.Context, clusterID uuid.UUID) (*scyllaclient.Client, error) {
+		return nil, nil
+	}
+)

--- a/pkg/service/configcache/tlsconfig.go
+++ b/pkg/service/configcache/tlsconfig.go
@@ -1,0 +1,90 @@
+// Copyright (C) 2024 ScyllaDB
+
+package configcache
+
+import (
+	"crypto/tls"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/secrets"
+	"github.com/scylladb/scylla-manager/v3/pkg/service"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	"github.com/scylladb/scylla-manager/v3/pkg/store"
+)
+
+// TLSConfigWithAddress is a concatenation of tls.Config and Address.
+type TLSConfigWithAddress struct {
+	*tls.Config
+	Address string
+}
+
+func newCQLTLSConfigIfEnabled(c *cluster.Cluster, nodeInfo *scyllaclient.NodeInfo, secretsStore store.Store,
+	host string,
+) (*TLSConfigWithAddress, error) {
+	cqlTLSEnabled, cqlClientCertAuth := nodeInfo.CQLTLSEnabled()
+	if !cqlTLSEnabled || c.ForceTLSDisabled {
+		return nil, nil // nolint: nilnil
+	}
+	cqlAddress := nodeInfo.CQLAddr(host)
+	if !c.ForceNonSSLSessionPort {
+		cqlAddress = nodeInfo.CQLSSLAddr(host)
+	}
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	if cqlClientCertAuth {
+		cert, err := prepareCertificates(c, secretsStore)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create TLS configuration for CQL session")
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+	return &TLSConfigWithAddress{
+		Address: cqlAddress,
+		Config:  tlsConfig,
+	}, nil
+}
+
+func newAlternatorTLSConfigIfEnabled(c *cluster.Cluster, nodeInfo *scyllaclient.NodeInfo, secretsStore store.Store,
+	host string,
+) (*TLSConfigWithAddress, error) {
+	alternatorTLSEnabled, alternatorClientCertAuth := nodeInfo.AlternatorTLSEnabled()
+	if !alternatorTLSEnabled {
+		return nil, nil // nolint: nilnil
+	}
+	alternatorAddress := nodeInfo.AlternatorAddr(host)
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	if alternatorClientCertAuth {
+		cert, err := prepareCertificates(c, secretsStore)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to create TLS configuration for Alternator session")
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+	return &TLSConfigWithAddress{
+		Address: alternatorAddress,
+		Config:  tlsConfig,
+	}, nil
+}
+
+func prepareCertificates(c *cluster.Cluster, secretsStore store.Store) (cert tls.Certificate, err error) {
+	id := &secrets.TLSIdentity{
+		ClusterID: c.ID,
+	}
+	if err := secretsStore.Get(id); err != nil {
+		if !errors.Is(err, service.ErrNotFound) {
+			return tls.Certificate{}, errors.Wrap(err, "fetch TLS config")
+		}
+		return tls.Certificate{}, errors.Wrap(err, "client encryption is enabled, but certificate is missing")
+	}
+
+	keyPair, err := tls.X509KeyPair(id.Cert, id.PrivateKey)
+	if err != nil {
+		return tls.Certificate{}, errors.Wrap(err, "invalid SSL user key pair")
+	}
+	return keyPair, nil
+}

--- a/pkg/service/healthcheck/service.go
+++ b/pkg/service/healthcheck/service.go
@@ -219,7 +219,7 @@ func (s *Service) parallelCQLPingFunc(ctx context.Context, clusterID uuid.UUID, 
 				s.logger.Error(ctx, "Unable to fetch node information", "error", err)
 				o.SSL = false
 			} else {
-				o.SSL = ni.TLSConfig[configcache.CQL] != nil
+				o.SSL = ni.CQLTLSConfig() != nil
 			}
 
 			return nil
@@ -294,7 +294,7 @@ func (s *Service) pingAlternator(ctx context.Context, clusterID uuid.UUID, host 
 		Timeout: timeout,
 	}
 
-	tlsConfig := ni.TLSConfig[configcache.Alternator]
+	tlsConfig := ni.AlternatorTLSConfig()
 	if tlsConfig != nil {
 		config.TLSConfig = tlsConfig.Clone()
 	}
@@ -321,7 +321,7 @@ func (s *Service) pingCQL(ctx context.Context, clusterID uuid.UUID, host string,
 		Timeout: timeout,
 	}
 
-	tlsConfig := ni.TLSConfig[configcache.CQL]
+	tlsConfig := ni.CQLTLSConfig()
 	if tlsConfig != nil {
 		config.Addr = tlsConfig.Address
 		config.TLSConfig = tlsConfig.Clone()

--- a/pkg/service/healthcheck/service_integration_test.go
+++ b/pkg/service/healthcheck/service_integration_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/configcache"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/scylladb/scylla-manager/v3/pkg/schema/table"
@@ -42,6 +43,10 @@ import (
 // It's the answer to https://github.com/scylladb/scylla-manager/issues/3796,
 // which is a part of https://github.com/scylladb/scylla-manager/issues/3767.
 func TestStatus_Ping_Independent_From_REST_Integration(t *testing.T) {
+	if IsIPV6Network() {
+		t.Skip("DB node do not have ip6tables and related modules to make it work properly")
+	}
+
 	// Given
 	tryUnblockCQL(t, ManagedClusterHosts())
 	tryUnblockREST(t, ManagedClusterHosts())
@@ -77,13 +82,17 @@ func TestStatus_Ping_Independent_From_REST_Integration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defaultConfigForHealtcheck := DefaultConfig()
-	defaultConfigForHealtcheck.NodeInfoTTL = 0
+	configCacheSvc := configcache.NewService(clusterSvc, scyllaClientProvider, s, logger.Named("config-cache"))
+	configCacheSvc.Init(context.Background())
+
+	defaultConfigForHealthcheck := DefaultConfig()
+	defaultConfigForHealthcheck.NodeInfoTTL = 0
 	healthSvc, err := NewService(
-		defaultConfigForHealtcheck,
+		defaultConfigForHealthcheck,
 		scyllaClientProvider,
 		s,
 		clusterSvc.GetClusterByID,
+		configCacheSvc,
 		logger,
 	)
 	if err != nil {
@@ -214,12 +223,15 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 		sc.Transport = hrt
 		return scyllaclient.NewClient(sc, logger.Named("scylla"))
 	}
+	configCacheSvc := configcache.NewService(clusterSvc, scyllaClientProvider, secretsStore, logger.Named("config-cache"))
+	configCacheSvc.Init(context.Background())
 
 	s, err := NewService(
 		c,
 		scyllaClientProvider,
 		secretsStore,
 		clusterProvider,
+		configCacheSvc,
 		logger,
 	)
 	if err != nil {

--- a/pkg/service/healthcheck/service_integration_test.go
+++ b/pkg/service/healthcheck/service_integration_test.go
@@ -82,7 +82,7 @@ func TestStatus_Ping_Independent_From_REST_Integration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	configCacheSvc := configcache.NewService(clusterSvc, scyllaClientProvider, s, logger.Named("config-cache"))
+	configCacheSvc := configcache.NewService(configcache.DefaultConfig(), clusterSvc, scyllaClientProvider, s, logger.Named("config-cache"))
 	configCacheSvc.Init(context.Background())
 
 	defaultConfigForHealthcheck := DefaultConfig()
@@ -223,7 +223,8 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 		sc.Transport = hrt
 		return scyllaclient.NewClient(sc, logger.Named("scylla"))
 	}
-	configCacheSvc := configcache.NewService(clusterSvc, scyllaClientProvider, secretsStore, logger.Named("config-cache"))
+	configCacheSvc := configcache.NewService(configcache.DefaultConfig(), clusterSvc, scyllaClientProvider,
+		secretsStore, logger.Named("config-cache"))
 	configCacheSvc.Init(context.Background())
 
 	s, err := NewService(


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-manager/issues/3767

PR is ready for a review.

It consists of the following commits:
- https://github.com/scylladb/scylla-manager/pull/3816/commits/2b77a40688d8e975ed0ab8858bbe6897267c5e6c :This commit addresses the lack of an interface definition for the cluster service, which consists of CRUD operations on the cluster object.
- https://github.com/scylladb/scylla-manager/pull/3816/commits/7947bc3893ec8fb6fe738fb09c2970894fee702f: Contains the implementation of the config cache service.
- https://github.com/scylladb/scylla-manager/pull/3816/commits/303df330a45ad44d5061f81985c33cb101858b69: This commit defines the contract of the epic - to make the CQL ping and Alternator ping independent from the agent's API responsiveness.
- https://github.com/scylladb/scylla-manager/pull/3816/commits/26517717830eee0c6a1a8ed0b06a05b0d73e32bd: Includes the config cache service into the application. It is initialized and started in the background.
- https://github.com/scylladb/scylla-manager/pull/3816/commits/e1cfdf2fca5dbc4a7d0fd504ad137a27591c5807: Changes the Healthcheck service to start consuming data from the config cache service.
- https://github.com/scylladb/scylla-manager/pull/3816/commits/f8b30d7be1a0f483b49d6e34951f1926aa537b5c: This commit removes the old caching approach from the Healthcheck service.
- https://github.com/scylladb/scylla-manager/pull/3816/commits/61ba6397a0c405d127c2feae6a5b5e6b9bc652d7: Another cleaning commit that simplifies the logic used to create the TLS configuration for CQL and Alternator sessions.

Open discussion: Does it make sense to merge the PR by rebasing it to master, or should we rather squash and merge (I'm starting to lean towards the latter)?

**How was it tested ?**

Additional integration test which blocks the agent's HTTP API on one of the nodes and validates if CQL and Alternator pings on this node will succeed.

SCT sanity check executed against this branch:

CQL healtcheck available all the time:
![image](https://github.com/scylladb/scylla-manager/assets/50329145/e2968c92-3dcc-4f9d-b41e-5d9696bd48c5)

**test_client_encryption** shows what happens when the node configuration changes
![image](https://github.com/scylladb/scylla-manager/assets/50329145/378bf4f3-6b64-42ab-ba77-28d0cda02f4b)

CQL is being unavailable for some time, until the configuration is refreshed and then it's reporting correct times again.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
