### PR TITLE
Don't rely SM side calculated replication strategy when filtering backup tables

### DIFF
--- a/pkg/scyllaclient/model.go
+++ b/pkg/scyllaclient/model.go
@@ -178,9 +178,11 @@ const (
 type Ring struct {
 	ReplicaTokens []ReplicaTokenRanges
 	HostDC        map[string]string
-	Replication   ReplicationStrategy
-	RF            int
-	DCrf          map[string]int // initialized only for NetworkTopologyStrategy
+	// Replication is not returned by Scylla, but assumed by SM.
+	// Don't use it for correctness.
+	Replication ReplicationStrategy
+	RF          int
+	DCrf        map[string]int // initialized only for NetworkTopologyStrategy
 }
 
 // Datacenters returns a list of datacenters the keyspace is replicated in.

--- a/pkg/scyllaclient/ring_describer.go
+++ b/pkg/scyllaclient/ring_describer.go
@@ -104,12 +104,12 @@ func getTabletKs(ctx context.Context, client *Client) *strset.Set {
 	out := strset.New()
 	// Assume that errors indicate that endpoints rejected 'replication' param,
 	// which means that given Scylla version does not support tablet API.
-	tablets, err := client.ReplicationKeyspaces(ctx, ReplicationTablet)
+	tablets, err := client.FilteredKeyspaces(ctx, KeyspaceTypeAll, ReplicationTablet)
 	if err != nil {
 		client.logger.Info(ctx, "Couldn't list tablet keyspaces", "error", err)
 		return out
 	}
-	vnodes, err := client.ReplicationKeyspaces(ctx, ReplicationVnode)
+	vnodes, err := client.FilteredKeyspaces(ctx, KeyspaceTypeAll, ReplicationVnode)
 	if err != nil {
 		client.logger.Info(ctx, "Couldn't list vnode keyspaces", "error", err)
 		return out

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -161,10 +161,15 @@ func (s *Service) targetFromProperties(ctx context.Context, clusterID uuid.UUID,
 		return Target{}, err
 	}
 
+	ks, err := client.KeyspacesByType(ctx)
+	if err != nil {
+		return Target{}, errors.Wrap(err, "get keyspaces by type")
+	}
+
 	filters := []tabFilter{
 		patternFilter{pattern: f},
 		dcFilter{dcs: strset.New(dcs...)},
-		localDataFilter{},
+		localDataFilter{keyspaces: ks},
 	}
 
 	// Try to add view filter - possible only when credentials are set


### PR DESCRIPTION
This PR adds a way to filter keyspaces by:
- all keyspaces
- user keyspaces
- non local keyspaces

And uses it in backup table filtering in order to fix #3989.

Fixes #3989