### PR TITLE
Release 3.2.8 follow up

### DIFF
--- a/pkg/service/cluster/service.go
+++ b/pkg/service/cluster/service.go
@@ -150,7 +150,11 @@ func (s *Service) CreateClientNoCache(ctx context.Context, clusterID uuid.UUID) 
 		config.Port = fmt.Sprint(c.Port)
 	}
 	config.AuthToken = c.AuthToken
-	config.Hosts = append([]string{c.Host}, c.KnownHosts...)
+	config.Hosts = nil
+	if c.Host != "" {
+		config.Hosts = []string{c.Host}
+	}
+	config.Hosts = append(config.Hosts, c.KnownHosts...)
 
 	client, err := scyllaclient.NewClient(config, s.logger.Named("client"))
 	if err != nil {

--- a/pkg/service/healthcheck/metrics_test.go
+++ b/pkg/service/healthcheck/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/scylladb/go-log"
 
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 )
@@ -27,10 +28,13 @@ func TestRemoveClusterMetricsWhenNumberOfMetricsExceedsDefaultChannelLength_2843
 		}
 		metric.With(hl).Set(1)
 	}
-	r := runner{metrics: &runnerMetrics{
-		status: metric,
-		rtt:    metric,
-	}}
+	r := runner{
+		logger: log.NewDevelopment(),
+		metrics: &runnerMetrics{
+			status: metric,
+			rtt:    metric,
+		},
+	}
 
 	r.removeMetricsForCluster(clusterID)
 }

--- a/pkg/service/healthcheck/service.go
+++ b/pkg/service/healthcheck/service.go
@@ -57,6 +57,7 @@ func (s *Service) Runner() Runner {
 	return Runner{
 		cql: runner{
 			logger:       s.logger.Named("CQL healthcheck"),
+			configCacher: s.configCache,
 			scyllaClient: s.scyllaClient,
 			timeout:      s.config.MaxTimeout,
 			metrics: &runnerMetrics{
@@ -68,6 +69,7 @@ func (s *Service) Runner() Runner {
 		},
 		rest: runner{
 			logger:       s.logger.Named("REST healthcheck"),
+			configCacher: s.configCache,
 			scyllaClient: s.scyllaClient,
 			timeout:      s.config.MaxTimeout,
 			metrics: &runnerMetrics{
@@ -79,6 +81,7 @@ func (s *Service) Runner() Runner {
 		},
 		alternator: runner{
 			logger:       s.logger.Named("Alternator healthcheck"),
+			configCacher: s.configCache,
 			scyllaClient: s.scyllaClient,
 			timeout:      s.config.MaxTimeout,
 			metrics: &runnerMetrics{

--- a/pkg/service/healthcheck/service.go
+++ b/pkg/service/healthcheck/service.go
@@ -56,6 +56,7 @@ func NewService(config Config, scyllaClient scyllaclient.ProviderFunc, secretsSt
 func (s *Service) Runner() Runner {
 	return Runner{
 		cql: runner{
+			logger:       s.logger.Named("CQL healthcheck"),
 			scyllaClient: s.scyllaClient,
 			timeout:      s.config.MaxTimeout,
 			metrics: &runnerMetrics{
@@ -66,6 +67,7 @@ func (s *Service) Runner() Runner {
 			pingAgent: s.pingAgent,
 		},
 		rest: runner{
+			logger:       s.logger.Named("REST healthcheck"),
 			scyllaClient: s.scyllaClient,
 			timeout:      s.config.MaxTimeout,
 			metrics: &runnerMetrics{
@@ -76,6 +78,7 @@ func (s *Service) Runner() Runner {
 			pingAgent: s.pingAgent,
 		},
 		alternator: runner{
+			logger:       s.logger.Named("Alternator healthcheck"),
 			scyllaClient: s.scyllaClient,
 			timeout:      s.config.MaxTimeout,
 			metrics: &runnerMetrics{


### PR DESCRIPTION
Don't silence healthcheck ping errors https://github.com/scylladb/scylla-manager/issues/3845

On client creation, skip empty initial host https://github.com/scylladb/scylla-manager/issues/3849

Healthcheck to stop calling agent's for list of live nodes https://github.com/scylladb/scylla-manager/issues/3847

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
