### PR TITLE
Use creds in alternator tests

### DIFF
--- a/pkg/ping/dynamoping/dynamoping_integration_test.go
+++ b/pkg/ping/dynamoping/dynamoping_integration_test.go
@@ -7,17 +7,20 @@ package dynamoping
 
 import (
 	"context"
-	"github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"testing"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 
 	_ "github.com/scylladb/scylla-manager/v3/pkg/testutils"
 )
 
 func TestPingIntegration(t *testing.T) {
 	config := Config{
-		Addr:    "http://" + testconfig.ManagedClusterHost() + ":8000",
-		Timeout: 250 * time.Millisecond,
+		Addr:                   "http://" + testconfig.ManagedClusterHost() + ":8000",
+		Timeout:                250 * time.Millisecond,
+		RequiresAuthentication: true,
 	}
 
 	t.Run("simple", func(t *testing.T) {
@@ -31,6 +34,9 @@ func TestPingIntegration(t *testing.T) {
 	t.Run("query", func(t *testing.T) {
 		d, err := QueryPing(context.Background(), config)
 		if err != nil {
+			if errors.Is(err, ErrAlternatorQueryPingNotSupported) {
+				t.Skip(ErrAlternatorQueryPingNotSupported)
+			}
 			t.Error(err)
 		}
 		t.Logf("QueryPing() = %s", d)

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -2402,8 +2402,10 @@ func TestBackupAlternatorIntegration(t *testing.T) {
 		clusterSession = CreateSessionAndDropAllKeyspaces(t, h.Client)
 	)
 
-	CreateAlternatorTable(t, ManagedClusterHost(), alternatorPort, testTable)
-	FillAlternatorTableWithOneRow(t, ManagedClusterHost(), alternatorPort, testTable)
+	accessKeyID, secretAccessKey := CreateAlternatorUser(t, clusterSession, "")
+	svc := CreateDynamoDBService(t, ManagedClusterHost(), alternatorPort, accessKeyID, secretAccessKey)
+	CreateAlternatorTable(t, svc, testTable)
+	FillAlternatorTableWithOneRow(t, svc, testTable)
 
 	Print("When: validate data insertion")
 	selectStmt := fmt.Sprintf("SELECT COUNT(*) FROM %q.%q WHERE key='test'", testKeyspace, testTable)

--- a/pkg/service/healthcheck/service.go
+++ b/pkg/service/healthcheck/service.go
@@ -300,15 +300,18 @@ func (s *Service) pingAlternator(ctx context.Context, _ uuid.UUID, host string, 
 		return 0, nil
 	}
 
-	pingFunc := dynamoping.SimplePing
-	if queryPing, err := ni.SupportsAlternatorQuery(); err == nil && queryPing {
-		pingFunc = dynamoping.QueryPing
-	}
-
 	addr := ni.AlternatorAddr(host)
 	config := dynamoping.Config{
-		Addr:    addr,
-		Timeout: timeout,
+		Addr:                   addr,
+		Timeout:                timeout,
+		RequiresAuthentication: ni.AlternatorEnforceAuthorization,
+	}
+
+	pingFunc := dynamoping.SimplePing
+	if !config.RequiresAuthentication {
+		if queryPing, err := ni.SupportsAlternatorQuery(); err == nil && queryPing {
+			pingFunc = dynamoping.QueryPing
+		}
 	}
 
 	tlsConfig := ni.AlternatorTLSConfig()

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -2042,8 +2042,11 @@ func TestServiceRepairIntegration(t *testing.T) {
 		)
 
 		Print("When: create alternator table with 1 row")
-		CreateAlternatorTable(t, ManagedClusterHost(), alternatorPort, testTable)
-		FillAlternatorTableWithOneRow(t, ManagedClusterHost(), alternatorPort, testTable)
+
+		accessKeyID, secretAccessKey := CreateAlternatorUser(t, clusterSession, "")
+		svc := CreateDynamoDBService(t, ManagedClusterHost(), alternatorPort, accessKeyID, secretAccessKey)
+		CreateAlternatorTable(t, svc, testTable)
+		FillAlternatorTableWithOneRow(t, svc, testTable)
 		defer dropKeyspace(t, clusterSession, testKeyspace)
 
 		h := newRepairTestHelper(t, session, defaultConfig())

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -1461,8 +1461,10 @@ func restoreAlternator(t *testing.T, schemaTarget, tablesTarget Target, testKeys
 	createUser(t, dstSession, user, "pass")
 	dstH = newRestoreTestHelper(t, mgrSession, cfg, schemaTarget.Location[0], nil, user, "pass")
 
-	CreateAlternatorTable(t, ManagedSecondClusterHosts()[0], alternatorPort, testTable)
-	FillAlternatorTableWithOneRow(t, ManagedSecondClusterHosts()[0], alternatorPort, testTable)
+	accessKeyID, secretAccessKey := CreateAlternatorUser(t, srcSession, "")
+	svc := CreateDynamoDBService(t, ManagedSecondClusterHosts()[0], alternatorPort, accessKeyID, secretAccessKey)
+	CreateAlternatorTable(t, svc, testTable)
+	FillAlternatorTableWithOneRow(t, svc, testTable)
 
 	schemaTarget.SnapshotTag = srcH.simpleBackup(schemaTarget.Location[0])
 

--- a/testing/scylla/config/scylla.yaml
+++ b/testing/scylla/config/scylla.yaml
@@ -644,6 +644,7 @@ api_ui_dir: /usr/lib/scylla/swagger-ui/dist/
 api_doc_dir: /usr/lib/scylla/api/api-doc/
 alternator_port: 8000
 alternator_write_isolation: only_rmw_uses_lwt
+alternator_enforce_authorization: true
 enable_ipv6_dns_lookup: true
 
 uuid_sstable_identifiers_enabled: false


### PR DESCRIPTION
This PR does a few things:
- it enforces authentication on alternator queries (https://github.com/scylladb/scylla-enterprise/issues/4708)
- it uses creds for authenticating alternator API in pkg tests (#4032)
- it replaces alternator query ping with simple ping when authentication is enforced (#4036)

Fixes #4032
Ref https://github.com/scylladb/scylla-enterprise/issues/4708
Ref #4036
