### PR TITLE
manager-build: fix configuration to match new docker version

### DIFF
--- a/dist/.goreleaser-docker.yaml
+++ b/dist/.goreleaser-docker.yaml
@@ -1,12 +1,11 @@
 project_name: scylla-manager
 dist: release-docker
+version: 2
 builds:
 - skip: true
 
 dockers:
   - ids:
-    - server
-    - client
     use: docker
     goos: linux
     goarch: amd64
@@ -17,13 +16,8 @@ dockers:
     extra_files:
       - docker/scylla-manager.yaml
       - release
-    build_flag_templates:
-    - "--build-arg=BASE_IMAGE=ubuntu:22.04"
-    - "--build-arg=ARCH=amd64"
 
   - ids:
-    - server
-    - client
     use: docker
     goos: linux
     goarch: arm64
@@ -35,11 +29,10 @@ dockers:
       - docker/scylla-manager.yaml
       - release/
     build_flag_templates:
-    - "--build-arg=BASE_IMAGE=arm64v8/ubuntu:22.04"
-    - "--build-arg=ARCH=arm64"
+      - "--build-arg=ARCH=arm64"
+      - "--platform=linux/arm64"
 
   - ids:
-    - agent
     use: docker
     goos: linux
     goarch: amd64
@@ -50,12 +43,8 @@ dockers:
     extra_files:
       - docker/scylla-manager.yaml
       - release
-    build_flag_templates:
-    - "--build-arg=BASE_IMAGE=ubuntu:22.04"
-    - "--build-arg=ARCH=amd64"
 
   - ids:
-    - agent
     use: docker
     goos: linux
     goarch: arm64
@@ -67,8 +56,8 @@ dockers:
       - docker/scylla-manager.yaml
       - release
     build_flag_templates:
-    - "--build-arg=BASE_IMAGE=arm64v8/ubuntu:22.04"
-    - "--build-arg=ARCH=arm64"
+      - "--build-arg=ARCH=arm64"
+      - "--platform=linux/arm64"
 
 docker_manifests:
   - id: scylla-manager

--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -1,5 +1,6 @@
 project_name: scylla-manager
 dist: release
+version: 2
 
 changelog:
   sort: asc
@@ -11,7 +12,7 @@ changelog:
       - '^testing:'
 
 snapshot:
-    name_template: '{{ .Version }}-SNAPSHOT'
+    version_template: '{{ .Version }}-SNAPSHOT'
 
 builds:
   - id: server

--- a/dist/docker/scylla-manager-agent.dockerfile
+++ b/dist/docker/scylla-manager-agent.dockerfile
@@ -1,7 +1,5 @@
-ARG BASE_IMAGE
-
-FROM $BASE_IMAGE
-ARG ARCH
+FROM ubuntu
+ARG ARCH=amd64
 
 RUN apt-get update && \
     apt-get -y upgrade && \
@@ -14,5 +12,5 @@ COPY release/scylla-manager-agent*$ARCH.deb /
 RUN dpkg -i scylla-manager-agent*$ARCH.deb && rm /scylla-manager-agent*.deb
 
 USER scylla-manager
-ENV HOME /var/lib/scylla-manager/
+ENV HOME=/var/lib/scylla-manager/
 ENTRYPOINT ["/usr/bin/scylla-manager-agent"]

--- a/dist/docker/scylla-manager.dockerfile
+++ b/dist/docker/scylla-manager.dockerfile
@@ -1,7 +1,6 @@
-ARG BASE_IMAGE
+FROM ubuntu
+ARG ARCH=amd64
 
-FROM $BASE_IMAGE
-ARG ARCH
 RUN apt-get update && \
     apt-get -y upgrade && \
     apt-get install -y --no-install-recommends ca-certificates && \
@@ -14,5 +13,5 @@ RUN dpkg -i scylla-manager-*$ARCH.deb && rm /scylla-manager-*.deb
 COPY docker/scylla-manager.yaml /etc/scylla-manager/
 
 USER scylla-manager
-ENV HOME /var/lib/scylla-manager/
+ENV HOME=/var/lib/scylla-manager/
 ENTRYPOINT ["/usr/bin/scylla-manager"]


### PR DESCRIPTION
Following the upgrade of all Jenkins nodes to Fedora40, a few configuration issues popped up
