### PR TITLE
Repair: use ranges parallelism

### DIFF
--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -553,7 +553,7 @@ func dumpRanges(ranges []TokenRange) string {
 			_ = buf.WriteByte(',')
 		}
 		if ttr.StartToken > ttr.EndToken {
-			_, _ = fmt.Fprintf(&buf, "%d:%d,%d:%d", dht.Murmur3MinToken, ttr.EndToken, ttr.StartToken, dht.Murmur3MaxToken)
+			_, _ = fmt.Fprintf(&buf, "%d:%d,%d:%d", ttr.StartToken, dht.Murmur3MaxToken, dht.Murmur3MinToken, ttr.EndToken)
 		} else {
 			_, _ = fmt.Fprintf(&buf, "%d:%d", ttr.StartToken, ttr.EndToken)
 		}

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -520,7 +520,7 @@ func ReplicaHash(replicaSet []string) uint64 {
 }
 
 // Repair invokes async repair and returns the repair command ID.
-func (c *Client) Repair(ctx context.Context, keyspace, table, master string, replicaSet []string, ranges []TokenRange, smallTableOpt bool) (int32, error) {
+func (c *Client) Repair(ctx context.Context, keyspace, table, master string, replicaSet []string, ranges []TokenRange, intensity int, smallTableOpt bool) (int32, error) {
 	dr := dumpRanges(ranges)
 	p := operations.StorageServiceRepairAsyncByKeyspacePostParams{
 		Context:        forceHost(ctx, master),
@@ -530,6 +530,8 @@ func (c *Client) Repair(ctx context.Context, keyspace, table, master string, rep
 	}
 	if smallTableOpt {
 		p.SmallTableOptimization = pointer.StringPtr("true")
+	} else {
+		p.RangesParallelism = pointer.StringPtr(fmt.Sprint(intensity))
 	}
 	// Single node cluster repair fails with hosts param
 	if len(replicaSet) > 1 {

--- a/pkg/service/repair/controller_test.go
+++ b/pkg/service/repair/controller_test.go
@@ -46,16 +46,16 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		replicaSet := []string{node1, node2}
 		c := newRowLevelRepairController(defaultIntensityHandler())
 
-		if rangesCount := c.TryBlock(replicaSet); rangesCount == 0 {
-			t.Fatal("expected to return ranges to repair, but got 0")
+		if ok, _ := c.TryBlock(replicaSet); !ok {
+			t.Fatal("expected to return ranges to repair, but got false")
 		}
-		if rangesCount := c.TryBlock(replicaSet); rangesCount != 0 {
-			t.Fatalf("expected to return 0 to repair, but got {%d}", rangesCount)
+		if ok, rangesCount := c.TryBlock(replicaSet); ok {
+			t.Fatalf("expected to return false, but got {%d}", rangesCount)
 		}
 
 		c.Unblock(replicaSet)
-		if rangesCount := c.TryBlock(replicaSet); rangesCount == 0 {
-			t.Fatal("expected to return ranges to repair, but got 0")
+		if ok, _ := c.TryBlock(replicaSet); !ok {
+			t.Fatal("expected to return ranges to repair, but got false")
 		}
 	})
 
@@ -70,7 +70,7 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		c := newRowLevelRepairController(ih)
 
 		ih.SetIntensity(context.Background(), expectedNrOfRanges)
-		if rangesCount := c.TryBlock(replicaSet); rangesCount != expectedNrOfRanges {
+		if ok, rangesCount := c.TryBlock(replicaSet); !ok || rangesCount != expectedNrOfRanges {
 			t.Fatalf("expected to return {%d} ranges to repair, but got {%d}", expectedNrOfRanges, rangesCount)
 		}
 	})
@@ -86,7 +86,7 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		c := newRowLevelRepairController(ih)
 
 		ih.SetIntensity(context.Background(), expectedNrOfRanges)
-		if rangesCount := c.TryBlock(replicaSet); rangesCount != expectedNrOfRanges {
+		if ok, rangesCount := c.TryBlock(replicaSet); !ok || rangesCount != expectedNrOfRanges {
 			t.Fatalf("expected to return {%d} ranges to repair, but got {%d}", expectedNrOfRanges, rangesCount)
 		}
 	})
@@ -103,7 +103,7 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		c := newRowLevelRepairController(ih)
 
 		ih.SetIntensity(context.Background(), intensity)
-		if rangesCount := c.TryBlock(replicaSet); rangesCount != minRangesInParallel {
+		if ok, rangesCount := c.TryBlock(replicaSet); !ok || rangesCount != minRangesInParallel {
 			t.Fatalf("expected to return {%d} ranges to repair, but got {%d}", minRangesInParallel, rangesCount)
 		}
 	})
@@ -117,10 +117,10 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		c := newRowLevelRepairController(ih)
 
 		ih.SetParallel(context.Background(), 1)
-		if rangesCount := c.TryBlock(replicaSet1); rangesCount == 0 {
+		if ok, _ := c.TryBlock(replicaSet1); !ok {
 			t.Fatal("expected to let in, but was denied")
 		}
-		if rangesCount := c.TryBlock(replicaSet2); rangesCount != 0 {
+		if ok, _ := c.TryBlock(replicaSet2); ok {
 			t.Fatal("expected to deny, but was let in")
 		}
 	})
@@ -134,13 +134,13 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		ih.maxParallel = maxParallel
 		c := newRowLevelRepairController(ih)
 
-		if rangesCount := c.TryBlock(replicaSet1); rangesCount == 0 {
+		if ok, _ := c.TryBlock(replicaSet1); !ok {
 			t.Fatal("expected to let in, but was denied")
 		}
-		if rangesCount := c.TryBlock(replicaSet2); rangesCount == 0 {
+		if ok, _ := c.TryBlock(replicaSet2); !ok {
 			t.Fatal("expected to let in, but was denied")
 		}
-		if rangesCount := c.TryBlock(replicaSet3); rangesCount != 0 {
+		if ok, _ := c.TryBlock(replicaSet3); ok {
 			t.Fatal("expected to deny, but was let in")
 		}
 	})

--- a/pkg/service/repair/controller_test.go
+++ b/pkg/service/repair/controller_test.go
@@ -29,8 +29,8 @@ func TestRowLevelRepairController_TryBlock(t *testing.T) {
 		node5: 16,
 		node6: 15,
 	}
-	defaultIntensityHandler := func() *intensityHandler {
-		return &intensityHandler{
+	defaultIntensityHandler := func() *intensityParallelHandler {
+		return &intensityParallelHandler{
 			logger:           log.Logger{},
 			maxHostIntensity: maxRangesPerHost,
 			intensity:        atomic.NewInt64(int64(defaultIntensity)),

--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -253,8 +253,8 @@ func (tg *tableGenerator) newJob() (job, bool) {
 			continue
 		}
 
-		if cnt := tg.ctl.TryBlock(filtered); cnt > 0 {
-			ranges := tg.getRangesToRepair(rt.Ranges, cnt)
+		if ok, intensity := tg.ctl.TryBlock(filtered); ok {
+			ranges := tg.getRangesToRepair(rt.Ranges, intensity)
 			if len(ranges) == 0 {
 				tg.DoneReplicas[repHash] = struct{}{}
 				tg.ctl.Unblock(filtered)
@@ -281,9 +281,9 @@ func (tg *tableGenerator) newJob() (job, bool) {
 	return job{}, false
 }
 
-func (tg *tableGenerator) getRangesToRepair(allRanges []scyllaclient.TokenRange, cnt Intensity) []scyllaclient.TokenRange {
+func (tg *tableGenerator) getRangesToRepair(allRanges []scyllaclient.TokenRange, intensity int) []scyllaclient.TokenRange {
 	if tg.JobType != normalJobType {
-		cnt = NewIntensity(len(allRanges))
+		intensity = len(allRanges)
 	}
 
 	var ranges []scyllaclient.TokenRange
@@ -293,7 +293,7 @@ func (tg *tableGenerator) getRangesToRepair(allRanges []scyllaclient.TokenRange,
 		}
 		delete(tg.TodoRanges, r)
 		ranges = append(ranges, r)
-		if NewIntensity(len(ranges)) >= cnt {
+		if len(ranges) >= intensity {
 			break
 		}
 	}

--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -69,6 +69,7 @@ type job struct {
 	master     string
 	replicaSet []string
 	ranges     []scyllaclient.TokenRange
+	intensity  int
 	jobType    jobType
 }
 
@@ -273,6 +274,7 @@ func (tg *tableGenerator) newJob() (job, bool) {
 				master:     tg.ms.Select(filtered),
 				replicaSet: filtered,
 				ranges:     ranges,
+				intensity:  intensity,
 				jobType:    jt,
 			}, true
 		}
@@ -282,6 +284,15 @@ func (tg *tableGenerator) newJob() (job, bool) {
 }
 
 func (tg *tableGenerator) getRangesToRepair(allRanges []scyllaclient.TokenRange, intensity int) []scyllaclient.TokenRange {
+	// Sending batched ranges in a single job results in better shard utilization.
+	// With intensity=10, normally SM would just send a job consisting of 10 ranges.
+	// It might happen that repairing 1 range takes more time than repairing the remaining 9.
+	// Then SM would be waiting for a repair job which repairs only 1 range,
+	// when given replica set could be repairing 9 additional ranges at the same time.
+	// Because of that, we send all ranges (limited to 1000 for safety) owned by given replica set per repair job.
+	// Controlling intensity happens by ranges_parallelism repair param.
+	const limit = 1000
+	intensity = min(len(allRanges), limit)
 	if tg.JobType != normalJobType {
 		intensity = len(allRanges)
 	}

--- a/pkg/service/repair/intensity_handler.go
+++ b/pkg/service/repair/intensity_handler.go
@@ -1,0 +1,81 @@
+// Copyright (C) 2024 ScyllaDB
+
+package repair
+
+import (
+	"context"
+	"math"
+
+	"github.com/scylladb/go-log"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+	"go.uber.org/atomic"
+)
+
+type sizeSetter interface {
+	SetSize(size int)
+}
+
+type intensityHandler struct {
+	taskID           uuid.UUID
+	runID            uuid.UUID
+	logger           log.Logger
+	maxHostIntensity map[string]Intensity
+	intensity        *atomic.Int64
+	maxParallel      int
+	parallel         *atomic.Int64
+	poolController   sizeSetter
+}
+
+const (
+	maxIntensity     Intensity = 0
+	defaultIntensity Intensity = 1
+	defaultParallel            = 0
+	chanSize                   = 10000
+)
+
+// SetIntensity sets the value of '--intensity' flag.
+func (i *intensityHandler) SetIntensity(ctx context.Context, intensity Intensity) {
+	i.logger.Info(ctx, "Setting repair intensity", "value", intensity, "previous", i.intensity.Load())
+	i.intensity.Store(int64(intensity))
+}
+
+// SetParallel sets the value of '--parallel' flag.
+func (i *intensityHandler) SetParallel(ctx context.Context, parallel int) {
+	i.logger.Info(ctx, "Setting repair parallel", "value", parallel, "previous", i.parallel.Load())
+	i.parallel.Store(int64(parallel))
+	if parallel == defaultParallel {
+		i.poolController.SetSize(i.maxParallel)
+	} else {
+		i.poolController.SetSize(parallel)
+	}
+}
+
+func (i *intensityHandler) ReplicaSetMaxIntensity(replicaSet []string) Intensity {
+	out := NewIntensity(math.MaxInt)
+	for _, rep := range replicaSet {
+		if ranges := i.maxHostIntensity[rep]; ranges < out {
+			out = ranges
+		}
+	}
+	return out
+}
+
+// MaxHostIntensity returns max_token_ranges_in_parallel per host.
+func (i *intensityHandler) MaxHostIntensity() map[string]Intensity {
+	return i.maxHostIntensity
+}
+
+// Intensity returns stored value for intensity.
+func (i *intensityHandler) Intensity() Intensity {
+	return NewIntensity(int(i.intensity.Load()))
+}
+
+// MaxParallel returns maximal achievable parallelism.
+func (i *intensityHandler) MaxParallel() int {
+	return i.maxParallel
+}
+
+// Parallel returns stored value for parallel.
+func (i *intensityHandler) Parallel() int {
+	return int(i.parallel.Load())
+}

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"strings"
 	"sync"
 	"time"
@@ -452,73 +451,4 @@ func (s *Service) SetParallel(ctx context.Context, clusterID uuid.UUID, parallel
 		"parallel":   ih.Parallel(),
 	}).ExecRelease()
 	return errors.Wrap(err, "update db")
-}
-
-type sizeSetter interface {
-	SetSize(size int)
-}
-
-type intensityHandler struct {
-	taskID           uuid.UUID
-	runID            uuid.UUID
-	logger           log.Logger
-	maxHostIntensity map[string]Intensity
-	intensity        *atomic.Int64
-	maxParallel      int
-	parallel         *atomic.Int64
-	poolController   sizeSetter
-}
-
-const (
-	maxIntensity     Intensity = 0
-	defaultIntensity Intensity = 1
-	defaultParallel            = 0
-	chanSize                   = 10000
-)
-
-// SetIntensity sets the value of '--intensity' flag.
-func (i *intensityHandler) SetIntensity(ctx context.Context, intensity Intensity) {
-	i.logger.Info(ctx, "Setting repair intensity", "value", intensity, "previous", i.intensity.Load())
-	i.intensity.Store(int64(intensity))
-}
-
-// SetParallel sets the value of '--parallel' flag.
-func (i *intensityHandler) SetParallel(ctx context.Context, parallel int) {
-	i.logger.Info(ctx, "Setting repair parallel", "value", parallel, "previous", i.parallel.Load())
-	i.parallel.Store(int64(parallel))
-	if parallel == defaultParallel {
-		i.poolController.SetSize(i.maxParallel)
-	} else {
-		i.poolController.SetSize(parallel)
-	}
-}
-
-func (i *intensityHandler) ReplicaSetMaxIntensity(replicaSet []string) Intensity {
-	out := NewIntensity(math.MaxInt)
-	for _, rep := range replicaSet {
-		if ranges := i.maxHostIntensity[rep]; ranges < out {
-			out = ranges
-		}
-	}
-	return out
-}
-
-// MaxHostIntensity returns max_token_ranges_in_parallel per host.
-func (i *intensityHandler) MaxHostIntensity() map[string]Intensity {
-	return i.maxHostIntensity
-}
-
-// Intensity returns stored value for intensity.
-func (i *intensityHandler) Intensity() Intensity {
-	return NewIntensity(int(i.intensity.Load()))
-}
-
-// MaxParallel returns maximal achievable parallelism.
-func (i *intensityHandler) MaxParallel() int {
-	return i.maxParallel
-}
-
-// Parallel returns stored value for parallel.
-func (i *intensityHandler) Parallel() int {
-	return int(i.parallel.Load())
 }

--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -73,7 +73,7 @@ func (w *worker) runRepair(ctx context.Context, j job) (out error) {
 		ranges = j.ranges
 	}
 
-	jobID, err = w.client.Repair(ctx, j.keyspace, j.table, j.master, j.replicaSet, ranges, j.jobType == optimizeJobType)
+	jobID, err = w.client.Repair(ctx, j.keyspace, j.table, j.master, j.replicaSet, ranges, j.intensity, j.jobType == optimizeJobType)
 	if err != nil {
 		return errors.Wrap(err, "schedule repair")
 	}
@@ -83,7 +83,8 @@ func (w *worker) runRepair(ctx context.Context, j job) (out error) {
 		"table", j.table,
 		"master", j.master,
 		"hosts", j.replicaSet,
-		"ranges", ranges,
+		"ranges", len(ranges),
+		"intensity", j.intensity,
 		"job_id", jobID,
 	)
 


### PR DESCRIPTION
This PR introduces token ranges batching in repair jobs.
Previously, with `intensity=X`, SM would simply send X token ranges per job. As described in #3789, this approach could lead to cluster being underutilized. Batching also solves #3792, as it increases the odds of repair job consisting of similar amount of token ranges owned by any shard. 

Fixes #3789
Fixes #3792
