### PR TITLE
Restore improvement: batch

### DIFF
--- a/docs/source/sctool/partials/sctool_restore.yaml
+++ b/docs/source/sctool/partials/sctool_restore.yaml
@@ -12,6 +12,7 @@ options:
       usage: |
         Number of SSTables per shard to process in one request by one node.
         Increasing the default batch size might significantly increase restore performance, as only one shard can work on restoring a single SSTable bundle.
+        Set to 0 for best performance (batches will contain sstables of total size up to 5% of expected total node workload).
     - name: cluster
       shorthand: c
       usage: |

--- a/docs/source/sctool/partials/sctool_restore_update.yaml
+++ b/docs/source/sctool/partials/sctool_restore_update.yaml
@@ -10,6 +10,7 @@ options:
       usage: |
         Number of SSTables per shard to process in one request by one node.
         Increasing the default batch size might significantly increase restore performance, as only one shard can work on restoring a single SSTable bundle.
+        Set to 0 for best performance (batches will contain sstables of total size up to 5% of expected total node workload).
     - name: cluster
       shorthand: c
       usage: |

--- a/pkg/command/restore/res.yaml
+++ b/pkg/command/restore/res.yaml
@@ -27,6 +27,7 @@ snapshot-tag: |
 batch-size: |
   Number of SSTables per shard to process in one request by one node.
   Increasing the default batch size might significantly increase restore performance, as only one shard can work on restoring a single SSTable bundle.
+  Set to 0 for best performance (batches will contain sstables of total size up to 5% of expected total node workload).
 
 parallel: |
   The maximum number of Scylla restore jobs that can be run at the same time (on different SSTables).

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -417,6 +417,9 @@ func (c *Client) HostsShardCount(ctx context.Context, hosts []string) (map[strin
 
 	out := make(map[string]uint)
 	for i, h := range hosts {
+		if shards[i] == 0 {
+			return nil, errors.Errorf("host %s reported 0 shard count", h)
+		}
 		out[h] = shards[i]
 	}
 	return out, nil

--- a/pkg/service/restore/batch.go
+++ b/pkg/service/restore/batch.go
@@ -207,6 +207,13 @@ func (b *batchDispatcher) createBatch(l *LocationWorkload, t *TableWorkload, dir
 	if i == 0 {
 		return batch{}, false
 	}
+	// Extend batch if it was to leave less than
+	// 1 sstable per shard for the next one.
+	if len(dir.SSTables)-i < int(shardCnt) {
+		for ; i < len(dir.SSTables); i++ {
+			size += dir.SSTables[i].Size
+		}
+	}
 
 	sstables := dir.SSTables[:i]
 	dir.SSTables = dir.SSTables[i:]

--- a/pkg/service/restore/batch_test.go
+++ b/pkg/service/restore/batch_test.go
@@ -1,0 +1,142 @@
+// Copyright (C) 2024 ScyllaDB
+
+package restore
+
+import (
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+)
+
+func TestBatchDispatcher(t *testing.T) {
+	l1 := backupspec.Location{
+		Provider: "s3",
+		Path:     "l1",
+	}
+	l2 := backupspec.Location{
+		Provider: "s3",
+		Path:     "l2",
+	}
+	workload := []LocationWorkload{
+		{
+			Location: l1,
+			Size:     170,
+			Tables: []TableWorkload{
+				{
+					Size: 60,
+					RemoteDirs: []RemoteDirWorkload{
+						{
+							RemoteSSTableDir: "a",
+							Size:             20,
+							SSTables: []RemoteSSTable{
+								{Size: 5},
+								{Size: 15},
+							},
+						},
+						{
+							RemoteSSTableDir: "e",
+							Size:             10,
+							SSTables: []RemoteSSTable{
+								{Size: 2},
+								{Size: 4},
+								{Size: 4},
+							},
+						},
+						{
+							RemoteSSTableDir: "b",
+							Size:             30,
+							SSTables: []RemoteSSTable{
+								{Size: 10},
+								{Size: 20},
+							},
+						},
+					},
+				},
+				{
+					Size: 110,
+					RemoteDirs: []RemoteDirWorkload{
+						{
+							RemoteSSTableDir: "c",
+							Size:             110,
+							SSTables: []RemoteSSTable{
+								{Size: 50},
+								{Size: 60},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Location: l2,
+			Size:     200,
+			Tables: []TableWorkload{
+				{
+					Size: 200,
+					RemoteDirs: []RemoteDirWorkload{
+						{
+							RemoteSSTableDir: "d",
+							Size:             200,
+							SSTables: []RemoteSSTable{
+								{Size: 110},
+								{Size: 90},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	locationHosts := map[backupspec.Location][]string{
+		l1: {"h1", "h2"},
+		l2: {"h3"},
+	}
+	hostToShard := map[string]uint{
+		"h1": 1,
+		"h2": 2,
+		"h3": 3,
+	}
+
+	bd := newBatchDispatcher(workload, 1, hostToShard, locationHosts)
+
+	scenario := []struct {
+		host  string
+		ok    bool
+		dir   string
+		size  int64
+		count int
+	}{
+		{host: "h1", ok: true, dir: "c", size: 60, count: 1},
+		{host: "h1", ok: true, dir: "c", size: 50, count: 1},
+		{host: "h2", ok: true, dir: "b", size: 30, count: 2},
+		{host: "h3", ok: true, dir: "d", size: 200, count: 2},
+		{host: "h3", ok: false},
+		{host: "h2", ok: true, dir: "a", size: 20, count: 2},
+		{host: "h2", ok: true, dir: "e", size: 10, count: 3}, // batch extended with leftovers < shard_cnt
+		{host: "h1", ok: false},
+		{host: "h2", ok: false},
+	}
+
+	for _, step := range scenario {
+		b, ok := bd.DispatchBatch(step.host)
+		if ok != step.ok {
+			t.Fatalf("Step: %+v, expected ok=%v, got ok=%v", step, step.ok, ok)
+		}
+		if ok == false {
+			continue
+		}
+		if b.RemoteSSTableDir != step.dir {
+			t.Fatalf("Step: %+v, expected dir=%v, got dir=%v", step, step.dir, b.RemoteSSTableDir)
+		}
+		if b.Size != step.size {
+			t.Fatalf("Step: %+v, expected size=%v, got size=%v", step, step.size, b.Size)
+		}
+		if len(b.SSTables) != step.count {
+			t.Fatalf("Step: %+v, expected count=%v, got count=%v", step, step.count, len(b.SSTables))
+		}
+	}
+
+	if err := bd.ValidateAllDispatched(); err != nil {
+		t.Fatalf("Expected sstables to be batched: %s", err)
+	}
+}

--- a/pkg/service/restore/model.go
+++ b/pkg/service/restore/model.go
@@ -36,6 +36,8 @@ type Target struct {
 	locationHosts map[Location][]string `json:"-"`
 }
 
+const maxBatchSize = 0
+
 func defaultTarget() Target {
 	return Target{
 		BatchSize: 2,
@@ -53,8 +55,8 @@ func (t Target) validateProperties() error {
 	if _, err := SnapshotTagTime(t.SnapshotTag); err != nil {
 		return err
 	}
-	if t.BatchSize <= 0 {
-		return errors.New("batch size param has to be greater than zero")
+	if t.BatchSize < 0 {
+		return errors.New("batch size param has to be greater or equal to zero")
 	}
 	if t.Parallel < 0 {
 		return errors.New("parallel param has to be greater or equal to zero")

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -394,7 +394,7 @@ func TestRestoreGetTargetUnitsViewsErrorIntegration(t *testing.T) {
 		{
 			name:  "non-positive batch size",
 			input: "testdata/get_target/non_positive_batch_size.input.json",
-			error: "batch size param has to be greater than zero",
+			error: "batch size param has to be greater or equal to zero",
 		},
 		{
 			name:  "no data matching keyspace pattern",

--- a/pkg/service/restore/tables_worker.go
+++ b/pkg/service/restore/tables_worker.go
@@ -174,12 +174,18 @@ func (w *tablesWorker) stageRestoreData(ctx context.Context) error {
 	}
 	w.initMetrics(workload)
 
-	bd := newBatchDispatcher(workload, w.target.BatchSize, w.target.locationHosts)
 	hostsS := strset.New()
 	for _, h := range w.target.locationHosts {
 		hostsS.Add(h...)
 	}
 	hosts := hostsS.List()
+
+	hostToShard, err := w.client.HostsShardCount(ctx, hosts)
+	if err != nil {
+		return errors.Wrap(err, "get hosts shard count")
+	}
+
+	bd := newBatchDispatcher(workload, w.target.BatchSize, hostToShard, w.target.locationHosts)
 
 	f := func(n int) (err error) {
 		h := hosts[n]

--- a/pkg/service/restore/tables_worker.go
+++ b/pkg/service/restore/tables_worker.go
@@ -184,6 +184,9 @@ func (w *tablesWorker) stageRestoreData(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "get hosts shard count")
 	}
+	for h, sh := range hostToShard {
+		w.logger.Info(ctx, "Host shard count", "host", h, "shards", sh)
+	}
 
 	bd := newBatchDispatcher(workload, w.target.BatchSize, hostToShard, w.target.locationHosts)
 


### PR DESCRIPTION
This PR introduces the following changes to batching mechanism:
- batches contain --batch-size*node_shard_count sstables instead of just --batch-size sstables (this was the initial design in[ restore 3.1 design doc](https://docs.google.com/document/d/1ugf6XCs28c4pwKsw9Lbu_EFb6ZSgMpJ_-Usf-Q9XAP4/edit#heading=h.f7jv2tbf2ofd))
- sorts sstables by decreasing size so that batches contain sstables of more similar size (#3979)
- added a special --batch-size=0 value which results in creating batches of not limited amount of sstables, but their total size is up to 5% of expected total node workload (#4059)

Fixes #3979
Fixes #4059
