### PR TITLE
[backport 3.3] Makefile: Set tags also during snapshot builds

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -19,13 +19,13 @@ $(shell echo $(RELEASE) > .release)
 GORELEASER := goreleaser --clean
 .PHONY: release
 release:
-	git tag $(VERSION_NAME) || true
+	git tag -f $(VERSION_NAME)
 	$(GORELEASER) $(publish) --skip=validate --config .goreleaser.yaml
 	$(GORELEASER) --skip=validate --config .goreleaser-docker.yaml
 
 .PHONY: snapshot
 snapshot:
-	GORELEASER_CURRENT_TAG=$(VERSION_NAME)
+	git tag -f $(VERSION_NAME)
 	$(GORELEASER) --snapshot --skip=publish --skip=validate --config .goreleaser.yaml
 	$(GORELEASER) --skip=validate --config .goreleaser-docker.yaml
 


### PR DESCRIPTION
Today we have a complete mixup with the tags, causing an override during builds. To avoid it, we should set a tag for each build (master or release)

Refs: https://github.com/scylladb/scylla-manager/issues/3944

The main fix for this issue will be from Scylla-pkg side

(cherry picked from commit 0ad5692f07840928f49affc64bb37d59e7db739a)

