### PR TITLE
Remove unused methods/references to old cache in healthcheck

### DIFF
--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -187,8 +187,6 @@ func (s *server) onClusterChange(ctx context.Context, c cluster.Change) error {
 		}
 	}
 
-	s.healthSvc.InvalidateCache(c.ID)
-
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-manager/issues/3800

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
