### PR TITLE
testing: enable sstable uuid identifiers in Scylla config

### DIFF
--- a/testing/scylla/config/scylla.yaml
+++ b/testing/scylla/config/scylla.yaml
@@ -32,6 +32,8 @@ num_tokens: 256
 data_file_directories:
   - /var/lib/scylla/data
 
+uuid_sstable_identifiers_enabled: true
+
 # commit log.  when running on magnetic HDD, this should be a
 # separate spindle than the data directories.
 commitlog_directory: /var/lib/scylla/commitlog


### PR DESCRIPTION
This PR enables UUID in SSTables names feature in Scylla Cluster against which all tests are being executed.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
