### PR TITLE
Allow for creating stand-alone dc filter

### DIFF
--- a/v3/pkg/util/inexlist/dcfilter/dcfilter.go
+++ b/v3/pkg/util/inexlist/dcfilter/dcfilter.go
@@ -37,6 +37,29 @@ func Apply(dcMap map[string][]string, filters []string) ([]string, error) {
 	return filtered, nil
 }
 
+// Filter that lets you filter datacenters.
+type Filter struct {
+	filters []string
+	inex    inexlist.InExList
+}
+
+func NewFilter(filters []string) (*Filter, error) {
+	// Decorate filters and create inexlist
+	inex, err := inexlist.ParseInExList(decorate(filters))
+	if err != nil {
+		return nil, errors.Wrapf(err, "parse dc filter %v", filters)
+	}
+	return &Filter{
+		filters: filters,
+		inex:    inex,
+	}, nil
+}
+
+// Check returns true iff dc matches filter.
+func (f *Filter) Check(dc string) bool {
+	return len(f.inex.Filter([]string{dc})) > 0
+}
+
 func decorate(filters []string) []string {
 	if len(filters) == 0 {
 		filters = append(filters, "*")


### PR DESCRIPTION
Sometimes we don't have access to all dcs right away, so it's more convenient to use Check instead of Apply.
It also allows for parsing dc filters just once.

This is a ground work for #4049.