### PR TITLE
Additional labels for healtcheck metrics

### DIFF
--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -205,6 +205,18 @@ func (c *Client) HostDatacenter(ctx context.Context, host string) (dc string, er
 	return
 }
 
+// HostRack looks up the rack that the given host belongs to.
+func (c *Client) HostRack(ctx context.Context, host string) (string, error) {
+	resp, err := c.scyllaOps.SnitchRackGet(&operations.SnitchRackGetParams{
+		Context: ctx,
+		Host:    &host,
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Payload, nil
+}
+
 // HostIDs returns a mapping from host IP to UUID.
 func (c *Client) HostIDs(ctx context.Context) (map[string]string, error) {
 	resp, err := c.scyllaOps.StorageServiceHostIDGet(&operations.StorageServiceHostIDGetParams{Context: ctx})

--- a/pkg/service/configcache/nodeconfig.go
+++ b/pkg/service/configcache/nodeconfig.go
@@ -15,10 +15,12 @@ type NodeConfig struct {
 
 	cqlTLSConfig        *TLSConfigWithAddress
 	alternatorTLSConfig *TLSConfigWithAddress
+	Rack                string
+	Datacenter          string
 }
 
 // NewNodeConfig creates and initializes new node configuration struct containing TLS configuration of CQL and Alternator.
-func NewNodeConfig(c *cluster.Cluster, nodeInfo *scyllaclient.NodeInfo, secretsStore store.Store, host string) (config NodeConfig, err error) {
+func NewNodeConfig(c *cluster.Cluster, nodeInfo *scyllaclient.NodeInfo, secretsStore store.Store, host, dc, rack string) (config NodeConfig, err error) {
 	cqlTLS, err := newCQLTLSConfigIfEnabled(c, nodeInfo, secretsStore, host)
 	if err != nil {
 		return NodeConfig{}, errors.Wrap(err, "building node config")
@@ -31,6 +33,8 @@ func NewNodeConfig(c *cluster.Cluster, nodeInfo *scyllaclient.NodeInfo, secretsS
 		NodeInfo:            nodeInfo,
 		cqlTLSConfig:        cqlTLS,
 		alternatorTLSConfig: alternatorTLS,
+		Datacenter:          dc,
+		Rack:                rack,
 	}, nil
 }
 

--- a/pkg/service/configcache/service.go
+++ b/pkg/service/configcache/service.go
@@ -234,8 +234,16 @@ func (svc *Service) retrieveNodeConfig(ctx context.Context, host string, client 
 	if err != nil {
 		return config, errors.Wrap(err, "retrieve cluster host configuration")
 	}
+	dc, err := client.HostDatacenter(ctx, host)
+	if err != nil {
+		return config, errors.Wrap(err, "retrieve host Datacenter info")
+	}
+	rack, err := client.HostRack(ctx, host)
+	if err != nil {
+		return config, errors.Wrap(err, "retrieve host Rack info")
+	}
 
-	config, err = NewNodeConfig(c, nodeInfoResp, svc.secretsStore, host)
+	config, err = NewNodeConfig(c, nodeInfoResp, svc.secretsStore, host, dc, rack)
 	if err != nil {
 		return config, errors.Wrap(err, "retrieve cluster host configuration")
 	}

--- a/pkg/service/healthcheck/metrics.go
+++ b/pkg/service/healthcheck/metrics.go
@@ -12,6 +12,7 @@ const (
 	hostKey     = "host"
 	dcKey       = "dc"
 	pingTypeKey = "ping_type"
+	rackKey     = "rack"
 
 	metricBufferSize = 100
 )
@@ -22,42 +23,42 @@ var (
 		Subsystem: "healthcheck",
 		Name:      "cql_status",
 		Help:      "Host native port status. -2 stands for unavailable agent, -1 for unavailable Scylla and 1 for everything is fine.",
-	}, []string{clusterKey, hostKey})
+	}, []string{clusterKey, hostKey, dcKey, rackKey})
 
 	cqlRTT = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "scylla_manager",
 		Subsystem: "healthcheck",
 		Name:      "cql_rtt_ms",
 		Help:      "Host native port RTT.",
-	}, []string{clusterKey, hostKey})
+	}, []string{clusterKey, hostKey, dcKey, rackKey})
 
 	restStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "scylla_manager",
 		Subsystem: "healthcheck",
 		Name:      "rest_status",
 		Help:      "Host REST status. -2 stands for unavailable agent, -1 for unavailable Scylla and 1 for everything is fine.",
-	}, []string{clusterKey, hostKey})
+	}, []string{clusterKey, hostKey, dcKey, rackKey})
 
 	restRTT = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "scylla_manager",
 		Subsystem: "healthcheck",
 		Name:      "rest_rtt_ms",
 		Help:      "Host REST RTT.",
-	}, []string{clusterKey, hostKey})
+	}, []string{clusterKey, hostKey, dcKey, rackKey})
 
 	alternatorStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "scylla_manager",
 		Subsystem: "healthcheck",
 		Name:      "alternator_status",
 		Help:      "Host Alternator status. -2 stands for unavailable agent, -1 for unavailable Scylla and 1 for everything is fine.",
-	}, []string{clusterKey, hostKey})
+	}, []string{clusterKey, hostKey, dcKey, rackKey})
 
 	alternatorRTT = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "scylla_manager",
 		Subsystem: "healthcheck",
 		Name:      "alternator_rtt_ms",
 		Help:      "Host Alternator RTT.",
-	}, []string{clusterKey, hostKey})
+	}, []string{clusterKey, hostKey, dcKey, rackKey})
 )
 
 func init() {


### PR DESCRIPTION
Fixes #3908 

This PR adds rack and datacenter labels to `scylla-manager-healthcheck-*` metrics so that it's easier to navigate through them.

Config cache service is extended to call for `/snitch/datacenter` and `/snitch/rack` endpoints to get the information about node's dc and rack.

Scylla client is extended to support calls to `/snitch/rack`.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
