### PR TITLE
Use small_table_optimization in repair

### DIFF
--- a/pkg/scyllaclient/client_agent_test.go
+++ b/pkg/scyllaclient/client_agent_test.go
@@ -254,3 +254,58 @@ func TestNodeInfoSupportsAlternatorQuery(t *testing.T) {
 		}
 	}
 }
+
+func TestNodeInfoSupportsRepairSmallTableOptimization(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		scyllaVer string
+		expected  bool
+	}{
+		{
+			scyllaVer: "2024.1.4",
+			expected:  false,
+		},
+		{
+			scyllaVer: "2024.2.5",
+			expected:  true,
+		},
+		{
+			scyllaVer: "2024.2.6",
+			expected:  true,
+		},
+		{
+			scyllaVer: "5.4.9",
+			expected:  false,
+		},
+		{
+			scyllaVer: "5.5.0",
+			expected:  true,
+		},
+		{
+			scyllaVer: "6.0.0",
+			expected:  true,
+		},
+		{
+			scyllaVer: "6.0.1",
+			expected:  true,
+		},
+		{
+			scyllaVer: "6.1.0",
+			expected:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		ni := scyllaclient.NodeInfo{
+			ScyllaVersion: tc.scyllaVer,
+		}
+		result, err := ni.SupportsRepairSmallTableOptimization()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != tc.expected {
+			t.Fatalf("expected {%v}, but got {%v}, version = {%s}", tc.expected, result, tc.scyllaVer)
+		}
+	}
+}

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -520,13 +520,16 @@ func ReplicaHash(replicaSet []string) uint64 {
 }
 
 // Repair invokes async repair and returns the repair command ID.
-func (c *Client) Repair(ctx context.Context, keyspace, table, master string, replicaSet []string, ranges []TokenRange) (int32, error) {
+func (c *Client) Repair(ctx context.Context, keyspace, table, master string, replicaSet []string, ranges []TokenRange, smallTableOpt bool) (int32, error) {
 	dr := dumpRanges(ranges)
 	p := operations.StorageServiceRepairAsyncByKeyspacePostParams{
 		Context:        forceHost(ctx, master),
 		Keyspace:       keyspace,
 		ColumnFamilies: &table,
 		Ranges:         &dr,
+	}
+	if smallTableOpt {
+		p.SmallTableOptimization = pointer.StringPtr("true")
 	}
 	// Single node cluster repair fails with hosts param
 	if len(replicaSet) > 1 {

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -224,7 +224,7 @@ func (s *Service) Repair(ctx context.Context, clusterID, taskID, runID uuid.UUID
 				"keyspace", kp.Keyspace,
 				"table", tp.Table,
 				"size", tp.Size,
-				"merge_ranges", tp.Optimize,
+				"small", tp.Small,
 			)
 		}
 	}

--- a/swagger/gen/scylla/v1/client/operations/storage_service_repair_async_by_keyspace_post_parameters.go
+++ b/swagger/gen/scylla/v1/client/operations/storage_service_repair_async_by_keyspace_post_parameters.go
@@ -81,6 +81,11 @@ type StorageServiceRepairAsyncByKeyspacePostParams struct {
 
 	*/
 	Hosts *string
+	/*IgnoreNodes
+	  Which hosts are to ignore in this repair. Multiple hosts can be listed separated by commas.
+
+	*/
+	IgnoreNodes *string
 	/*Incremental
 	  If the value is the string 'true' with any capitalization, perform incremental repair.
 
@@ -111,6 +116,16 @@ type StorageServiceRepairAsyncByKeyspacePostParams struct {
 
 	*/
 	Ranges *string
+	/*RangesParallelism
+	  An integer specifying the number of ranges to repair in parallel by user request. If this number is bigger than the max_repair_ranges_in_parallel calculated by Scylla core, the smaller one will be used.
+
+	*/
+	RangesParallelism *string
+	/*SmallTableOptimization
+	  If the value is the string 'true' with any capitalization, perform small table optimization. When this option is enabled, user can send the repair request to any of the nodes in the cluster. There is no need to send repair requests to multiple nodes. All token ranges for the table will be repaired automatically.
+
+	*/
+	SmallTableOptimization *string
 	/*StartToken
 	  Token on which to begin repair
 
@@ -204,6 +219,17 @@ func (o *StorageServiceRepairAsyncByKeyspacePostParams) SetHosts(hosts *string) 
 	o.Hosts = hosts
 }
 
+// WithIgnoreNodes adds the ignoreNodes to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) WithIgnoreNodes(ignoreNodes *string) *StorageServiceRepairAsyncByKeyspacePostParams {
+	o.SetIgnoreNodes(ignoreNodes)
+	return o
+}
+
+// SetIgnoreNodes adds the ignoreNodes to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) SetIgnoreNodes(ignoreNodes *string) {
+	o.IgnoreNodes = ignoreNodes
+}
+
 // WithIncremental adds the incremental to the storage service repair async by keyspace post params
 func (o *StorageServiceRepairAsyncByKeyspacePostParams) WithIncremental(incremental *string) *StorageServiceRepairAsyncByKeyspacePostParams {
 	o.SetIncremental(incremental)
@@ -268,6 +294,28 @@ func (o *StorageServiceRepairAsyncByKeyspacePostParams) WithRanges(ranges *strin
 // SetRanges adds the ranges to the storage service repair async by keyspace post params
 func (o *StorageServiceRepairAsyncByKeyspacePostParams) SetRanges(ranges *string) {
 	o.Ranges = ranges
+}
+
+// WithRangesParallelism adds the rangesParallelism to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) WithRangesParallelism(rangesParallelism *string) *StorageServiceRepairAsyncByKeyspacePostParams {
+	o.SetRangesParallelism(rangesParallelism)
+	return o
+}
+
+// SetRangesParallelism adds the rangesParallelism to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) SetRangesParallelism(rangesParallelism *string) {
+	o.RangesParallelism = rangesParallelism
+}
+
+// WithSmallTableOptimization adds the smallTableOptimization to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) WithSmallTableOptimization(smallTableOptimization *string) *StorageServiceRepairAsyncByKeyspacePostParams {
+	o.SetSmallTableOptimization(smallTableOptimization)
+	return o
+}
+
+// SetSmallTableOptimization adds the smallTableOptimization to the storage service repair async by keyspace post params
+func (o *StorageServiceRepairAsyncByKeyspacePostParams) SetSmallTableOptimization(smallTableOptimization *string) {
+	o.SmallTableOptimization = smallTableOptimization
 }
 
 // WithStartToken adds the startToken to the storage service repair async by keyspace post params
@@ -364,6 +412,22 @@ func (o *StorageServiceRepairAsyncByKeyspacePostParams) WriteToRequest(r runtime
 
 	}
 
+	if o.IgnoreNodes != nil {
+
+		// query param ignore_nodes
+		var qrIgnoreNodes string
+		if o.IgnoreNodes != nil {
+			qrIgnoreNodes = *o.IgnoreNodes
+		}
+		qIgnoreNodes := qrIgnoreNodes
+		if qIgnoreNodes != "" {
+			if err := r.SetQueryParam("ignore_nodes", qIgnoreNodes); err != nil {
+				return err
+			}
+		}
+
+	}
+
 	if o.Incremental != nil {
 
 		// query param incremental
@@ -443,6 +507,38 @@ func (o *StorageServiceRepairAsyncByKeyspacePostParams) WriteToRequest(r runtime
 		qRanges := qrRanges
 		if qRanges != "" {
 			if err := r.SetQueryParam("ranges", qRanges); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.RangesParallelism != nil {
+
+		// query param ranges_parallelism
+		var qrRangesParallelism string
+		if o.RangesParallelism != nil {
+			qrRangesParallelism = *o.RangesParallelism
+		}
+		qRangesParallelism := qrRangesParallelism
+		if qRangesParallelism != "" {
+			if err := r.SetQueryParam("ranges_parallelism", qRangesParallelism); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	if o.SmallTableOptimization != nil {
+
+		// query param small_table_optimization
+		var qrSmallTableOptimization string
+		if o.SmallTableOptimization != nil {
+			qrSmallTableOptimization = *o.SmallTableOptimization
+		}
+		qSmallTableOptimization := qrSmallTableOptimization
+		if qSmallTableOptimization != "" {
+			if err := r.SetQueryParam("small_table_optimization", qSmallTableOptimization); err != nil {
 				return err
 			}
 		}

--- a/swagger/scylla_v1.json
+++ b/swagger/scylla_v1.json
@@ -10390,11 +10390,32 @@
             "description": "Which hosts are to participate in this repair. Multiple hosts can be listed separated by commas."
           },
           {
+            "name": "ignore_nodes",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Which hosts are to ignore in this repair. Multiple hosts can be listed separated by commas."
+          },
+          {
             "name": "trace",
             "in": "query",
             "required": false,
             "type": "string",
             "description": "If the value is the string 'true' with any capitalization, enable tracing of the repair."
+          },
+          {
+            "name": "ranges_parallelism",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "An integer specifying the number of ranges to repair in parallel by user request. If this number is bigger than the max_repair_ranges_in_parallel calculated by Scylla core, the smaller one will be used."
+          },
+          {
+            "name": "small_table_optimization",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "If the value is the string 'true' with any capitalization, perform small table optimization. When this option is enabled, user can send the repair request to any of the nodes in the cluster. There is no need to send repair requests to multiple nodes. All token ranges for the table will be repaired automatically."
           }
         ],
         "responses": {


### PR DESCRIPTION
This PR utilizes the small_table_optimization param in repair API which allows SM to repair the whole table with just one API call. It should bring significant improvements when repairing smaller tables.

As we can't check supported API parameters on Scylla side, we need to rely on checking Scylla version.

Fixes #3642