### PR TITLE
[GitHub nightly] run against Scylla-enterprise-nightly:latest

### DIFF
--- a/.github/workflows/integration-tests-nightly-ipv4-raftschema-rafttopology-tablets.yaml
+++ b/.github/workflows/integration-tests-nightly-ipv4-raftschema-rafttopology-tablets.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  scylla-version: 'scylla-nightly:5.5.0-dev-0.20240321.900b56b117a1'
+  scylla-version: 'scylla-enterprise-nightly:latest-enterprise'
   ip-family: IPV4
   raft-schema: true
   raft-topology: true

--- a/.github/workflows/integration-tests-nightly-ipv4-raftschema-rafttopology.yaml
+++ b/.github/workflows/integration-tests-nightly-ipv4-raftschema-rafttopology.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  scylla-version: 'scylla-nightly:5.5.0-dev-0.20240321.900b56b117a1'
+  scylla-version: 'scylla-enterprise-nightly:latest-enterprise'
   ip-family: IPV4
   raft-schema: true
   raft-topology: true

--- a/.github/workflows/integration-tests-nightly-ipv4-raftschema.yaml
+++ b/.github/workflows/integration-tests-nightly-ipv4-raftschema.yaml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  scylla-version: 'scylla-nightly:5.5.0-dev-0.20240321.900b56b117a1'
+  scylla-version: 'scylla-enterprise-nightly:latest-enterprise'
   ip-family: IPV4
   raft-schema: true
   raft-topology: false


### PR DESCRIPTION
Setting the nightly tests to run against the latest Scylla-enterprise nightly container rather than a specific version from OSS

Fixes: https://github.com/scylladb/scylla-manager/issues/3833


