### PR TITLE
Makefile: Fix version and tag creation for snapshots

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -19,13 +19,13 @@ $(shell echo $(RELEASE) > .release)
 GORELEASER := goreleaser --clean
 .PHONY: release
 release:
-	git tag $(VERSION_NAME) || true
+	git tag -f $(VERSION_NAME)
 	$(GORELEASER) $(publish) --skip=validate --config .goreleaser.yaml
 	$(GORELEASER) --skip=validate --config .goreleaser-docker.yaml
 
 .PHONY: snapshot
 snapshot:
-	GORELEASER_CURRENT_TAG=$(VERSION_NAME)
+	git tag -f $(VERSION_NAME)
 	$(GORELEASER) --snapshot --skip=publish --skip=validate --config .goreleaser.yaml
 	$(GORELEASER) --skip=validate --config .goreleaser-docker.yaml
 

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,5 +1,5 @@
 RELEASE      := 0.$(shell date +%Y%m%d).$(shell git describe --always)
-VERSION         ?=3.4.dev
+VERSION         ?=3.4.0-dev
 PUBLISH      := 0
 
 ifdef $$VERSION


### PR DESCRIPTION
This PR contains 2 commits:

https://github.com/scylladb/scylla-manager/commit/0813d708a66d0fc86dbba3040071edbbf475f6c5
During the automated branch creation, we mistakenly modified the dev
release to `3.4.dev` instead of `3.4.0-dev`

Fixing it

I will send a follow-up PR in Scylla-pkg to fix it on our side

https://github.com/scylladb/scylla-manager/commit/cb10ca21bd1bd653609686a258a331ce98ed260a

Today we have a complete mixup with the tags, causing an override during
builds. To avoid it, we should set a tag for each build (master or
release)

Refs: #3944

The main fix for this issue will be from the Scylla-pkg side