### PR TITLE
Cheksum comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ integration-test:
 	@$(MAKE) pkg-integration-test PKG=./pkg/ping/dynamoping
 	@$(MAKE) pkg-integration-test PKG=./pkg/scyllaclient
 	@$(MAKE) pkg-integration-test PKG=./pkg/service/backup
+	@$(MAKE) pkg-integration-test PKG=./pkg/service/restore
 	@$(MAKE) pkg-integration-test PKG=./pkg/service/cluster
 	@$(MAKE) pkg-integration-test PKG=./pkg/service/healthcheck
 	@$(MAKE) pkg-integration-test PKG=./pkg/service/repair

--- a/pkg/managerclient/backup.go
+++ b/pkg/managerclient/backup.go
@@ -10,6 +10,7 @@ const (
 	BackupStageIndex        string = "INDEX"
 	BackupStageManifest     string = "MANIFEST"
 	BackupStageSchema       string = "SCHEMA"
+	BackupStageDeduplicate  string = "DEDUPLICATE"
 	BackupStageUpload       string = "UPLOAD"
 	BackupStageMoveManifest string = "MOVE_MANIFEST"
 	BackupStageMigrate      string = "MIGRATE"
@@ -24,6 +25,7 @@ var backupStageName = map[string]string{
 	BackupStageIndex:        "indexing files",
 	BackupStageManifest:     "uploading manifests",
 	BackupStageSchema:       "uploading schema",
+	BackupStageDeduplicate:  "deduplicating the snapshot",
 	BackupStageUpload:       "uploading data",
 	BackupStageMoveManifest: "moving manifests",
 	BackupStageMigrate:      "migrating legacy metadata",

--- a/pkg/rclone/rcserver/rc.go
+++ b/pkg/rclone/rcserver/rc.go
@@ -331,7 +331,7 @@ func init() {
 	rc.Add(rc.Call{
 		Path:         "operations/cat",
 		AuthRequired: true,
-		Fn:           wrap(rcCat, pathHasPrefix("backup/meta/", "backup/schema/")),
+		Fn:           wrap(rcCat, or(pathHasPrefix("backup/meta/", "backup/schema/"), pathHasSuffix(".crc32"))),
 		Title:        "Concatenate any files and send them in response",
 		Help: `This takes the following parameters
 

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -847,6 +847,9 @@ func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID
 		StageSchema: func() error {
 			return w.UploadSchema(ctx, hi)
 		},
+		StageDeduplicate: func() error {
+			return w.Deduplicate(ctx, hi, target.UploadParallel)
+		},
 		StageUpload: func() error {
 			return w.Upload(ctx, hi, target.UploadParallel)
 		},

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -882,7 +882,7 @@ func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID
 		// Skip completed stages
 		if run.PrevID != uuid.Nil {
 			// Allow reindexing if previous state is manifest creation or upload
-			if stage == StageIndex && (prevStage == StageManifest || prevStage == StageUpload) { //nolint: revive
+			if stage == StageIndex && (prevStage == StageManifest || prevStage == StageUpload || prevStage == StageDeduplicate) { //nolint: revive
 				// continue
 			} else if prevStage.Index() > stage.Index() {
 				return nil

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -45,6 +45,8 @@ type Service struct {
 	scyllaClient   scyllaclient.ProviderFunc
 	clusterSession cluster.SessionFunc
 	logger         log.Logger
+
+	dth deduplicateTestHooks
 }
 
 func NewService(session gocqlx.Session, config Config, metrics metrics.BackupMetrics,
@@ -806,6 +808,7 @@ func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID
 				return &bytes.Buffer{}
 			},
 		},
+		dth: s.dth,
 	}
 
 	// Map stages to worker functions

--- a/pkg/service/backup/service_deduplicate_integration_test.go
+++ b/pkg/service/backup/service_deduplicate_integration_test.go
@@ -1,0 +1,163 @@
+// Copyright (C) 2024 ScyllaDB
+
+//go:build all || integration
+// +build all integration
+
+package backup_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+)
+
+func TestBackupPauseResumeOnDeduplicationStage(t *testing.T) {
+	const (
+		testBucket   = "backuptest-deduplication"
+		testKeyspace = "backuptest_deduplication"
+	)
+
+	location := s3Location(testBucket)
+	config := defaultConfig()
+
+	var (
+		session        = db.CreateScyllaManagerDBSession(t)
+		h              = newBackupTestHelper(t, session, config, location, nil)
+		clusterSession = db.CreateSessionAndDropAllKeyspaces(t, h.Client)
+		ctx, cancel    = context.WithCancel(context.Background())
+	)
+
+	db.WriteData(t, clusterSession, testKeyspace, 3)
+
+	target := backup.Target{
+		Units: []backup.Unit{
+			{
+				Keyspace: testKeyspace,
+			},
+		},
+		DC:        []string{"dc1"},
+		Location:  []backupspec.Location{location},
+		Retention: 2,
+		RateLimit: []backup.DCLimit{
+			{"dc1", 1},
+		},
+		Continue: true,
+	}
+	if err := h.service.InitTarget(ctx, h.ClusterID, &target); err != nil {
+		t.Fatal(err)
+	}
+
+	Print("Given: backup is created out of the current cluster state")
+	var originalTotalSize int64
+	func() {
+		var deduplicatedOnFreshBackup int64
+		after := func(skipped, uploaded, size int64) {
+			deduplicatedOnFreshBackup += skipped
+		}
+		defer h.service.RemoveDeduplicateTestHooks()
+		h.service.SetDeduplicateTestHooks(func() {}, after)
+
+		if err := h.service.Backup(ctx, h.ClusterID, h.TaskID, h.RunID, target); err != nil {
+			t.Fatal(err)
+		}
+		Print("Then: nothing is deduplicated")
+		if deduplicatedOnFreshBackup != 0 {
+			t.Fatalf("Expected deduplicated 0 bytes on fresh backup, but was %v", deduplicatedOnFreshBackup)
+		}
+	}()
+
+	Print("Then: another backup to deduplicate everything (no delta)")
+	time.Sleep(time.Second)
+	func() {
+		var totalDeduplicated, totalUploaded, totalSize int64
+		after := func(skipped, uploaded, size int64) {
+			totalDeduplicated += skipped
+			totalUploaded += uploaded
+			totalSize += size
+		}
+		defer h.service.RemoveDeduplicateTestHooks()
+		h.service.SetDeduplicateTestHooks(func() {}, after)
+
+		if err := h.service.Backup(ctx, h.ClusterID, h.TaskID, h.RunID, target); err != nil {
+			t.Fatal(err)
+		}
+
+		Print("Then: everything is deduplicated")
+		if totalDeduplicated != totalSize {
+			t.Fatalf("Expected deduplicated %v bytes on delta 0 backup, but was %v", totalSize, totalDeduplicated)
+		}
+		Print("Then: nothing is uploaded")
+		if totalUploaded != 0 {
+			t.Fatalf("Expected uploaded 0 bytes on delta 0 backup, but was %v", totalUploaded)
+		}
+		Printf("Then: total size is equal to first backup")
+		if totalSize != originalTotalSize {
+			t.Fatalf("Expected total size to be %v, but was %v", originalTotalSize, totalSize)
+		}
+	}()
+
+	Print("Given: yet  another backup is started on empty delta (no data changes) and paused od DEDUPLICATE stage")
+	time.Sleep(time.Second)
+	func() {
+		onlyOneHostToProcessMutex := sync.Mutex{}
+		var totalDeduplicated, totalUploaded, totalSize int64
+		before := func() {
+			onlyOneHostToProcessMutex.Lock()
+		}
+		after := func(skipped, uploaded, size int64) {
+			totalDeduplicated += skipped
+			totalUploaded += uploaded
+			totalSize += size
+			cancel()
+			onlyOneHostToProcessMutex.Unlock()
+		}
+		defer h.service.RemoveDeduplicateTestHooks()
+		h.service.SetDeduplicateTestHooks(before, after)
+
+		if err := h.service.Backup(ctx, h.ClusterID, h.TaskID, h.RunID, target); err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatal(err)
+		}
+
+		Print("Then: not everything is either deduplicated and 0 is uploaded")
+		if totalDeduplicated == totalSize || totalUploaded > 0 {
+			t.Fatalf("Expected backup to be paused in the middle")
+		}
+	}()
+
+	Print("When: backup is resumed with the new RunID")
+	func() {
+		var totalDeduplicated, totalUploaded, totalSize int64
+		after := func(skipped, uploaded, size int64) {
+			totalDeduplicated += skipped
+			totalUploaded += uploaded
+			totalSize += size
+		}
+		defer h.service.RemoveDeduplicateTestHooks()
+		h.service.SetDeduplicateTestHooks(func() {}, after)
+
+		if err := h.service.Backup(context.Background(), h.ClusterID, h.TaskID, uuid.NewTime(), target); err != nil {
+			t.Fatal(err)
+		}
+		Printf("Then: total size is equal to first backup")
+		if totalSize != originalTotalSize {
+			t.Fatalf("Expected total size to be %v, but was %v", originalTotalSize, totalSize)
+		}
+		Print("Then: everything is deduplicated")
+		if totalDeduplicated != totalSize {
+			t.Fatalf("Expected deduplicated %v bytes on delta 0 backup, but was %v", totalSize, totalDeduplicated)
+		}
+		Print("Then: nothing is uploaded")
+		if totalUploaded != 0 {
+			t.Fatalf("Expected uploaded 0 bytes on delta 0 backup, but was %v", totalUploaded)
+		}
+	}()
+
+}

--- a/pkg/service/backup/service_testutils.go
+++ b/pkg/service/backup/service_testutils.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2024 ScyllaDB
+
+//go:build all || integration
+// +build all integration
+
+package backup
+
+type dthHelper struct {
+	before func()
+	after  func(skipped, uploaded, size int64)
+}
+
+func (d dthHelper) beforeDeduplicateHost() {
+	d.before()
+}
+
+func (d dthHelper) afterDeduplicateHost(skipped, uploaded, size int64) {
+	d.after(skipped, uploaded, size)
+}
+
+func (s *Service) SetDeduplicateTestHooks(before func(), after func(skipped, uploaded, size int64)) {
+	s.dth = dthHelper{
+		before: before,
+		after:  after,
+	}
+}
+
+func (s *Service) RemoveDeduplicateTestHooks() {
+	s.dth = nil
+}

--- a/pkg/service/backup/stage.go
+++ b/pkg/service/backup/stage.go
@@ -15,6 +15,7 @@ const (
 	StageIndex        Stage = "INDEX"
 	StageManifest     Stage = "MANIFEST"
 	StageSchema       Stage = "SCHEMA"
+	StageDeduplicate  Stage = "DEDUPLICATE"
 	StageUpload       Stage = "UPLOAD"
 	StageMoveManifest Stage = "MOVE_MANIFEST"
 	StageMigrate      Stage = "MIGRATE"
@@ -43,6 +44,7 @@ func StageOrder() []Stage {
 		StageIndex,
 		StageManifest,
 		StageSchema,
+		StageDeduplicate,
 		StageUpload,
 		StageMoveManifest,
 		StageMigrate,

--- a/pkg/service/backup/stage.go
+++ b/pkg/service/backup/stage.go
@@ -56,7 +56,7 @@ func StageOrder() []Stage {
 // Resumable run can be continued.
 func (s Stage) Resumable() bool {
 	switch s {
-	case StageIndex, StageManifest, StageUpload, StageMoveManifest, StageMigrate, StagePurge:
+	case StageIndex, StageManifest, StageUpload, StageDeduplicate, StageMoveManifest, StageMigrate, StagePurge:
 		return true
 	default:
 		return false

--- a/pkg/service/backup/worker.go
+++ b/pkg/service/backup/worker.go
@@ -81,6 +81,8 @@ type worker struct {
 	mu           sync.Mutex
 
 	memoryPool *sync.Pool
+
+	dth deduplicateTestHooks
 }
 
 func (w *worker) WithLogger(logger log.Logger) *worker {

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -1,0 +1,170 @@
+// Copyright (C) 2024 ScyllaDB
+
+package backup
+
+import (
+	"bytes"
+	"context"
+	"path"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/sstable"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
+)
+
+// Deduplicate handles the deduplicate stage of the backup process.
+// The implementation is expected to follow RFC document
+// https://docs.google.com/document/d/1EtGlF6UGNy34D_7QsnCheaukp3UwVObZU56PBdd0CQ8/edit#heading=h.jl2qbpcarwp9
+func (w *worker) Deduplicate(ctx context.Context, hosts []hostInfo, limits []DCLimit) (err error) {
+	f := func(h hostInfo) error {
+		w.Logger.Info(ctx, "Removing duplicated files from local snapshot", "host", h.IP)
+		err := w.deduplicateHost(ctx, h)
+		if err == nil {
+			w.Logger.Info(ctx, "Done deduplication", "host", h.IP)
+		}
+		return err
+	}
+
+	notify := func(h hostInfo, err error) {
+		w.Logger.Error(ctx, "Removing duplicated files failed on host", "host", h.IP, "error", err)
+	}
+
+	return inParallelWithLimits(hosts, limits, f, notify)
+}
+
+func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
+	if err := w.setRateLimit(ctx, h); err != nil {
+		return errors.Wrap(err, "set rate limit")
+	}
+
+	dirs := w.hostSnapshotDirs(h)
+	f := func(i int) (err error) {
+		d := dirs[i]
+		dataDst := h.Location.RemotePath(w.remoteSSTableDir(h, d))
+
+		remoteFilesSSTableIDSet := make(map[string]struct{})
+		listOpts := &scyllaclient.RcloneListDirOpts{
+			FilesOnly: true,
+			Recurse:   true,
+		}
+		if err := w.Client.RcloneListDirIter(ctx, h.IP, dataDst, listOpts, func(f *scyllaclient.RcloneListDirItem) {
+			id := sstable.ExtractID(f.Name)
+			remoteFilesSSTableIDSet[id] = struct{}{}
+		}); err != nil {
+			return errors.Wrapf(err, "host %s: listing all files from %s", h.IP, dataDst)
+		}
+
+		// Iterate over all SSTable IDs and group files per ID.
+		ssTablesGroupByID := make(map[string][]string)
+		for _, file := range d.Progress.files {
+			id := sstable.ExtractID(file.Name)
+			ssTablesGroupByID[id] = append(ssTablesGroupByID[id], file.Name)
+		}
+
+		if err := w.basedOnUUIDGenerationAvailability(ctx, d, h, remoteFilesSSTableIDSet, ssTablesGroupByID); err != nil {
+			return errors.Wrap(err, "deduplication based on UUID as generation id content")
+		}
+
+		if err := w.basedOnCrc32Content(ctx, d, h, dataDst, remoteFilesSSTableIDSet, ssTablesGroupByID); err != nil {
+			return errors.Wrap(err, "deduplication based on .crc32 content")
+		}
+
+		return nil
+	}
+
+	notify := func(i int, err error) {
+		d := dirs[i]
+		w.Logger.Error(ctx, "Failed to deduplicate host",
+			"host", d.Host,
+			"keyspace", d.Keyspace,
+			"table", d.Table,
+			"error", err,
+		)
+	}
+
+	return parallel.Run(len(dirs), 1, f, notify)
+}
+
+func (w *worker) basedOnUUIDGenerationAvailability(ctx context.Context, d snapshotDir, h hostInfo,
+	remoteSSTables map[string]struct{}, ssTablesGroupByID map[string][]string,
+) error {
+	// Per every SSTable files group, check if the name uses UUID to identify the SSTable generation.
+	// If the above is true, then check if files exists in the remote storage and remove it locally if exists in rmeote.
+	for id, ssTableContent := range ssTablesGroupByID {
+		// Check if id is an integer (no UUID)
+		if _, err := strconv.Atoi(id); err == nil {
+			continue
+		}
+		// Check if SSTable is available on remote already
+		if _, ok := remoteSSTables[id]; !ok {
+			continue
+		}
+		// Remove duplicated SSTable from local snapshot
+		for _, file := range ssTableContent {
+			// remove if exists in remote
+			localSSTableFileNameWithPath := path.Join(d.Path, file)
+			w.Logger.Debug(ctx, "Removing local snapshot file (deduplication based on generation UUID)",
+				"host", h.IP, "file", localSSTableFileNameWithPath)
+			if err := w.Client.RcloneDeleteFile(ctx, h.IP, localSSTableFileNameWithPath); err != nil {
+				return errors.Wrapf(err, "cannot delete local snapshot's SSTable file %s", localSSTableFileNameWithPath)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (w *worker) basedOnCrc32Content(ctx context.Context, d snapshotDir, h hostInfo, dataDst string,
+	remoteSSTables map[string]struct{}, ssTablesGroupByID map[string][]string,
+) error {
+	// Reference to SSTables 3.0 Data File Format
+	// https://opensource.docs.scylladb.com/stable/architecture/sstable/sstable3/sstables-3-data-file-format.html
+
+	// Per every SSTable files group, compare local <ID>-Digest.crc32 content
+	// to the remote <ID>-Digest.crc32 content.
+	// The same content implies that SSTable can be deduplicated and removed from local directory.
+	for id, ssTableContent := range ssTablesGroupByID {
+		crc32Idx := slices.IndexFunc(ssTableContent, func(s string) bool {
+			return strings.HasSuffix(s, "Digest.crc32")
+		})
+		if crc32Idx == -1 {
+			continue
+		}
+		if _, ok := remoteSSTables[id]; !ok {
+			continue
+		}
+
+		remoteCRC32FileNameWithPath := path.Join(dataDst, ssTableContent[crc32Idx])
+		remoteCRC32, err := w.Client.RcloneCat(ctx, h.IP, remoteCRC32FileNameWithPath)
+		if err != nil {
+			if strings.Contains(err.Error(), "object not found") {
+				continue
+			}
+			return errors.Wrapf(err, "cannot get content of remote CRC32 %s", remoteCRC32FileNameWithPath)
+		}
+
+		localCRC32FileNameWithPath := path.Join(d.Path, ssTableContent[crc32Idx])
+		localCRC32, err := w.Client.RcloneCat(ctx, h.IP, localCRC32FileNameWithPath)
+		if err != nil {
+			return errors.Wrapf(err, "cannot get content of local CRC32 %s", localCRC32FileNameWithPath)
+		}
+
+		// If checksums are equal, then it means that SSTable can be deduplicated as there is no need in
+		// transferring it again to the remote storage.
+		// Deduplication here means to remove SSTable files from local storage.
+		if bytes.Equal(localCRC32, remoteCRC32) {
+			for _, fileToBeRemoved := range ssTableContent {
+				localSSTableFileNameWithPath := path.Join(d.Path, fileToBeRemoved)
+				w.Logger.Debug(ctx, "Removing local snapshot file (deduplication based on .crc32)", "host", h.IP, "file", localSSTableFileNameWithPath)
+				if err := w.Client.RcloneDeleteFile(ctx, h.IP, localSSTableFileNameWithPath); err != nil {
+					return errors.Wrapf(err, "cannot delete local snapshot's SSTable file %s", localSSTableFileNameWithPath)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/service/backup/worker_upload.go
+++ b/pkg/service/backup/worker_upload.go
@@ -190,7 +190,7 @@ func (w *worker) uploadDataDir(ctx context.Context, dst, src string, d snapshotD
 		return err
 	}
 
-	w.Logger.Debug(ctx, "Uploading dir", "host", d.Host, "from", src, "to", dst, "job_id", id)
+	w.Logger.Info(ctx, "Uploading dir", "host", d.Host, "from", src, "to", dst, "job_id", id)
 	d.Progress.AgentJobID = id
 	w.onRunProgress(ctx, d.Progress)
 

--- a/pkg/service/restore/tablesdir_worker.go
+++ b/pkg/service/restore/tablesdir_worker.go
@@ -571,7 +571,10 @@ type bundle []string
 func newBundles(fm FilesMeta) map[string]bundle {
 	bundles := make(map[string]bundle)
 	for _, f := range fm.Files {
-		id := sstable.ExtractID(f)
+		id, err := sstable.ExtractID(f)
+		if err != nil {
+			panic(err)
+		}
 		bundles[id] = append(bundles[id], f)
 	}
 	return bundles

--- a/pkg/sstable/sstable_naming_test.go
+++ b/pkg/sstable/sstable_naming_test.go
@@ -55,7 +55,10 @@ func TestSExtractID(t *testing.T) {
 		tcase := testCases[id]
 		t.Run(tcase.in, func(t *testing.T) {
 			t.Parallel()
-			val := ExtractID(tcase.in)
+			val, err := ExtractID(tcase.in)
+			if err != nil {
+				t.Fatalf("invalid sstable, error = {%v}", err)
+			}
 			if tcase.expected != val {
 				t.Fatalf("expected %s, received %s", tcase.expected, val)
 			}

--- a/testing/scylla/config/scylla.yaml
+++ b/testing/scylla/config/scylla.yaml
@@ -645,3 +645,5 @@ api_doc_dir: /usr/lib/scylla/api/api-doc/
 alternator_port: 8000
 alternator_write_isolation: only_rmw_uses_lwt
 enable_ipv6_dns_lookup: true
+
+uuid_sstable_identifiers_enabled: false


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-manager/issues/3827

This PR adds explicit stage to the backup process - deduplication.
It follows https://docs.google.com/document/d/1EtGlF6UGNy34D_7QsnCheaukp3UwVObZU56PBdd0CQ8/edit#heading=h.jl2qbpcarwp9

It is done to mitigate the problem with current deduplication/checksum comparison which causes SM to create a checksum of every SSTable file and to compare it with the checksum from remote.

This PR changes restore of versioned snapshot as well to corrupt CRC32 files.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
