### PR TITLE
Restore improvement: compaction

### DIFF
--- a/docs/source/sctool/partials/sctool_restore.yaml
+++ b/docs/source/sctool/partials/sctool_restore.yaml
@@ -7,6 +7,11 @@ description: |
     a specific follow-up action described by selected type.
 usage: sctool restore --cluster <id|name> --location [<dc>:]<provider>:<bucket> --snapshot-tag <tag> [flags]
 options:
+    - name: allow-compaction
+      default_value: "false"
+      usage: |
+        Defines if auto compactions should be running on Scylla nodes during restore.
+        Disabling auto compactions decreases restore time duration, but increases compaction workload after the restore is done.
     - name: batch-size
       default_value: "2"
       usage: |

--- a/docs/source/sctool/partials/sctool_restore_update.yaml
+++ b/docs/source/sctool/partials/sctool_restore_update.yaml
@@ -5,6 +5,11 @@ description: |
     If there is one restore task the 'restore/task-id' argument is not needed.
 usage: sctool restore update --cluster <id|name> [flags] [<restore/task-id>]
 options:
+    - name: allow-compaction
+      default_value: "false"
+      usage: |
+        Defines if auto compactions should be running on Scylla nodes during restore.
+        Disabling auto compactions decreases restore time duration, but increases compaction workload after the restore is done.
     - name: batch-size
       default_value: "2"
       usage: |

--- a/pkg/command/restore/cmd.go
+++ b/pkg/command/restore/cmd.go
@@ -23,16 +23,17 @@ type command struct {
 	flag.TaskBase
 	client *managerclient.Client
 
-	cluster       string
-	location      []string
-	keyspace      []string
-	snapshotTag   string
-	batchSize     int
-	parallel      int
-	restoreSchema bool
-	restoreTables bool
-	dryRun        bool
-	showTables    bool
+	cluster         string
+	location        []string
+	keyspace        []string
+	snapshotTag     string
+	batchSize       int
+	parallel        int
+	allowCompaction bool
+	restoreSchema   bool
+	restoreTables   bool
+	dryRun          bool
+	showTables      bool
 }
 
 func NewCommand(client *managerclient.Client) *cobra.Command {
@@ -78,6 +79,7 @@ func (cmd *command) init() {
 	w.Unwrap().StringVarP(&cmd.snapshotTag, "snapshot-tag", "T", "", "")
 	w.Unwrap().IntVar(&cmd.batchSize, "batch-size", 2, "")
 	w.Unwrap().IntVar(&cmd.parallel, "parallel", 1, "")
+	w.Unwrap().BoolVar(&cmd.allowCompaction, "allow-compaction", false, "")
 	w.Unwrap().BoolVar(&cmd.restoreSchema, "restore-schema", false, "")
 	w.Unwrap().BoolVar(&cmd.restoreTables, "restore-tables", false, "")
 	w.Unwrap().BoolVar(&cmd.dryRun, "dry-run", false, "")
@@ -142,6 +144,10 @@ func (cmd *command) run(args []string) error {
 	}
 	if cmd.Flag("parallel").Changed {
 		props["parallel"] = cmd.parallel
+		ok = true
+	}
+	if cmd.Flag("allow-compaction").Changed {
+		props["allow_compaction"] = cmd.allowCompaction
 		ok = true
 	}
 	if cmd.Flag("restore-schema").Changed {

--- a/pkg/command/restore/res.yaml
+++ b/pkg/command/restore/res.yaml
@@ -33,6 +33,10 @@ parallel: |
   The maximum number of Scylla restore jobs that can be run at the same time (on different SSTables).
   Each node can take part in at most one restore at any given moment.
 
+allow-compaction: |
+  Defines if auto compactions should be running on Scylla nodes during restore.
+  Disabling auto compactions decreases restore time duration, but increases compaction workload after the restore is done.
+
 restore-schema: |
   Specifies restore type (alternative to '--restore-tables' flag).
   Restore will recreate schema by applying the backed up output of DESCRIBE SCHEMA WITH INTERNALS via CQL.

--- a/pkg/service/restore/model.go
+++ b/pkg/service/restore/model.go
@@ -23,14 +23,15 @@ import (
 
 // Target specifies what data should be restored and from which locations.
 type Target struct {
-	Location      []Location `json:"location"`
-	Keyspace      []string   `json:"keyspace,omitempty"`
-	SnapshotTag   string     `json:"snapshot_tag"`
-	BatchSize     int        `json:"batch_size,omitempty"`
-	Parallel      int        `json:"parallel,omitempty"`
-	RestoreSchema bool       `json:"restore_schema,omitempty"`
-	RestoreTables bool       `json:"restore_tables,omitempty"`
-	Continue      bool       `json:"continue"`
+	Location        []Location `json:"location"`
+	Keyspace        []string   `json:"keyspace,omitempty"`
+	SnapshotTag     string     `json:"snapshot_tag"`
+	BatchSize       int        `json:"batch_size,omitempty"`
+	Parallel        int        `json:"parallel,omitempty"`
+	AllowCompaction bool       `json:"allow_compaction,omitempty"`
+	RestoreSchema   bool       `json:"restore_schema,omitempty"`
+	RestoreTables   bool       `json:"restore_tables,omitempty"`
+	Continue        bool       `json:"continue"`
 
 	// Cache for host with access to remote location
 	locationHosts map[Location][]string `json:"-"`


### PR DESCRIPTION
This PR adds new boolean restore flag `--allow-compaction` (false by default).
When it's set to false, SM disables auto compactions on restored tables for the time of the restore and enables them back when its done.

Fixes #3953 
