### PR TITLE
Kk/do not report error on healtcheck nodetool status

### DIFF
--- a/pkg/service/healthcheck/service.go
+++ b/pkg/service/healthcheck/service.go
@@ -57,6 +57,7 @@ func (s *Service) Runner() Runner {
 	return Runner{
 		cql: runner{
 			logger:       s.logger.Named("CQL healthcheck"),
+			configCacher: s.configCache,
 			scyllaClient: s.scyllaClient,
 			timeout:      s.config.MaxTimeout,
 			metrics: &runnerMetrics{
@@ -68,6 +69,7 @@ func (s *Service) Runner() Runner {
 		},
 		rest: runner{
 			logger:       s.logger.Named("REST healthcheck"),
+			configCacher: s.configCache,
 			scyllaClient: s.scyllaClient,
 			timeout:      s.config.MaxTimeout,
 			metrics: &runnerMetrics{
@@ -79,6 +81,7 @@ func (s *Service) Runner() Runner {
 		},
 		alternator: runner{
 			logger:       s.logger.Named("Alternator healthcheck"),
+			configCacher: s.configCache,
 			scyllaClient: s.scyllaClient,
 			timeout:      s.config.MaxTimeout,
 			metrics: &runnerMetrics{


### PR DESCRIPTION
Fixes #3847 

Config cache interface is updated with the possibility of listing available hosts of the cluster.
Healthcheck runner is changed to not create http client and to ask about live nodes, but it get's this information from config-cache directly.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
