### PR TITLE
Insert repair state under mutex

### DIFF
--- a/pkg/scyllaclient/client_rclone_agent_integration_test.go
+++ b/pkg/scyllaclient/client_rclone_agent_integration_test.go
@@ -164,14 +164,19 @@ func TestRcloneStoppingTransferIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	job, err := client.RcloneJobInfo(ctx, testHost, id, longPollingTimeoutSeconds)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if job.Transferred[0].Error == "" {
-		t.Fatal("Expected error but got empty")
-	}
+	WaitCond(t, func() bool {
+		job, err := client.RcloneJobInfo(ctx, testHost, id, longPollingTimeoutSeconds)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(job.Transferred) > 0 {
+			if job.Transferred[0].Error == "" {
+				t.Fatal("Expected error but got empty")
+			}
+			return true
+		}
+		return false
+	}, time.Second, 3*time.Second)
 }
 
 func TestRcloneJobProgressIntegration(t *testing.T) {

--- a/pkg/service/backup/worker_snapshot.go
+++ b/pkg/service/backup/worker_snapshot.go
@@ -22,7 +22,8 @@ func (w *worker) Snapshot(ctx context.Context, hosts []hostInfo, limits []DCLimi
 	// a part of any snapshot by migrating from not yet snapshot-ed host to already snapshot-ed one.
 	if snapshotTabletKs {
 		defer func() {
-			err = stdErrors.Join(err, w.Client.ControlTabletLoadBalancing(context.Background(), true))
+			tabletBalancingErr := w.Client.ControlTabletLoadBalancing(context.Background(), true)
+			err = stdErrors.Join(err, errors.Wrap(tabletBalancingErr, "enable post snapshot tablet load balancing"))
 		}()
 		if err := w.Client.ControlTabletLoadBalancing(ctx, false); err != nil {
 			return errors.Wrapf(err, "disable tablet load balancing")

--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -119,7 +119,8 @@ func (g *generator) Run(ctx context.Context) (err error) {
 
 	defer func() {
 		// Always leave tablet migration enabled after repair
-		err = stdErrors.Join(err, g.ringDescriber.ControlTabletLoadBalancing(context.Background(), true))
+		tabletBalancingErr := g.ringDescriber.ControlTabletLoadBalancing(context.Background(), true)
+		err = stdErrors.Join(err, errors.Wrap(tabletBalancingErr, "control post repair tablet load balancing"))
 	}()
 
 	for _, ksp := range g.plan.Keyspaces {

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1156,7 +1156,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 	h := newRepairTestHelper(t, session, defaultConfig())
 	clusterSession := CreateSessionAndDropAllKeyspaces(t, h.Client)
 
-	createKeyspace(t, clusterSession, "test_repair", 2, 2)
+	tryCreateTabletKeyspace(t, clusterSession, "test_repair", 2, 2, 256)
 	WriteData(t, clusterSession, "test_repair", 1, "test_table_0", "test_table_1")
 	defer dropKeyspace(t, clusterSession, "test_repair")
 
@@ -1658,8 +1658,8 @@ func TestServiceRepairIntegration(t *testing.T) {
 		if err != nil {
 			h.T.Fatal(err)
 		}
-		if p.Success == 0 || p.Error == 0 || p.SuccessPercentage+p.ErrorPercentage < 98 { // Leave some wiggle room for rounding errors
-			h.T.Fatal("Expected to get ~100% progress with some successes and errors")
+		if p.Success == 0 || p.Error == 0 || p.Success+p.Error != p.TokenRanges { // Leave some wiggle room for rounding errors
+			h.T.Fatalf("Expected to get full progress with some successes and errors, got %v", p)
 		}
 	})
 


### PR DESCRIPTION
This PR removes flakiness from:
- `TestServiceRepairResumeAllRangesIntegration`
- `TestServiceRepairIntegration/repair temporary network outage`
- `TestRcloneStoppingTransferIntegration`

Fixes #3919
