### PR TITLE
Improve schema backup

### DIFF
--- a/pkg/command/backup/cmd.go
+++ b/pkg/command/backup/cmd.go
@@ -37,6 +37,7 @@ type command struct {
 	dryRun           bool
 	showTables       bool
 	purgeOnly        bool
+	skipSchema       bool
 }
 
 func NewCommand(client *managerclient.Client) *cobra.Command {
@@ -88,6 +89,7 @@ func (cmd *command) init() {
 	w.Unwrap().BoolVar(&cmd.dryRun, "dry-run", false, "")
 	w.Unwrap().BoolVar(&cmd.showTables, "show-tables", false, "")
 	w.Unwrap().BoolVar(&cmd.purgeOnly, "purge-only", false, "")
+	w.Unwrap().BoolVar(&cmd.skipSchema, "skip-schema", false, "")
 }
 
 func (cmd *command) run(args []string) error {
@@ -152,6 +154,10 @@ func (cmd *command) run(args []string) error {
 	}
 	if cmd.Flag("purge-only").Changed {
 		props["purge_only"] = cmd.purgeOnly
+		ok = true
+	}
+	if cmd.Flag("skip-schema").Changed {
+		props["skip_schema"] = cmd.purgeOnly
 		ok = true
 	}
 

--- a/pkg/command/backup/res.yaml
+++ b/pkg/command/backup/res.yaml
@@ -39,3 +39,10 @@ show-tables: |
 
 purge-only: |
   Run the backup cleanup only.
+
+skip-schema: |
+  Don't backup schema.
+  For ScyllaDB versions starting at 6.0 and 2024.2, SM requires CQL credentials to back up the schema.
+  CQL Credentials can be added with 'sctool cluster update --username --password' command.
+  This flag can be used to skip this step and allow for backing up user data without providing SM with CQL credentials.
+  Note that it's impossible to restore schema from such backups.

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -706,7 +706,10 @@ func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID
 			return w.Snapshot(ctx, hi, target.SnapshotParallel)
 		},
 		StageAwaitSchema: func() error {
-			return w.DumpSchema(ctx, hi, s.clusterSession)
+			if !target.SkipSchema {
+				return w.DumpSchema(ctx, hi, s.clusterSession)
+			}
+			return nil
 		},
 		StageIndex: func() error {
 			return w.Index(ctx, hi, target.UploadParallel)


### PR DESCRIPTION
This PR makes a several changes regarding schema backup.
They aim to increase schema backup safety by making it impossible to skip schema backup by simply not providing CQL creds (which was possible for Scylla version >= 6.0). Skipping schema backup is still possible (some users might not want to provide the CQL creds), but requires user to deliberately add the new `--skip-schema` flag. 
They also make the schema backup more robust for multi Scylla version cluster, or a cluster where SM does not have CQL access to all of the nodes.  

Fixes #4007
Fixes #3995