### PR TITLE
Don't wrap errors as plain strings

### DIFF
--- a/pkg/scyllaclient/status.go
+++ b/pkg/scyllaclient/status.go
@@ -81,7 +81,7 @@ func makeAgentError(resp *http.Response) error {
 		payload: new(agentModels.ErrorResponse),
 	}
 	if err := json.Unmarshal(b, ae.payload); err != nil {
-		return errors.Errorf("agent [HTTP %d] cannot read response: %s", resp.StatusCode, err)
+		return fmt.Errorf("agent [HTTP %d] cannot read response: %w", resp.StatusCode, err)
 	}
 
 	return ae

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -380,9 +380,9 @@ func (s *Service) checkHostLocation(ctx context.Context, client *scyllaclient.Cl
 
 		if scyllaclient.StatusCodeOf(err) > 0 {
 			tip := fmt.Sprintf("make sure the location is correct and credentials are set, to debug SSH to %s and run \"scylla-manager-agent check-location -L %s --debug\"", h, l)
-			err = errors.Errorf("%s: %s - %s", h, err, tip)
+			err = fmt.Errorf("%s: %w - %s", h, err, tip)
 		} else {
-			err = errors.Errorf("%s: %s", h, err)
+			err = fmt.Errorf("%s: %w", h, err)
 		}
 		return err
 	}

--- a/pkg/service/cluster/service.go
+++ b/pkg/service/cluster/service.go
@@ -380,7 +380,7 @@ func (s *Service) PutCluster(ctx context.Context, c *Cluster) (err error) {
 			tip = "make sure auth_token config option on nodes is set correctly"
 		}
 		if tip != "" {
-			err = errors.Errorf("%s - %s", err, tip)
+			err = fmt.Errorf("%w - %s", err, tip)
 		}
 
 		return err

--- a/pkg/util/version/version.go
+++ b/pkg/util/version/version.go
@@ -90,7 +90,7 @@ func CheckConstraint(ver, constraint string) (bool, error) {
 
 	c, err := version.NewConstraint(constraint)
 	if err != nil {
-		return false, errors.Errorf("version constraint syntax error: %s", err)
+		return false, fmt.Errorf("version constraint syntax error: %w", err)
 	}
 	return c.Check(v), nil
 }


### PR DESCRIPTION
Using `errors.Errorf("%s", err)` results in making it impossible to later check nested error cause with `errors.Is` function.
On the other hand, it works fine with `fmt.Errorf("%w", err)`.

Fixes #3925
