### PR TITLE
Don't add cluster to SM DB before validation finishes

### DIFF
--- a/pkg/scyllaclient/config.go
+++ b/pkg/scyllaclient/config.go
@@ -4,6 +4,7 @@ package scyllaclient
 
 import (
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
@@ -110,6 +111,9 @@ func (c Config) Validate() error {
 	var err error
 	if len(c.Hosts) == 0 {
 		err = multierr.Append(err, errors.New("missing hosts"))
+	}
+	if slices.Contains(c.Hosts, "") {
+		err = multierr.Append(err, errors.New("empty host"))
 	}
 	if c.Port == "" {
 		err = multierr.Append(err, errors.New("missing port"))

--- a/pkg/scyllaclient/hostpool.go
+++ b/pkg/scyllaclient/hostpool.go
@@ -29,6 +29,9 @@ func hostPool(next http.RoundTripper, pool hostpool.HostPool, port string) http.
 		// Get host from pool
 		if !ok {
 			hpr = pool.Get()
+			if hpr == nil {
+				return nil, errors.New("empty host pool response")
+			}
 			h = hpr.Host()
 		}
 

--- a/pkg/service/cluster/service.go
+++ b/pkg/service/cluster/service.go
@@ -483,9 +483,11 @@ func (s *Service) validateHostsConnectivity(ctx context.Context, c *Cluster) err
 		return errors.Wrap(err, "load known hosts")
 	}
 
-	if err := s.discoverAndSetClusterHosts(ctx, c); err != nil {
-		return errors.Wrap(err, "discover and set cluster hosts")
+	knownHosts, err := s.discoverClusterHosts(ctx, c)
+	if err != nil {
+		return errors.Wrap(err, "discover cluster hosts")
 	}
+	c.KnownHosts = knownHosts
 
 	config := s.clientConfig(c)
 	client, err := scyllaclient.NewClient(config, s.logger.Named("client"))


### PR DESCRIPTION
Commit https://github.com/scylladb/scylla-manager/commit/5bf6b35699c0645ba8598a53516e03ba7e01383f introduced a bug that when adding cluster to SM finished with error,
cluster was still saved in SM DB, but only with the ID and known hosts fields.
That's because method validateHostsConnectivity used discoverAndSetClusterHosts
instead of discoverClusterHosts, which happened before inserting cluster to SM DB.

In case client was mistakenly initialized with "" host, getting host from the pool would panic.
This should be replaced with a simple error. This PR adds additional validation to client config,
which prohibits specifying empty host there. It also makes host pool return an error instead of panic
in case of invalid host pool response.

This PR also includes testes for mentioned issues (validated that those tests weren't passing without the fixes).

Fixes #4028
