### PR TITLE
Fix backup progress deduplication

### DIFF
--- a/pkg/service/backup/service_deduplicate_integration_test.go
+++ b/pkg/service/backup/service_deduplicate_integration_test.go
@@ -61,6 +61,7 @@ func TestBackupPauseResumeOnDeduplicationStage(t *testing.T) {
 		var deduplicatedOnFreshBackup int64
 		after := func(skipped, uploaded, size int64) {
 			deduplicatedOnFreshBackup += skipped
+			originalTotalSize += size
 		}
 		defer h.service.RemoveDeduplicateTestHooks()
 		h.service.SetDeduplicateTestHooks(func() {}, after)

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -91,9 +91,11 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 		}
 		deduplicated := make([]string, 0, len(deduplicatedUUIDSSTables)+len(deduplicatedIntSSTables))
 
-		for _, fi := range deduplicatedUUIDSSTables {
-			d.Progress.Skipped += fi.Size
-			deduplicated = append(deduplicated, fi.Name)
+		for _, deduplicatedSet := range [][]fileInfo{deduplicatedIntSSTables, deduplicatedUUIDSSTables} {
+			for _, fi := range deduplicatedSet {
+				d.Progress.Skipped += fi.Size
+				deduplicated = append(deduplicated, fi.Name)
+			}
 		}
 		_, err = w.Client.RcloneDeletePathsInBatches(ctx, h.IP, d.Path, deduplicated, 1000)
 		if err != nil {

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -47,7 +47,7 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 		defer func(sd []snapshotDir) {
 			var skipped, uploaded, size int64
 			for _, v := range sd {
-				skipped += v.Progress.Skipped
+				skipped += v.SkippedBytesOffset
 				uploaded += v.Progress.Uploaded
 				size += v.Progress.Size
 			}


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylla-manager/issues/3959

This PR contains the following:
- includes deduplicated SSTables (by crc32) into the batch of files to delete
- updates size of deduplicated files into SkippedBytesOffset to show the progress correctly eventually
- fixes integration test of deduplication part

The problems above were find by https://jenkins.scylladb.com/job/scylla-staging/job/mikita/job/manager-master/job/sct-feature-test-backup/15/

Lack of deduplication based on crc32 could be observed on local runs (local docker setup disables UUID for generation ID).

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
