### PR TITLE
Label tasks and clusters

### DIFF
--- a/docs/source/sctool/partials/sctool_backup.yaml
+++ b/docs/source/sctool/partials/sctool_backup.yaml
@@ -70,6 +70,15 @@ options:
         Patterns are evaluated from left to right.
         If a pattern starts with '!' it unselects items that were selected by previous patterns i.e. 'a?,!aa' selects *ab* but not *aa*.
 
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: location
       shorthand: L
       default_value: '[]'
@@ -80,7 +89,7 @@ options:
         The 'bucket' parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
     - name: name
       usage: |
-        Task name that can be used insead of ID.
+        Task name that can be used instead of ID.
     - name: num-retries
       shorthand: r
       default_value: "3"

--- a/docs/source/sctool/partials/sctool_backup_update.yaml
+++ b/docs/source/sctool/partials/sctool_backup_update.yaml
@@ -71,6 +71,15 @@ options:
         Patterns are evaluated from left to right.
         If a pattern starts with '!' it unselects items that were selected by previous patterns i.e. 'a?,!aa' selects *ab* but not *aa*.
 
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: location
       shorthand: L
       default_value: '[]'
@@ -81,7 +90,7 @@ options:
         The 'bucket' parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
     - name: name
       usage: |
-        Task name that can be used insead of ID.
+        Task name that can be used instead of ID.
     - name: num-retries
       shorthand: r
       default_value: "3"

--- a/docs/source/sctool/partials/sctool_backup_validate.yaml
+++ b/docs/source/sctool/partials/sctool_backup_validate.yaml
@@ -44,6 +44,15 @@ options:
 
         The task run date is aligned with '--start date' value.
         For example, if you select '--interval 7d' task would run weekly at the '--start-date' time.
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: location
       shorthand: L
       default_value: '[]'
@@ -54,7 +63,7 @@ options:
         The 'bucket' parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
     - name: name
       usage: |
-        Task name that can be used insead of ID.
+        Task name that can be used instead of ID.
     - name: num-retries
       shorthand: r
       default_value: "3"

--- a/docs/source/sctool/partials/sctool_backup_validate_update.yaml
+++ b/docs/source/sctool/partials/sctool_backup_validate_update.yaml
@@ -41,6 +41,15 @@ options:
 
         The task run date is aligned with '--start date' value.
         For example, if you select '--interval 7d' task would run weekly at the '--start-date' time.
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: location
       shorthand: L
       default_value: '[]'
@@ -51,7 +60,7 @@ options:
         The 'bucket' parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
     - name: name
       usage: |
-        Task name that can be used insead of ID.
+        Task name that can be used instead of ID.
     - name: num-retries
       shorthand: r
       default_value: "3"

--- a/docs/source/sctool/partials/sctool_cluster_add.yaml
+++ b/docs/source/sctool/partials/sctool_cluster_add.yaml
@@ -31,6 +31,15 @@ options:
       shorthand: i
       usage: |
         Explicitly specify cluster ID, when not provided random `UUID` will be generated.
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: name
       shorthand: "n"
       usage: |

--- a/docs/source/sctool/partials/sctool_cluster_update.yaml
+++ b/docs/source/sctool/partials/sctool_cluster_update.yaml
@@ -36,6 +36,15 @@ options:
         Hostname or `IP` of the node that will be used to discover other nodes belonging to the cluster.
         Note that this will be persisted and used every time Scylla Manager starts.
         You can use either an IPv4 or IPv6 address.
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: name
       shorthand: "n"
       usage: |

--- a/docs/source/sctool/partials/sctool_repair.yaml
+++ b/docs/source/sctool/partials/sctool_repair.yaml
@@ -94,9 +94,18 @@ options:
         Patterns are evaluated from left to right.
         If a pattern starts with '!' it unselects items that were selected by previous patterns i.e. 'a?,!aa' selects *ab* but not *aa*.
 
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: name
       usage: |
-        Task name that can be used insead of ID.
+        Task name that can be used instead of ID.
     - name: num-retries
       shorthand: r
       default_value: "3"

--- a/docs/source/sctool/partials/sctool_repair_update.yaml
+++ b/docs/source/sctool/partials/sctool_repair_update.yaml
@@ -95,9 +95,18 @@ options:
         Patterns are evaluated from left to right.
         If a pattern starts with '!' it unselects items that were selected by previous patterns i.e. 'a?,!aa' selects *ab* but not *aa*.
 
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: name
       usage: |
-        Task name that can be used insead of ID.
+        Task name that can be used instead of ID.
     - name: num-retries
       shorthand: r
       default_value: "3"

--- a/docs/source/sctool/partials/sctool_restore.yaml
+++ b/docs/source/sctool/partials/sctool_restore.yaml
@@ -65,6 +65,15 @@ options:
         Patterns are evaluated from left to right.
         If a pattern starts with '!' it unselects items that were selected by previous patterns i.e. 'a?,!aa' selects *ab* but not *aa*.
 
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: location
       shorthand: L
       default_value: '[]'
@@ -81,7 +90,7 @@ options:
         The `<bucket>` parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
     - name: name
       usage: |
-        Task name that can be used insead of ID.
+        Task name that can be used instead of ID.
     - name: num-retries
       shorthand: r
       default_value: "3"

--- a/docs/source/sctool/partials/sctool_restore_update.yaml
+++ b/docs/source/sctool/partials/sctool_restore_update.yaml
@@ -63,6 +63,15 @@ options:
         Patterns are evaluated from left to right.
         If a pattern starts with '!' it unselects items that were selected by previous patterns i.e. 'a?,!aa' selects *ab* but not *aa*.
 
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: location
       shorthand: L
       default_value: '[]'
@@ -79,7 +88,7 @@ options:
         The `<bucket>` parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
     - name: name
       usage: |
-        Task name that can be used insead of ID.
+        Task name that can be used instead of ID.
     - name: num-retries
       shorthand: r
       default_value: "3"

--- a/docs/source/sctool/partials/sctool_suspend.yaml
+++ b/docs/source/sctool/partials/sctool_suspend.yaml
@@ -47,9 +47,18 @@ options:
 
         The task run date is aligned with '--start date' value.
         For example, if you select '--interval 7d' task would run weekly at the '--start-date' time.
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: name
       usage: |
-        Task name that can be used insead of ID.
+        Task name that can be used instead of ID.
     - name: num-retries
       shorthand: r
       default_value: "3"

--- a/docs/source/sctool/partials/sctool_suspend_update.yaml
+++ b/docs/source/sctool/partials/sctool_suspend_update.yaml
@@ -39,9 +39,18 @@ options:
 
         The task run date is aligned with '--start date' value.
         For example, if you select '--interval 7d' task would run weekly at the '--start-date' time.
+    - name: label
+      usage: |
+        A comma-separated list of label modifications. Labels are represented as a key-value store.
+        Character '=' has a special meaning and cannot be a part of label's key nor value.
+        A single modification takes form of:
+        * '<key>=<value>' - sets the label <key> to <value>
+        * '<key>-'        - removes the label
+
+        For example, '--label k1=v1,k2-' will set the label 'k1' to 'v1' and will also remove label 'k2'.
     - name: name
       usage: |
-        Task name that can be used insead of ID.
+        Task name that can be used instead of ID.
     - name: num-retries
       shorthand: r
       default_value: "3"

--- a/pkg/command/cluster/clusteradd/cmd.go
+++ b/pkg/command/cluster/clusteradd/cmd.go
@@ -25,6 +25,7 @@ type command struct {
 
 	id                     string
 	name                   string
+	label                  flag.Label
 	host                   string
 	port                   int64
 	authToken              string
@@ -57,6 +58,7 @@ func (cmd *command) init() {
 	w := cmd.Flags()
 	w.StringVarP(&cmd.id, "id", "i", "", "")
 	w.StringVarP(&cmd.name, "name", "n", "", "")
+	w.Var(&cmd.label, "label", "")
 	w.StringVar(&cmd.host, "host", "", "")
 	w.Int64Var(&cmd.port, "port", 10001, "")
 	w.StringVar(&cmd.authToken, "auth-token", "", "")
@@ -85,6 +87,7 @@ func (cmd *command) run() error {
 	c := &managerclient.Cluster{
 		ID:                     cmd.id,
 		Name:                   cmd.name,
+		Labels:                 cmd.label.NewLabels(),
 		Host:                   cmd.host,
 		AuthToken:              cmd.authToken,
 		Username:               cmd.username,

--- a/pkg/command/cluster/clusteradd/res.yaml
+++ b/pkg/command/cluster/clusteradd/res.yaml
@@ -28,6 +28,15 @@ name: |
   Use this parameter to identify the cluster by an alias name which is more meaningful.
   This `alias` name can be used with all commands that accept --cluster parameter.
 
+label: |
+  A comma-separated list of label modifications. Labels are represented as a key-value store.
+  Character '=' has a special meaning and cannot be a part of label's key nor value.
+  A single modification takes form of:
+  * '<key>=<value>' - sets the label <key> to <value>
+  * '<key>-'        - removes the label
+  
+  For example, ``--label k1=v1,k2-`` will set the label 'k1' to 'v1' and will also remove label 'k2'.
+
 host: |
   Hostname or `IP` of the node that will be used to discover other nodes belonging to the cluster.
   Note that this will be persisted and used every time Scylla Manager starts.

--- a/pkg/command/cluster/clusterlist/cmd_integration_api_test.go
+++ b/pkg/command/cluster/clusterlist/cmd_integration_api_test.go
@@ -1,0 +1,95 @@
+// Copyright (C) 2024 ScyllaDB
+
+//go:build all || api_integration
+// +build all api_integration
+
+package clusterlist
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/managerclient"
+	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla-manager/models"
+)
+
+const (
+	authToken        = "token"
+	clusterIntroHost = "192.168.200.11"
+)
+
+func TestSctoolClusterListIntegrationAPITest(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		createCluster         *models.Cluster
+		updateCluster         *models.Cluster
+		args                  []string
+		expectedOutputPattern string
+	}{
+		{
+			name: "update cluster with label",
+			createCluster: &models.Cluster{
+				AuthToken: authToken,
+				Host:      clusterIntroHost,
+				Labels: map[string]string{
+					"k1": "v1",
+				},
+			},
+			updateCluster: &models.Cluster{
+				AuthToken: authToken,
+				Host:      clusterIntroHost,
+				Labels: map[string]string{
+					"k2": "v2",
+				},
+			},
+			args:                  []string{"cluster", "list"},
+			expectedOutputPattern: `<cluster_id> *\| *\| *k2=v2`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			client, err := managerclient.NewClient("http://localhost:5080/api/v1")
+			if err != nil {
+				t.Fatalf("Unable to create managerclient to consume managet HTTP API, err = {%v}", err)
+			}
+
+			clusterID, err := client.CreateCluster(context.Background(), tc.createCluster)
+			if err != nil {
+				t.Fatalf("Unable to create cluster for further listing, err = {%v}", err)
+			}
+			if tc.updateCluster != nil {
+				uc := tc.updateCluster
+				uc.ID = clusterID
+				if err := client.UpdateCluster(context.Background(), uc); err != nil {
+					t.Fatalf("Unable to update cluster for further listing, err = {%v}", err)
+				}
+			}
+
+			cmd := exec.Command("./sctool.api-tests", tc.args...)
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			cmd.Dir = "/scylla-manager"
+
+			output, err := cmd.Output()
+			if err != nil {
+				t.Fatalf("Unable to list clusters with sctool cluster list, err = {%v}, stderr = {%v}", err, stderr.String())
+			}
+
+			defer func() {
+				if err := client.DeleteCluster(context.Background(), clusterID); err != nil {
+					t.Logf("Failed to delete cluster, err = {%v}", err)
+				}
+			}()
+
+			re := regexp.MustCompile(strings.ReplaceAll(tc.expectedOutputPattern, "<cluster_id>", clusterID))
+			if !re.Match(output) {
+				t.Fatalf("Expected to get pattern {%v}, got {%s}", tc.expectedOutputPattern, string(output))
+			}
+		})
+	}
+
+}

--- a/pkg/command/cluster/clusterupdate/cmd.go
+++ b/pkg/command/cluster/clusterupdate/cmd.go
@@ -22,6 +22,7 @@ type command struct {
 
 	cluster                string
 	name                   string
+	label                  flag.Label
 	host                   string
 	port                   int64
 	authToken              string
@@ -55,6 +56,7 @@ func (cmd *command) init() {
 	w := flag.Wrap(cmd.Flags())
 	w.Cluster(&cmd.cluster)
 	w.Unwrap().StringVarP(&cmd.name, "name", "n", "", "")
+	w.Unwrap().Var(&cmd.label, "label", "")
 	w.Unwrap().StringVar(&cmd.host, "host", "", "")
 	w.Unwrap().Int64Var(&cmd.port, "port", 10001, "")
 	w.Unwrap().StringVar(&cmd.authToken, "auth-token", "", "")
@@ -77,6 +79,10 @@ func (cmd *command) run() error {
 	ok := false
 	if cmd.Flags().Changed("name") {
 		cluster.Name = cmd.name
+		ok = true
+	}
+	if cmd.Flags().Changed("label") {
+		cluster.Labels = cmd.label.ApplyDiff(cluster.Labels)
 		ok = true
 	}
 	if cmd.Flags().Changed("host") {

--- a/pkg/command/cluster/clusterupdate/res.yaml
+++ b/pkg/command/cluster/clusterupdate/res.yaml
@@ -15,6 +15,15 @@ name: |
   Use this parameter to identify the cluster by an alias name which is more meaningful.
   This `alias` name can be used with all commands that accept --cluster parameter.
 
+label: |
+  A comma-separated list of label modifications. Labels are represented as a key-value store.
+  Character '=' has a special meaning and cannot be a part of label's key nor value.
+  A single modification takes form of:
+  * '<key>=<value>' - sets the label <key> to <value>
+  * '<key>-'        - removes the label
+  
+  For example, ``--label k1=v1,k2-`` will set the label 'k1' to 'v1' and will also remove label 'k2'.
+
 host: |
   Hostname or `IP` of the node that will be used to discover other nodes belonging to the cluster.
   Note that this will be persisted and used every time Scylla Manager starts.

--- a/pkg/command/flag/flag.go
+++ b/pkg/command/flag/flag.go
@@ -127,6 +127,10 @@ func (w Wrapper) name(p *string) {
 	w.fs.StringVar(p, "name", "", usage["name"])
 }
 
+func (w Wrapper) label(p *Label) {
+	w.fs.Var(p, "label", usage["label"])
+}
+
 func (w Wrapper) cron(p *Cron) {
 	w.fs.VarP(p, "cron", "", usage["cron"])
 }

--- a/pkg/command/flag/task.go
+++ b/pkg/command/flag/task.go
@@ -17,6 +17,7 @@ type TaskBase struct {
 
 	enabled  bool
 	name     string
+	label    Label
 	cron     Cron
 	window   []string
 	timezone Timezone
@@ -46,6 +47,7 @@ func (cmd *TaskBase) Init() {
 	w := Wrap(cmd.Flags())
 	w.enabled(&cmd.enabled)
 	w.name(&cmd.name)
+	w.label(&cmd.label)
 	w.cron(&cmd.cron)
 	w.window(&cmd.window)
 	w.timezone(&cmd.timezone)
@@ -66,6 +68,7 @@ func (cmd *TaskBase) CreateTask(taskType string) *managerclient.Task {
 		Type:    taskType,
 		Enabled: cmd.enabled,
 		Name:    cmd.name,
+		Labels:  cmd.label.NewLabels(),
 		Schedule: &managerclient.Schedule{
 			Cron:       cmd.cron.Value(),
 			Window:     cmd.window,
@@ -88,6 +91,10 @@ func (cmd *TaskBase) UpdateTask(task *managerclient.Task) bool {
 	}
 	if cmd.Flag("name").Changed {
 		task.Name = cmd.name
+		ok = true
+	}
+	if cmd.Flag("label").Changed {
+		task.Labels = cmd.label.ApplyDiff(task.Labels)
 		ok = true
 	}
 	if cmd.Flag("cron").Changed {

--- a/pkg/command/flag/task.yaml
+++ b/pkg/command/flag/task.yaml
@@ -2,7 +2,16 @@ enabled: |
   Not enabled tasks are not executed and are hidden from the task list.
 
 name: |
-  Task name that can be used insead of ID.
+  Task name that can be used instead of ID.
+
+label: |
+  A comma-separated list of label modifications. Labels are represented as a key-value store.
+  Character '=' has a special meaning and cannot be a part of label's key nor value.
+  A single modification takes form of:
+  * '<key>=<value>' - sets the label <key> to <value>
+  * '<key>-'        - removes the label
+  
+  For example, ``--label k1=v1,k2-`` will set the label 'k1' to 'v1' and will also remove label 'k2'.
 
 cron: |
   Task schedule as a cron `expression`.

--- a/pkg/command/flag/type_test.go
+++ b/pkg/command/flag/type_test.go
@@ -3,10 +3,13 @@
 package flag
 
 import (
+	"errors"
+	"maps"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 )
 
@@ -72,6 +75,87 @@ func TestParseTime(t *testing.T) {
 		diff := test.T.Sub(m).Abs()
 		if diff > epsilon {
 			t.Fatal(i, m, test.T, diff, test.S)
+		}
+	}
+}
+
+func TestParseLabel(t *testing.T) {
+	testCases := []struct {
+		S string
+		T Label
+		E error
+	}{
+		{
+			S: "k1=v1",
+			T: Label{
+				add: map[string]string{
+					"k1": "v1",
+				},
+			},
+		},
+		{
+			S: "k1-",
+			T: Label{
+				remove: []string{"k1"},
+			},
+		},
+		{
+			S: "k1=v1,k2=v2,k3-,k4=v4",
+			T: Label{
+				add: map[string]string{
+					"k1": "v1",
+					"k2": "v2",
+					"k4": "v4",
+				},
+				remove: []string{"k3"},
+			},
+		},
+		{
+			S: "k1=v1,with space=with-dash_underscore666",
+			T: Label{
+				add: map[string]string{
+					"k1":         "v1",
+					"with space": "with-dash_underscore666",
+				},
+			},
+		},
+		{
+			S: "k1=v1,k1-",
+			E: errAddAndRemoveLabel,
+		},
+		{
+			S: "k1=v1=v2",
+			E: errUnknownLabelSpec,
+		},
+		{
+			S: "k1",
+			E: errUnknownLabelSpec,
+		},
+	}
+
+	parse := func(s string) (Label, error) {
+		var l Label
+		err := l.Set(s)
+		return l, err
+	}
+
+	for i, tc := range testCases {
+		l, err := parse(tc.S)
+
+		if tc.E != nil {
+			if !errors.Is(err, tc.E) {
+				t.Fatalf("%d: expected error: %s, but got: %s", i, tc.E, err)
+			}
+			continue
+		} else if err != nil {
+			t.Fatalf("%d: expected no error, but got: %s", i, err)
+		}
+
+		if !maps.Equal(l.add, tc.T.add) {
+			t.Fatalf("%d: expected added labels: %v, but got: %v", i, l.add, tc.T.add)
+		}
+		if !strset.New(l.remove...).IsEqual(strset.New(tc.T.remove...)) {
+			t.Fatalf("%d: expected removed labels: %v, but got: %v", i, l.remove, tc.T.remove)
 		}
 	}
 }

--- a/pkg/command/info/cmd_integration_api_test.go
+++ b/pkg/command/info/cmd_integration_api_test.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2024 ScyllaDB
+
+//go:build all || api_integration
+// +build all api_integration
+
+package info
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"regexp"
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/managerclient"
+	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla-manager/models"
+)
+
+const (
+	authToken        = "token"
+	clusterIntroHost = "192.168.200.11"
+)
+
+func TestSctoolInfoLabelsIntegrationAPITest(t *testing.T) {
+	client, err := managerclient.NewClient("http://localhost:5080/api/v1")
+	if err != nil {
+		t.Fatalf("Unable to create managerclient to consume managet HTTP API, err = {%v}", err)
+	}
+
+	clusterID, err := client.CreateCluster(context.Background(), &models.Cluster{
+		AuthToken: authToken,
+		Host:      clusterIntroHost,
+	})
+	if err != nil {
+		t.Fatalf("Unable to create cluster for further listing, err = {%v}", err)
+	}
+
+	defer func() {
+		if err := client.DeleteCluster(context.Background(), clusterID); err != nil {
+			t.Logf("Failed to delete cluster, err = {%v}", err)
+		}
+	}()
+
+	taskID, err := client.CreateTask(context.Background(), clusterID, &managerclient.Task{
+		Type:    "repair",
+		Enabled: true,
+		Labels: map[string]string{
+			"k1": "v1",
+		},
+		Properties: make(map[string]interface{}),
+	})
+	if err != nil {
+		t.Logf("Failed to create task, err = {%v}", err)
+	}
+
+	if err := client.UpdateTask(context.Background(), clusterID, &managerclient.Task{
+		ID:      taskID.String(),
+		Type:    "repair",
+		Enabled: true,
+		Labels: map[string]string{
+			"k1": "v3",
+		},
+		Properties: make(map[string]interface{}),
+	}); err != nil {
+		t.Fatalf("Unable to update cluster for further listing, err = {%v}", err)
+	}
+
+	cmd := exec.Command("./sctool.api-tests", "info", "--cluster", clusterID, "repair/"+taskID.String())
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Dir = "/scylla-manager"
+
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Unable to list tasks with sctool tasks, err = {%v}, stderr = {%v}", err, stderr.String())
+	}
+
+	re := regexp.MustCompile(`k1: v3`)
+	if !re.Match(output) {
+		t.Fatalf("Expected to get pattern {k1: k3}, got {%s}", string(output))
+	}
+}

--- a/pkg/command/repair/cmd_api_integration_test.go
+++ b/pkg/command/repair/cmd_api_integration_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2024 ScyllaDB
+
+//go:build all || api_integration
+// +build all api_integration
+
+package repair
+
+import (
+	"bytes"
+	"context"
+	"maps"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/managerclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla-manager/models"
+)
+
+const (
+	authToken        = "token"
+	clusterIntroHost = "192.168.200.11"
+)
+
+func TestSctoolRepairLabelIntegrationAPITest(t *testing.T) {
+	client, err := managerclient.NewClient("http://localhost:5080/api/v1")
+	if err != nil {
+		t.Fatalf("Unable to create managerclient to consume managet HTTP API, err = {%v}", err)
+	}
+
+	clusterID, err := client.CreateCluster(context.Background(), &models.Cluster{
+		AuthToken: authToken,
+		Host:      clusterIntroHost,
+	})
+	if err != nil {
+		t.Fatalf("Unable to create cluster for further listing, err = {%v}", err)
+	}
+
+	defer func() {
+		if err := client.DeleteCluster(context.Background(), clusterID); err != nil {
+			t.Logf("Failed to delete cluster, err = {%v}", err)
+		}
+	}()
+
+	cmd := exec.Command("./sctool.api-tests", "repair", "--cluster", clusterID, "--label", "k1=v1,k2=v2")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Dir = "/scylla-manager"
+
+	rawRepairTaskID, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Unable to create task with sctool repair, err = {%v}, stderr = {%v}", err, stderr.String())
+	}
+
+	repairTaskID, _ := strings.CutSuffix(string(rawRepairTaskID), "\n")
+	rawTaskID, _ := strings.CutPrefix(repairTaskID, "repair/")
+	taskID, err := uuid.Parse(rawTaskID)
+	if err != nil {
+		t.Fatalf("Unable to parse created task ID, err = {%v}", err)
+	}
+
+	cmd = exec.Command("./sctool.api-tests", "repair", "update", "--cluster", clusterID, repairTaskID, "--label", "k1=v3")
+	cmd.Stderr = &stderr
+	cmd.Dir = "/scylla-manager"
+
+	_, err = cmd.Output()
+	if err != nil {
+		t.Fatalf("Unable to update task with sctool repair update, err = {%v}, stderr = {%v}", err, stderr.String())
+	}
+
+	task, err := client.GetTask(context.Background(), clusterID, "repair", taskID)
+	if err != nil {
+		t.Fatalf("Unable to get updated task wtih client, err = {%v}", err)
+	}
+
+	if !maps.Equal(task.Labels, map[string]string{
+		"k2": "v2",
+		"k1": "v3",
+	}) {
+		t.Fatalf("Labels mismatch {%v}", task.Labels)
+	}
+}

--- a/pkg/command/tasks/cmd_integration_api_test.go
+++ b/pkg/command/tasks/cmd_integration_api_test.go
@@ -1,0 +1,83 @@
+// Copyright (C) 2024 ScyllaDB
+
+//go:build all || api_integration
+// +build all api_integration
+
+package tasks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/managerclient"
+	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla-manager/models"
+)
+
+const (
+	authToken        = "token"
+	clusterIntroHost = "192.168.200.11"
+)
+
+func TestSctoolTasksLabelsIntegrationAPITest(t *testing.T) {
+	client, err := managerclient.NewClient("http://localhost:5080/api/v1")
+	if err != nil {
+		t.Fatalf("Unable to create managerclient to consume managet HTTP API, err = {%v}", err)
+	}
+
+	clusterID, err := client.CreateCluster(context.Background(), &models.Cluster{
+		AuthToken: authToken,
+		Host:      clusterIntroHost,
+	})
+	if err != nil {
+		t.Fatalf("Unable to create cluster for further listing, err = {%v}", err)
+	}
+
+	defer func() {
+		if err := client.DeleteCluster(context.Background(), clusterID); err != nil {
+			t.Logf("Failed to delete cluster, err = {%v}", err)
+		}
+	}()
+
+	taskID, err := client.CreateTask(context.Background(), clusterID, &managerclient.Task{
+		Type:    "repair",
+		Enabled: true,
+		Labels: map[string]string{
+			"k1": "v1",
+		},
+		Properties: make(map[string]interface{}),
+	})
+	if err != nil {
+		t.Logf("Failed to create task, err = {%v}", err)
+	}
+
+	if err := client.UpdateTask(context.Background(), clusterID, &managerclient.Task{
+		ID:      taskID.String(),
+		Type:    "repair",
+		Enabled: true,
+		Labels: map[string]string{
+			"k2": "v2",
+		},
+		Properties: make(map[string]interface{}),
+	}); err != nil {
+		t.Fatalf("Unable to update cluster for further listing, err = {%v}", err)
+	}
+
+	cmd := exec.Command("./sctool.api-tests", "tasks", "--cluster", clusterID)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	cmd.Dir = "/scylla-manager"
+
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("Unable to list tasks with sctool tasks, err = {%v}, stderr = {%v}", err, stderr.String())
+	}
+
+	re := regexp.MustCompile(fmt.Sprintf(`%s *\| *k2=v2`, taskID))
+	if !re.Match(output) {
+		t.Fatalf("Expected to get pattern {<task_id> *\\| *k2=v2}, got {%s}", string(output))
+	}
+}

--- a/pkg/managerclient/client.go
+++ b/pkg/managerclient/client.go
@@ -329,6 +329,7 @@ func (c *Client) UpdateTask(ctx context.Context, clusterID string, t *Task) erro
 		TaskFields: &models.TaskUpdate{
 			Enabled:    t.Enabled,
 			Name:       t.Name,
+			Labels:     t.Labels,
 			Schedule:   t.Schedule,
 			Tags:       t.Tags,
 			Properties: t.Properties,

--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -40,7 +40,7 @@ type ClusterSlice []*models.Cluster
 
 // Render renders ClusterSlice in a tabular format.
 func (cs ClusterSlice) Render(w io.Writer) error {
-	t := table.New("ID", "Name", "Port", "CQL credentials")
+	t := table.New("ID", "Name", "Labels", "Port", "CQL credentials")
 	for _, c := range cs {
 		p := "default"
 		if c.Port != 0 {
@@ -50,7 +50,7 @@ func (cs ClusterSlice) Render(w io.Writer) error {
 		if c.Username != "" && c.Password != "" {
 			creds = "set"
 		}
-		t.AddRow(c.ID, c.Name, p, creds)
+		t.AddRow(c.ID, c.Name, formatLabels(c.Labels), p, creds)
 	}
 	if _, err := w.Write([]byte(t.String())); err != nil {
 		return err

--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -218,7 +218,12 @@ Window:	{{ WindowDesc .Schedule.Window }}
 Tz:	{{ .Schedule.Timezone }}
 {{ end -}}
 {{ if .Schedule.NumRetries -}}
-Retry:	{{ .Schedule.NumRetries }} {{ if .Schedule.RetryWait }}(initial backoff {{ .Schedule.RetryWait }}){{ end }}
+Retry:	{{ .Schedule.NumRetries }} {{ if .Schedule.RetryWait }}(initial backoff {{ .Schedule.RetryWait }}){{ end }}{{ end -}}
+{{ if .Labels }}
+Labels:
+{{- range $key, $val := .Labels }}
+- {{ $key }}: {{ $val -}}
+{{ end }}
 {{ end -}}
 
 {{ if .Properties }}

--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -198,8 +198,8 @@ func makeTaskUpdate(t *Task) *models.TaskUpdate {
 		Type:       t.Type,
 		Enabled:    t.Enabled,
 		Name:       t.Name,
+		Labels:     t.Labels,
 		Schedule:   t.Schedule,
-		Tags:       t.Tags,
 		Properties: t.Properties,
 	}
 }

--- a/pkg/managerclient/model.go
+++ b/pkg/managerclient/model.go
@@ -492,7 +492,7 @@ type TaskListItems struct {
 
 // Render renders TaskListItems in a tabular format.
 func (li TaskListItems) Render(w io.Writer) error {
-	columns := []any{"Task", "Schedule", "Window", "Timezone", "Success", "Error", "Last Success", "Last Error", "Status", "Next"}
+	columns := []any{"Task", "Labels", "Schedule", "Window", "Timezone", "Success", "Error", "Last Success", "Last Error", "Status", "Next"}
 	if li.ShowProps {
 		columns = append(columns, "Properties")
 	}
@@ -545,7 +545,7 @@ func (li TaskListItems) Render(w io.Writer) error {
 		}
 
 		row := []any{
-			id, schedule, strings.Join(t.Schedule.Window, ","), t.Schedule.Timezone,
+			id, formatLabels(t.Labels), schedule, strings.Join(t.Schedule.Window, ","), t.Schedule.Timezone,
 			t.SuccessCount, t.ErrorCount, FormatTimePointer(t.LastSuccess), FormatTimePointer(t.LastError),
 			status, next,
 		}
@@ -1359,4 +1359,12 @@ func (bl BackupListItems) Render(w io.Writer) error {
 		}
 	}
 	return nil
+}
+
+func formatLabels(labels map[string]string) string {
+	var out []string
+	for k, v := range labels {
+		out = append(out, k+"="+v)
+	}
+	return strings.Join(out, ", ")
 }

--- a/pkg/schema/table/table.go
+++ b/pkg/schema/table/table.go
@@ -66,6 +66,7 @@ var (
 			"auth_token",
 			"id",
 			"known_hosts",
+			"labels",
 			"name",
 			"port",
 			"force_tls_disabled",
@@ -252,6 +253,7 @@ var (
 			"enabled",
 			"error_count",
 			"id",
+			"labels",
 			"last_error",
 			"last_success",
 			"name",
@@ -259,7 +261,6 @@ var (
 			"sched",
 			"status",
 			"success_count",
-			"tags",
 			"type",
 		},
 		PartKey: []string{

--- a/pkg/schema/table/update.go
+++ b/pkg/schema/table/update.go
@@ -14,9 +14,9 @@ var SchedulerTaskUpdate = table.New(table.Metadata{
 		"enabled",
 		"id",
 		"name",
+		"labels",
 		"properties",
 		"sched",
-		"tags",
 		"type",
 	},
 	PartKey: []string{

--- a/pkg/service/cluster/model.go
+++ b/pkg/service/cluster/model.go
@@ -13,12 +13,13 @@ import (
 
 // Cluster specifies a cluster properties.
 type Cluster struct {
-	ID         uuid.UUID `json:"id"`
-	Name       string    `json:"name"`
-	Host       string    `json:"host"`
-	KnownHosts []string  `json:"-"`
-	Port       int       `json:"port,omitempty"`
-	AuthToken  string    `json:"auth_token"`
+	ID         uuid.UUID         `json:"id"`
+	Name       string            `json:"name"`
+	Labels     map[string]string `json:"labels"`
+	Host       string            `json:"host"`
+	KnownHosts []string          `json:"-"`
+	Port       int               `json:"port,omitempty"`
+	AuthToken  string            `json:"auth_token"`
 
 	ForceTLSDisabled       bool `json:"force_tls_disabled"`
 	ForceNonSSLSessionPort bool `json:"force_non_ssl_session_port"`

--- a/pkg/service/scheduler/model.go
+++ b/pkg/service/scheduler/model.go
@@ -323,15 +323,16 @@ func (s Schedule) backoff() retry.Backoff {
 
 // Task specify task type, properties and schedule.
 type Task struct {
-	ClusterID  uuid.UUID       `json:"cluster_id"`
-	Type       TaskType        `json:"type"`
-	ID         uuid.UUID       `json:"id"`
-	Name       string          `json:"name"`
-	Tags       []string        `json:"tags,omitempty"`
-	Enabled    bool            `json:"enabled,omitempty"`
-	Deleted    bool            `json:"deleted,omitempty"`
-	Sched      Schedule        `json:"schedule,omitempty"`
-	Properties json.RawMessage `json:"properties,omitempty"`
+	ClusterID  uuid.UUID         `json:"cluster_id"`
+	Type       TaskType          `json:"type"`
+	ID         uuid.UUID         `json:"id"`
+	Name       string            `json:"name"`
+	Labels     map[string]string `json:"labels"`
+	Enabled    bool              `json:"enabled,omitempty"`
+	Deleted    bool              `json:"deleted,omitempty"`
+	Sched      Schedule          `json:"schedule,omitempty"`
+	Properties json.RawMessage   `json:"properties,omitempty"`
+	Tags       []string
 
 	Status       Status     `json:"status"`
 	SuccessCount int        `json:"success_count"`

--- a/schema/v3.3.1.cql
+++ b/schema/v3.3.1.cql
@@ -1,0 +1,3 @@
+ALTER TABLE cluster ADD labels map<text, text>;
+ALTER TABLE scheduler_task DROP tags;
+ALTER TABLE scheduler_task ADD labels map<text, text>;

--- a/swagger/gen/scylla-manager/models/cluster.go
+++ b/swagger/gen/scylla-manager/models/cluster.go
@@ -30,6 +30,9 @@ type Cluster struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// labels
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 

--- a/swagger/gen/scylla-manager/models/task.go
+++ b/swagger/gen/scylla-manager/models/task.go
@@ -25,6 +25,9 @@ type Task struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// labels
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 
@@ -34,7 +37,7 @@ type Task struct {
 	// schedule
 	Schedule *Schedule `json:"schedule,omitempty"`
 
-	// tags
+	// This field is DEPRECATED. Use labels instead.
 	Tags []string `json:"tags"`
 
 	// type

--- a/swagger/gen/scylla-manager/models/task_list_item.go
+++ b/swagger/gen/scylla-manager/models/task_list_item.go
@@ -29,6 +29,9 @@ type TaskListItem struct {
 	// id
 	ID string `json:"id,omitempty"`
 
+	// labels
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// last error
 	// Format: date-time
 	LastError *strfmt.DateTime `json:"last_error,omitempty"`
@@ -62,7 +65,7 @@ type TaskListItem struct {
 	// suspended
 	Suspended bool `json:"suspended,omitempty"`
 
-	// tags
+	// This field is DEPRECATED. Use labels instead.
 	Tags []string `json:"tags"`
 
 	// type

--- a/swagger/gen/scylla-manager/models/task_update.go
+++ b/swagger/gen/scylla-manager/models/task_update.go
@@ -19,6 +19,9 @@ type TaskUpdate struct {
 	// enabled
 	Enabled bool `json:"enabled,omitempty"`
 
+	// labels
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 
@@ -28,7 +31,7 @@ type TaskUpdate struct {
 	// schedule
 	Schedule *Schedule `json:"schedule,omitempty"`
 
-	// tags
+	// This field is DEPRECATED. Use labels instead.
 	Tags []string `json:"tags"`
 
 	// type

--- a/swagger/scylla-manager.json
+++ b/swagger/scylla-manager.json
@@ -44,6 +44,12 @@
         "password": {
           "type": "string"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "ssl_user_cert_file": {
           "type": "string",
           "format": "byte"
@@ -312,11 +318,18 @@
         "name": {
           "type": "string"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "tags": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "This field is DEPRECATED. Use labels instead."
         },
         "enabled": {
           "type": "boolean"
@@ -345,11 +358,18 @@
         "name": {
           "type": "string"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "tags": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "This field is DEPRECATED. Use labels instead."
         },
         "enabled": {
           "type": "boolean"
@@ -402,11 +422,18 @@
         "type": {
           "type": "string"
         },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "tags": {
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "description": "This field is DEPRECATED. Use labels instead."
         },
         "enabled": {
           "type": "boolean"


### PR DESCRIPTION
This PR adds a possibility of labeling cluster/tasks with the `--label` flag.
I decided to implement the [approach with a single flag](https://github.com/scylladb/scylla-manager/issues/3219#issuecomment-2231385713), which has the special syntax for defining labels to be removed (similar to the [kubctl label](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set)).



Fixes  #3219
