### PR TITLE
Stop testing dicts table

### DIFF
--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -322,9 +322,6 @@ func TestRestoreGetTargetUnitsViewsIntegration(t *testing.T) {
 			if checkAnyConstraint(t, h.Client, "< 1000") {
 				ignoreUnits = append(ignoreUnits, "system_replicated_keys")
 			}
-			if checkAnyConstraint(t, h.Client, "< 2024.2") {
-				ignoreUnits = append(ignoreUnits, "dicts")
-			}
 			if checkAnyConstraint(t, h.Client, ">= 6.0, < 2000", ">= 2024.2, > 1000") {
 				ignoreUnits = append(ignoreUnits,
 					"system_auth",

--- a/pkg/service/restore/testdata/get_target/continue_false.units.json
+++ b/pkg/service/restore/testdata/get_target/continue_false.units.json
@@ -72,11 +72,6 @@
         "size": 185891
       },
       {
-        "table": "dicts",
-        "tombstone_gc": "timeout",
-        "size": 0
-      },
-      {
         "table": "service_levels",
         "tombstone_gc": "timeout",
         "size": 0

--- a/pkg/service/restore/testdata/get_target/default_values.units.json
+++ b/pkg/service/restore/testdata/get_target/default_values.units.json
@@ -72,11 +72,6 @@
         "size": 185891
       },
       {
-        "table": "dicts",
-        "tombstone_gc": "timeout",
-        "size": 0
-      },
-      {
         "table": "service_levels",
         "tombstone_gc": "timeout",
         "size": 0


### PR DESCRIPTION
The dicts table is being dropped for now. See:
https://github.com/scylladb/scylla-enterprise/pull/4570 https://github.com/scylladb/scylla-enterprise/pull/4591 https://github.com/scylladb/scylla-enterprise/pull/4592

Fixes #4004
