### PR TITLE
Typos

### DIFF
--- a/cloud/backup-cleaner/README.md
+++ b/cloud/backup-cleaner/README.md
@@ -62,4 +62,4 @@ sudo systemd-run --slice scylla-helper.slice ./delete.sh scylla-cloud-backup-XXX
 8. Validate the deletes were successful
 
 Look for errors `grep Errors -A 30 ./delete.sh.log`.
-Check the object count matches what we have in summary `grep Key ./delet.sh.log | wc -l`. 
+Check the object count matches what we have in summary `grep -c Key ./delete.sh.log`. 

--- a/dist/etc/scylla-manager-agent.yaml
+++ b/dist/etc/scylla-manager-agent.yaml
@@ -79,7 +79,7 @@
 
 # Backup S3 configuration.
 #
-# Note that when running in AWS Scylla Manger Agent can read hosts IAM role.
+# Note that when running in AWS Scylla Manager Agent can read hosts IAM role.
 # It's recommended to define access rules based on IAM roles.
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
 #
@@ -157,7 +157,7 @@
 
 # Backup GCS configuration.
 #
-# Note that when running in GCP Scylla Manger Agent can use instance
+# Note that when running in GCP Scylla Manager Agent can use instance
 # Service Account. It's recommended to define access rules based on IAM roles
 # attached to Service Account.
 # https://cloud.google.com/docs/authentication/production

--- a/dist/scripts/scyllamgr_setup
+++ b/dist/scripts/scyllamgr_setup
@@ -105,7 +105,7 @@ if [[ ${INTERACTIVE} == 1 ]]; then
     SETUP_SCYLLA=$?
     interactive_ask_service "Do you want the Scylla Manager service to automatically start when the node boots?" "Yes - automatically start Scylla Manager when the node boots. No - skip this step." "yes" &&:
     ENABLE_SERVICE=$?
-    interactive_ask_service "Do you want to enable Scylla Manger to check if there is a newer version of Scylla Manager available?" "Yes - start the Scylla Manager housekeeping service to check for a newer version. This check runs periodically. No - skips this step." "yes" &&:
+    interactive_ask_service "Do you want to enable Scylla Manager to check if there is a newer version of Scylla Manager available?" "Yes - start the Scylla Manager housekeeping service to check for a newer version. This check runs periodically. No - skips this step." "yes" &&:
     CHECK_FOR_UPDATES=$?
 fi
 

--- a/docs/source/backup/examples.rst
+++ b/docs/source/backup/examples.rst
@@ -127,7 +127,7 @@ replacing the ``-c`` cluster flag with your cluster's cluster name or ID and rep
 Create backup for archiving keyspace
 ------------------------------------
 
-We can archive any particular keyspace, and keep it in our bucket regardless of an already scheduled backups.
+We can archive any particular keyspace, and keep it in our bucket regardless of an already scheduled backup.
 
 **Procedure**
 

--- a/docs/source/backup/index.rst
+++ b/docs/source/backup/index.rst
@@ -41,7 +41,7 @@ Features
 Selecting tables and nodes to back up
 =====================================
 
-| The ``--keyspace``/``--dc`` flags allow for specifying glob patter for selecting tables/data centers to back up.
+| The ``--keyspace``/``--dc`` flags allow for specifying glob pattern for selecting tables/data centers to back up.
 | Even when table should be backed up according to ``--keyspace`` flag, but it is not replicated in specified data centers (``--dc`` flag), the table won't be backed up.
 
 | All currently down nodes are ignored for the backup procedure.

--- a/docs/source/health-check.rst
+++ b/docs/source/health-check.rst
@@ -112,7 +112,7 @@ Node status check also provides additional columns that show properties of the a
 - Memory - Total OS memory available
 - Uptime - How long the system has been running without restarts
 - Scylla - Version of Scylla server running on the node
-- Agent - Version Scylla Manger Agent running on the node
+- Agent - Version of Scylla Manager Agent running on the node
 - Host - UUID of the node
 - Address - IP address of the node
 

--- a/docs/source/sctool/download-files.rst
+++ b/docs/source/sctool/download-files.rst
@@ -2,7 +2,7 @@
 Download files
 ==============
 
-Scylla Manger Agent comes with a download-files subcommand that given a backup location can be used to:
+Scylla Manager Agent comes with a download-files subcommand that given a backup location can be used to:
 
 #. List clusters, datacenters and nodes.
 #. Search for snapshot tags.

--- a/docs/source/sctool/partials/sctool_backup_delete.yaml
+++ b/docs/source/sctool/partials/sctool_backup_delete.yaml
@@ -27,7 +27,7 @@ options:
       shorthand: T
       default_value: '[]'
       usage: |
-        A list of snapshot `tags` sparated by a comma.
+        A list of snapshot `tags` separated by a comma.
 inherited_options:
     - name: api-cert-file
       usage: |

--- a/docs/source/upgrade/index.rst
+++ b/docs/source/upgrade/index.rst
@@ -86,7 +86,7 @@ It should have a status of *“Active: inactive (dead)”*.
 Upgrade the ScyllaDB Manager Server and Client 
 ------------------------------------------------
 
-.. TODO This section must be udpated when the installation instructions are moved to the docs:
+.. TODO This section must be updated when the installation instructions are moved to the docs:
 .. The link should take the user to the relevant page in the docs, not to the Download Center.
 
 #. **On the Manager server**, update the Manager repo file. Go to ScyllaDB Manager in 

--- a/issues/fix-broken-SM-v3.1-release/README.md
+++ b/issues/fix-broken-SM-v3.1-release/README.md
@@ -2,7 +2,7 @@
 
 As described in this [issue](https://github.com/scylladb/scylla-manager/issues/3415), there was a time window
 when instead of releasing Scylla Manager 3.1, we mistakenly released the release candidate. \
-It means that anyone, who upgraded Scylla Manger to version 3.1 shortly after its release,
+It means that anyone, who upgraded Scylla Manager to version 3.1 shortly after its release,
 could experience various bugs (e.g. broken backup retention which could lead to growing storage space consumption).
 
 ## Verifying Scylla Manager version

--- a/pkg/callhome/doc.go
+++ b/pkg/callhome/doc.go
@@ -22,7 +22,7 @@ status - allowed values are
 
 per-machine-uuid - uuid of the machine that manager is running on
 the-registration-uuid - uuid of the registration unique to registered user
-scylla-manager-version - version of the Scylla Manger
+scylla-manager-version - version of the Scylla Manager
 rtype - linux distribution id (ubuntu, debian, rehl, centos, fedora, unknown)
 */
 package callhome

--- a/pkg/command/backup/backupdelete/res.yaml
+++ b/pkg/command/backup/backupdelete/res.yaml
@@ -9,4 +9,4 @@ long: |
   If the `--snapshot-tag` does not belong to the `--cluster`, the command will end with an error.
 
 snapshot-tag: |
-  A list of snapshot `tags` sparated by a comma.
+  A list of snapshot `tags` separated by a comma.

--- a/pkg/command/cluster/clusteradd/cmd_integration_api_test.go
+++ b/pkg/command/cluster/clusteradd/cmd_integration_api_test.go
@@ -83,7 +83,7 @@ func TestSctoolClusterAddIntegrationAPITest(t *testing.T) {
 			// given
 			client, err := managerclient.NewClient("http://localhost:5080/api/v1")
 			if err != nil {
-				t.Fatalf("Unable to create managerclient to consume managet HTTP API, err = {%v}", err)
+				t.Fatalf("Unable to create managerclient to consume manager HTTP API, err = {%v}", err)
 			}
 			cmd := exec.Command("./sctool.api-tests", tc.args...)
 			var stderr bytes.Buffer

--- a/pkg/command/cluster/clusterlist/cmd_integration_api_test.go
+++ b/pkg/command/cluster/clusterlist/cmd_integration_api_test.go
@@ -54,7 +54,7 @@ func TestSctoolClusterListIntegrationAPITest(t *testing.T) {
 			// given
 			client, err := managerclient.NewClient("http://localhost:5080/api/v1")
 			if err != nil {
-				t.Fatalf("Unable to create managerclient to consume managet HTTP API, err = {%v}", err)
+				t.Fatalf("Unable to create managerclient to consume manager HTTP API, err = {%v}", err)
 			}
 
 			clusterID, err := client.CreateCluster(context.Background(), tc.createCluster)

--- a/pkg/command/cluster/clusterupdate/cmd_integration_api_test.go
+++ b/pkg/command/cluster/clusterupdate/cmd_integration_api_test.go
@@ -105,7 +105,7 @@ func TestSctoolClusterUpdateIntegrationAPITest(t *testing.T) {
 			// given
 			client, err := managerclient.NewClient("http://localhost:5080/api/v1")
 			if err != nil {
-				t.Fatalf("Unable to create managerclient to consume managet HTTP API, err = {%v}", err)
+				t.Fatalf("Unable to create managerclient to consume manager HTTP API, err = {%v}", err)
 			}
 
 			fillCluster := func(c *models.Cluster) {

--- a/pkg/command/info/cmd_integration_api_test.go
+++ b/pkg/command/info/cmd_integration_api_test.go
@@ -24,7 +24,7 @@ const (
 func TestSctoolInfoLabelsIntegrationAPITest(t *testing.T) {
 	client, err := managerclient.NewClient("http://localhost:5080/api/v1")
 	if err != nil {
-		t.Fatalf("Unable to create managerclient to consume managet HTTP API, err = {%v}", err)
+		t.Fatalf("Unable to create managerclient to consume manager HTTP API, err = {%v}", err)
 	}
 
 	clusterID, err := client.CreateCluster(context.Background(), &models.Cluster{

--- a/pkg/command/repair/cmd_api_integration_test.go
+++ b/pkg/command/repair/cmd_api_integration_test.go
@@ -26,7 +26,7 @@ const (
 func TestSctoolRepairLabelIntegrationAPITest(t *testing.T) {
 	client, err := managerclient.NewClient("http://localhost:5080/api/v1")
 	if err != nil {
-		t.Fatalf("Unable to create managerclient to consume managet HTTP API, err = {%v}", err)
+		t.Fatalf("Unable to create managerclient to consume manager HTTP API, err = {%v}", err)
 	}
 
 	clusterID, err := client.CreateCluster(context.Background(), &models.Cluster{
@@ -71,7 +71,7 @@ func TestSctoolRepairLabelIntegrationAPITest(t *testing.T) {
 
 	task, err := client.GetTask(context.Background(), clusterID, "repair", taskID)
 	if err != nil {
-		t.Fatalf("Unable to get updated task wtih client, err = {%v}", err)
+		t.Fatalf("Unable to get updated task with client, err = {%v}", err)
 	}
 
 	if !maps.Equal(task.Labels, map[string]string{

--- a/pkg/command/tasks/cmd_integration_api_test.go
+++ b/pkg/command/tasks/cmd_integration_api_test.go
@@ -25,7 +25,7 @@ const (
 func TestSctoolTasksLabelsIntegrationAPITest(t *testing.T) {
 	client, err := managerclient.NewClient("http://localhost:5080/api/v1")
 	if err != nil {
-		t.Fatalf("Unable to create managerclient to consume managet HTTP API, err = {%v}", err)
+		t.Fatalf("Unable to create managerclient to consume manager HTTP API, err = {%v}", err)
 	}
 
 	clusterID, err := client.CreateCluster(context.Background(), &models.Cluster{

--- a/pkg/downloader/downloader.go
+++ b/pkg/downloader/downloader.go
@@ -146,7 +146,7 @@ func (d *Downloader) download(ctx context.Context, m backup.ManifestInfoWithCont
 	if usage.Free == nil {
 		d.logger.Info(ctx, "Failed to get free bytes", "usage", usage)
 	} else if *usage.Free < size {
-		return errors.Errorf("not enought disk space free %s required %s", fs.SizeSuffix(*usage.Free), fs.SizeSuffix(size))
+		return errors.Errorf("not enough disk space free %s required %s", fs.SizeSuffix(*usage.Free), fs.SizeSuffix(size))
 	}
 
 	f := func(i int) error {

--- a/pkg/scyllaclient/client_ping.go
+++ b/pkg/scyllaclient/client_ping.go
@@ -59,7 +59,7 @@ func (c *Client) GetNodesWithLocationAccess(ctx context.Context, nodes NodeStatu
 
 	if len(checked) == 0 {
 		combinedErr := multierr.Combine(nodeErr...)
-		return nil, errors.Wrapf(combinedErr, "no nodes with access to loaction: %s", remotePath)
+		return nil, errors.Wrapf(combinedErr, "no nodes with access to location: %s", remotePath)
 	}
 
 	return checked, nil

--- a/pkg/scyllaclient/client_rclone_agent_integration_test.go
+++ b/pkg/scyllaclient/client_rclone_agent_integration_test.go
@@ -169,7 +169,7 @@ func TestRcloneDeletePathsInBatchesAgentIntegration(t *testing.T) {
 						Printf("And: validate that the only files left are %v", tc.after)
 					}
 					if err := validateDir(ctx, client, testHost, remote, tc.after); err != nil {
-						t.Error(errors.Wrapf(err, "%s: validate dir conetnt after paths deletion", remote))
+						t.Error(errors.Wrapf(err, "%s: validate dir content after paths deletion", remote))
 					}
 				}
 

--- a/pkg/scyllaclient/client_rclone_integration_test.go
+++ b/pkg/scyllaclient/client_rclone_integration_test.go
@@ -56,7 +56,7 @@ func TestRcloneLocalToS3CopyDirIntegration(t *testing.T) {
 	}
 	Print("And: 2 files are transferred")
 	if len(job.Transferred) != 2 {
-		t.Errorf("Expected 2 transfered files got %d", len(job.Transferred))
+		t.Errorf("Expected 2 transferred files got %d", len(job.Transferred))
 	}
 	for _, r := range job.Transferred {
 		if r.Error != "" {

--- a/pkg/scyllaclient/client_rclone_test.go
+++ b/pkg/scyllaclient/client_rclone_test.go
@@ -376,7 +376,7 @@ func TestRcloneListDirIterCancelContext(t *testing.T) {
 
 	err := client.RcloneListDirIter(ctx, scyllaclienttest.TestHost, "rclonetest:list", nil, f)
 	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("RcloneListDirIter() error %s, expected context cancelation", err)
+		t.Fatalf("RcloneListDirIter() error %s, expected context cancellation", err)
 	}
 	if len(files) != 1 {
 		t.Fatalf("Files = %+v, expected one item", files)

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -338,7 +338,7 @@ func (c *Client) ShardCount(ctx context.Context, host string) (uint, error) {
 	}
 
 	if _, ok := metrics[metricName]; !ok {
-		return 0, errors.Errorf("scylla doest not expose %s metric", metricName)
+		return 0, errors.Errorf("scylla does not expose %s metric", metricName)
 	}
 
 	shards := len(metrics[metricName].Metric)
@@ -862,7 +862,7 @@ func (c *Client) TotalMemory(ctx context.Context, host string) (int64, error) {
 	}
 
 	if _, ok := metrics[metricName]; !ok {
-		return 0, errors.New("scylla doest not expose total memory metric")
+		return 0, errors.New("scylla does not expose total memory metric")
 	}
 
 	var totalMemory int64

--- a/pkg/scyllaclient/testdata/scylla_metrics/metrics
+++ b/pkg/scyllaclient/testdata/scylla_metrics/metrics
@@ -721,7 +721,7 @@ scylla_lsa_zones{instance="aacdf42015e4",shard="0",type="gauge"} 1.000000
 scylla_lsa_zones{instance="aacdf42015e4",shard="1",type="gauge"} 1.000000
 scylla_lsa_zones{instance="aacdf42015e4",shard="2",type="gauge"} 1.000000
 scylla_lsa_zones{instance="aacdf42015e4",shard="3",type="gauge"} 1.000000
-# HELP scylla_memory_allocated_memory Allocated memeory size in bytes
+# HELP scylla_memory_allocated_memory Allocated memory size in bytes
 # TYPE scylla_memory_allocated_memory counter
 scylla_memory_allocated_memory{instance="aacdf42015e4",shard="0",type="bytes"} 142356480
 scylla_memory_allocated_memory{instance="aacdf42015e4",shard="1",type="bytes"} 141131776
@@ -739,7 +739,7 @@ scylla_memory_dirty_bytes{instance="aacdf42015e4",shard="0",type="gauge"} 262144
 scylla_memory_dirty_bytes{instance="aacdf42015e4",shard="1",type="gauge"} 524288.000000
 scylla_memory_dirty_bytes{instance="aacdf42015e4",shard="2",type="gauge"} 1310720.000000
 scylla_memory_dirty_bytes{instance="aacdf42015e4",shard="3",type="gauge"} 1572864.000000
-# HELP scylla_memory_free_memory Free memeory size in bytes
+# HELP scylla_memory_free_memory Free memory size in bytes
 # TYPE scylla_memory_free_memory counter
 scylla_memory_free_memory{instance="aacdf42015e4",shard="0",type="bytes"} 7642271744
 scylla_memory_free_memory{instance="aacdf42015e4",shard="1",type="bytes"} 7643496448
@@ -805,7 +805,7 @@ scylla_memory_system_virtual_dirty_bytes{instance="aacdf42015e4",shard="0",type=
 scylla_memory_system_virtual_dirty_bytes{instance="aacdf42015e4",shard="1",type="gauge"} 524288.000000
 scylla_memory_system_virtual_dirty_bytes{instance="aacdf42015e4",shard="2",type="gauge"} 1310720.000000
 scylla_memory_system_virtual_dirty_bytes{instance="aacdf42015e4",shard="3",type="gauge"} 1572864.000000
-# HELP scylla_memory_total_memory Total memeory size in bytes
+# HELP scylla_memory_total_memory Total memory size in bytes
 # TYPE scylla_memory_total_memory counter
 scylla_memory_total_memory{instance="aacdf42015e4",shard="0",type="bytes"} 7784628224
 scylla_memory_total_memory{instance="aacdf42015e4",shard="1",type="bytes"} 7784628224

--- a/pkg/service/backup/README.md
+++ b/pkg/service/backup/README.md
@@ -20,7 +20,7 @@ Entrypoint on the backup service that starts the process of backing up the data 
 func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID, target Target) error
 ```
 
-`target.Target` defines the backup. It contains information about what to backup, where to backup, what is the retention policy, what paralellism must be used and how to rate limit.<br/>
+`target.Target` defines the backup. It contains information about what to backup, where to backup, what is the retention policy, what paralelism must be used and how to rate limit.<br/>
 
 ```go
 func (s *Service) GetTarget(ctx context.Context, clusterID uuid.UUID, properties json.RawMessage)

--- a/pkg/service/backup/README.md
+++ b/pkg/service/backup/README.md
@@ -20,7 +20,7 @@ Entrypoint on the backup service that starts the process of backing up the data 
 func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID, target Target) error
 ```
 
-`target.Target` defines the backup. It contains information about what to backup, where to backup, what is the retention policy, what paralelism must be used and how to rate limit.<br/>
+`target.Target` defines the backup. It contains information about what to backup, where to backup, what is the retention policy, what parallelism must be used and how to rate limit.<br/>
 
 ```go
 func (s *Service) GetTarget(ctx context.Context, clusterID uuid.UUID, properties json.RawMessage)

--- a/pkg/util/workerpool/pool.go
+++ b/pkg/util/workerpool/pool.go
@@ -15,7 +15,7 @@ type JobHandler[T, R any] interface {
 	Done(ctx context.Context)
 }
 
-// Pool allows for executing homogenous JobHandlers with ongoing control over parallelism.
+// Pool allows for executing homogeneous JobHandlers with ongoing control over parallelism.
 // Use Spawn, Kill and SetSize methods to change the current amount of workers.
 // Use Submit to submit new task and Results to wait for the results.
 // Pool can be closed with Close or drained with cancelling workers context.

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -55,7 +55,7 @@ build: ## Build custom docker image
 up: ## Start docker containers
 up:
 	@echo "==> Starting testing env with SCYLLA_VERSION=$(SCYLLA_VERSION) and IP_FAMILY=$(IP_FAMILY) and RAFT_SCHEMA=$(RAFT_SCHEMA) and TABLETS=$(TABLETS)"
-# Scylla bootstap proceedure have requirements that leads us to follow certain recipe:
+# Scylla bootstrap procedure have requirements that leads us to follow certain recipe:
 # 1. Spin up first node on the cluster
 # 2. Spin up and join other seed node, which is first node from DC2
 # 3. Spin up rest of the nodes

--- a/testing/scylla/scylla-sm.yaml
+++ b/testing/scylla/scylla-sm.yaml
@@ -24,7 +24,7 @@ num_tokens: 256
 
 # Directory where Scylla should store all its files, which are commitlog,
 # data, hints, view_hints and saved_caches subdirectories. All of these
-# subs can be overriden by the respective options below.
+# subs can be overridden by the respective options below.
 # If unset, the value defaults to /var/lib/scylla
 # workdir: /var/lib/scylla
 
@@ -385,7 +385,7 @@ commitlog_total_space_in_mb: -1
 # tombstones seen in memory so we can return them to the coordinator, which
 # will use them to make sure other replicas also know about the deleted rows.
 # With workloads that generate a lot of tombstones, this can cause performance
-# problems and even exaust the server heap.
+# problems and even exhaust the server heap.
 # (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
 # Adjust the thresholds here if you understand the dangers and want to
 # scan more tombstones anyway.  These thresholds may also be adjusted at runtime
@@ -397,7 +397,7 @@ commitlog_total_space_in_mb: -1
 # Increase if your rows are large, or if you have a very large
 # number of rows per partition.  The competing goals are these:
 #   1) a smaller granularity means more index entries are generated
-#      and looking up rows withing the partition by collation column
+#      and looking up rows within the partition by collation column
 #      is faster
 #   2) but, Scylla will keep the collation index in memory for hot
 #      rows (as part of the key cache), so a larger granularity means
@@ -498,7 +498,7 @@ commitlog_total_space_in_mb: -1
 # not met, performance and reliability can be degraded.
 #
 # These requirements include:
-#    - A filesystem with good support for aysnchronous I/O (AIO). Currently,
+#    - A filesystem with good support for asynchronous I/O (AIO). Currently,
 #      this means XFS.
 #
 # false: strict environment checks are in place; do not start if they are not met.
@@ -535,7 +535,7 @@ commitlog_total_space_in_mb: -1
 #  [shard0] [shard1] ... [shardN-1] [shard0] [shard1] ... [shardN-1] ...
 #
 # Scylla versions 1.6 and below used just one repetition of the pattern;
-# this intefered with data placement among nodes (vnodes).
+# this interfered with data placement among nodes (vnodes).
 #
 # Scylla versions 1.7 and above use 4096 repetitions of the pattern; this
 # provides for better data distribution.


### PR DESCRIPTION
Fixes around docs, testing code, error messages. Found by codespell. Skipped swagger, though I'm sure there are typos there as well.