### PR TITLE
test 6.1

### DIFF
--- a/.github/cfg/integration-test-cfg.yaml
+++ b/.github/cfg/integration-test-cfg.yaml
@@ -1,39 +1,39 @@
-- scylla-version: scylla-enterprise:2023.1.9
+- scylla-version: scylla-enterprise:2023.1.11
   ip-family: IPV4
   raft-schema: disabled
   tablets: none
 
-- scylla-version: scylla-enterprise:2023.1.9
+- scylla-version: scylla-enterprise:2023.1.11
   ip-family: IPV4
   raft-schema: enabled
   tablets: none
 
-- scylla-version: scylla-enterprise:2023.1.9
+- scylla-version: scylla-enterprise:2023.1.11
   ip-family: IPV6
   raft-schema: enabled
   tablets: none
 
-- scylla-version: scylla-enterprise:2024.1.5
+- scylla-version: scylla-enterprise:2024.1.9
   ip-family: IPV4
   raft-schema: none
   tablets: none
 
-- scylla-version: scylla-enterprise:2024.1.5
+- scylla-version: scylla-enterprise:2024.1.9
   ip-family: IPV6
   raft-schema: none
   tablets: none
 
-- scylla-version: scylla:6.0.1
+- scylla-version: scylla:6.1.1
   ip-family: IPV4
   raft-schema: none
   tablets: disabled
 
-- scylla-version: scylla:6.0.1
+- scylla-version: scylla:6.1.1
   ip-family: IPV4
   raft-schema: none
   tablets: enabled
 
-- scylla-version: scylla:6.0.1
+- scylla-version: scylla:6.1.1
   ip-family: IPV6
   raft-schema: none
   tablets: enabled

--- a/.github/workflows/integration-tests-2023.1.11-IPV4-raftschema.yaml
+++ b/.github/workflows/integration-tests-2023.1.11-IPV4-raftschema.yaml
@@ -2,10 +2,10 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla:6.0.1
-    ip-family: IPV6
-    raft-schema: none
-    tablets: enabled
+    scylla-version: scylla-enterprise:2023.1.11
+    ip-family: IPV4
+    raft-schema: enabled
+    tablets: none
 jobs:
     backup:
         name: Test backup
@@ -99,7 +99,7 @@ jobs:
               run: make pkg-integration-test PKG=./pkg/store
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
-name: integration-tests-6.0.1-IPV6-tablets
+name: integration-tests-2023.1.11-IPV4-raftschema
 "on":
     pull_request:
         types:

--- a/.github/workflows/integration-tests-2023.1.11-IPV4.yaml
+++ b/.github/workflows/integration-tests-2023.1.11-IPV4.yaml
@@ -2,9 +2,9 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla-enterprise:2024.1.5
+    scylla-version: scylla-enterprise:2023.1.11
     ip-family: IPV4
-    raft-schema: none
+    raft-schema: disabled
     tablets: none
 jobs:
     backup:
@@ -99,7 +99,7 @@ jobs:
               run: make pkg-integration-test PKG=./pkg/store
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
-name: integration-tests-2024.1.5-IPV4
+name: integration-tests-2023.1.11-IPV4
 "on":
     pull_request:
         types:

--- a/.github/workflows/integration-tests-2023.1.11-IPV6-raftschema.yaml
+++ b/.github/workflows/integration-tests-2023.1.11-IPV6-raftschema.yaml
@@ -2,8 +2,8 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla-enterprise:2023.1.9
-    ip-family: IPV4
+    scylla-version: scylla-enterprise:2023.1.11
+    ip-family: IPV6
     raft-schema: enabled
     tablets: none
 jobs:
@@ -99,7 +99,7 @@ jobs:
               run: make pkg-integration-test PKG=./pkg/store
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
-name: integration-tests-2023.1.9-IPV4-raftschema
+name: integration-tests-2023.1.11-IPV6-raftschema
 "on":
     pull_request:
         types:

--- a/.github/workflows/integration-tests-2024.1.9-IPV4.yaml
+++ b/.github/workflows/integration-tests-2024.1.9-IPV4.yaml
@@ -2,10 +2,10 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla:6.0.1
+    scylla-version: scylla-enterprise:2024.1.9
     ip-family: IPV4
     raft-schema: none
-    tablets: disabled
+    tablets: none
 jobs:
     backup:
         name: Test backup
@@ -99,7 +99,7 @@ jobs:
               run: make pkg-integration-test PKG=./pkg/store
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
-name: integration-tests-6.0.1-IPV4
+name: integration-tests-2024.1.9-IPV4
 "on":
     pull_request:
         types:

--- a/.github/workflows/integration-tests-2024.1.9-IPV6.yaml
+++ b/.github/workflows/integration-tests-2024.1.9-IPV6.yaml
@@ -2,10 +2,10 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla:6.0.1
-    ip-family: IPV4
+    scylla-version: scylla-enterprise:2024.1.9
+    ip-family: IPV6
     raft-schema: none
-    tablets: enabled
+    tablets: none
 jobs:
     backup:
         name: Test backup
@@ -99,7 +99,7 @@ jobs:
               run: make pkg-integration-test PKG=./pkg/store
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
-name: integration-tests-6.0.1-IPV4-tablets
+name: integration-tests-2024.1.9-IPV6
 "on":
     pull_request:
         types:

--- a/.github/workflows/integration-tests-6.1.1-IPV4-tablets.yaml
+++ b/.github/workflows/integration-tests-6.1.1-IPV4-tablets.yaml
@@ -2,10 +2,10 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla-enterprise:2023.1.9
+    scylla-version: scylla:6.1.1
     ip-family: IPV4
-    raft-schema: disabled
-    tablets: none
+    raft-schema: none
+    tablets: enabled
 jobs:
     backup:
         name: Test backup
@@ -99,7 +99,7 @@ jobs:
               run: make pkg-integration-test PKG=./pkg/store
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
-name: integration-tests-2023.1.9-IPV4
+name: integration-tests-6.1.1-IPV4-tablets
 "on":
     pull_request:
         types:

--- a/.github/workflows/integration-tests-6.1.1-IPV4.yaml
+++ b/.github/workflows/integration-tests-6.1.1-IPV4.yaml
@@ -2,10 +2,10 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla-enterprise:2024.1.5
-    ip-family: IPV6
+    scylla-version: scylla:6.1.1
+    ip-family: IPV4
     raft-schema: none
-    tablets: none
+    tablets: disabled
 jobs:
     backup:
         name: Test backup
@@ -99,7 +99,7 @@ jobs:
               run: make pkg-integration-test PKG=./pkg/store
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
-name: integration-tests-2024.1.5-IPV6
+name: integration-tests-6.1.1-IPV4
 "on":
     pull_request:
         types:

--- a/.github/workflows/integration-tests-6.1.1-IPV6-tablets.yaml
+++ b/.github/workflows/integration-tests-6.1.1-IPV6-tablets.yaml
@@ -2,10 +2,10 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla-enterprise:2023.1.9
+    scylla-version: scylla:6.1.1
     ip-family: IPV6
-    raft-schema: enabled
-    tablets: none
+    raft-schema: none
+    tablets: enabled
 jobs:
     backup:
         name: Test backup
@@ -99,7 +99,7 @@ jobs:
               run: make pkg-integration-test PKG=./pkg/store
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
-name: integration-tests-2023.1.9-IPV6-raftschema
+name: integration-tests-6.1.1-IPV6-tablets
 "on":
     pull_request:
         types:

--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ Scylla Manager consists of tree components:
 
 ## Scylla integration status
 
-| ScyllaDB version      | workflows                                                                                                                              | Limitations                                                                                                                                           |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **latest-enterprise** | ![integration-tests-latest-enterprise-IPV4]<br/>![integration-tests-latest-enterprise-IPV4-tablets]                                    | Restoration of **Authentication** and **Service Levels** is not supported<br/>Restoration of schema containing **Alternator** tables is not supported |
-| **6.0.1**             | ![integration-tests-6.0.1-IPV4]<br/>![integration-tests-6.0.1-IPV4-tablets]<br/>![integration-tests-6.0.1-IPV6-tablets]                | Restoration of **Authentication** and **Service Levels** is not supported<br/>Restoration of schema containing **Alternator** tables is not supported |
-| **2024.1.5**          | ![integration-tests-2024.1.5-IPV4]<br/>![integration-tests-2024.1.5-IPV6]                                                              | Restoration of schema into cluster with `consistant_cluster_management: true` is not supported                                                        |
-| **2023.1.9**          | ![integration-tests-2023.1.9-IPV4]<br/>![integration-tests-2023.1.9-IPV4-raftschema]<br/>![integration-tests-2023.1.9-IPV6-raftschema] | Restoration of schema into cluster with `consistant_cluster_management: true` is not supported                                                        |
+| ScyllaDB version      | Workflows                                                                                                                                 | Limitations                                                                                                                                           |
+|-----------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **2024.1.9**          | ![integration-tests-2024.1.9-IPV4]<br/>![integration-tests-2024.1.9-IPV6]                                                                 | Restoration of schema into cluster with `consistant_cluster_management: true` is not supported                                                        |
+| **2023.1.11**         | ![integration-tests-2023.1.11-IPV4]<br/>![integration-tests-2023.1.11-IPV4-raftschema]<br/>![integration-tests-2023.1.11-IPV6-raftschema] | Restoration of schema into cluster with `consistant_cluster_management: true` is not supported                                                        |
+| **6.1.1**             | ![integration-tests-6.1.1-IPV4]<br/>![integration-tests-6.1.1-IPV4-tablets]<br/>![integration-tests-6.1.1-IPV6-tablets]                   | Restoration of **Authentication** and **Service Levels** is not supported<br/>Restoration of schema containing **Alternator** tables is not supported |
+| **latest-enterprise** | ![integration-tests-latest-enterprise-IPV4]<br/>![integration-tests-latest-enterprise-IPV4-tablets]                                       | Restoration of **Authentication** and **Service Levels** is not supported<br/>Restoration of schema containing **Alternator** tables is not supported |
 
-[integration-tests-2023.1.9-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2023.1.9-IPV4.yaml/badge.svg?branch=master
-[integration-tests-2023.1.9-IPV4-raftschema]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2023.1.9-IPV4-raftschema.yaml/badge.svg?branch=master
-[integration-tests-2023.1.9-IPV6-raftschema]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2023.1.9-IPV6-raftschema.yaml/badge.svg?branch=master
-[integration-tests-2024.1.5-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2024.1.5-IPV4.yaml/badge.svg?branch=master
-[integration-tests-2024.1.5-IPV6]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2024.1.5-IPV6.yaml/badge.svg?branch=master
-[integration-tests-6.0.1-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-6.0.1-IPV4.yaml/badge.svg?branch=master
-[integration-tests-6.0.1-IPV4-tablets]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-6.0.1-IPV4-tablets.yaml/badge.svg?branch=master
-[integration-tests-6.0.1-IPV6-tablets]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-6.0.1-IPV6-tablets.yaml/badge.svg?branch=master
+[integration-tests-2024.1.9-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2024.1.9-IPV4.yaml/badge.svg?branch=master
+[integration-tests-2024.1.9-IPV6]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2024.1.9-IPV6.yaml/badge.svg?branch=master
+[integration-tests-2023.1.11-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2023.1.11-IPV4.yaml/badge.svg?branch=master
+[integration-tests-2023.1.11-IPV4-raftschema]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2023.1.11-IPV4-raftschema.yaml/badge.svg?branch=master
+[integration-tests-2023.1.11-IPV6-raftschema]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2023.1.11-IPV6-raftschema.yaml/badge.svg?branch=master
+[integration-tests-6.1.1-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-6.1.1-IPV4.yaml/badge.svg?branch=master
+[integration-tests-6.1.1-IPV4-tablets]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-6.1.1-IPV4-tablets.yaml/badge.svg?branch=master
+[integration-tests-6.1.1-IPV6-tablets]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-6.1.1-IPV6-tablets.yaml/badge.svg?branch=master
 [integration-tests-latest-enterprise-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-latest-enterprise-IPV4.yaml/badge.svg?branch=master
 [integration-tests-latest-enterprise-IPV4-tablets]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-latest-enterprise-IPV4-tablets.yaml/badge.svg?branch=master
 


### PR DESCRIPTION
This PR bums tested Scylla versions to the newest patch release.
It also stops testing Scylla 6.0 in favor of Scylla 6.1.

Rebased on #4034.