### PR TITLE
Restore improvement: rate limit

### DIFF
--- a/docs/source/sctool/partials/sctool_restore.yaml
+++ b/docs/source/sctool/partials/sctool_restore.yaml
@@ -107,6 +107,13 @@ options:
       usage: |
         The maximum number of Scylla restore jobs that can be run at the same time (on different SSTables).
         Each node can take part in at most one restore at any given moment.
+    - name: rate-limit
+      default_value: '[]'
+      usage: |
+        Limits the download rate (as expressed in  megabytes (MiB) per second) at which sstables can be downloaded from backup location to Scylla nodes.
+        You can set limits for more than one DC using a comma-separated list expressed in the format `[<dc>:]<limit>`.
+        The <dc>: part is optional and is only needed when different datacenters require different download limits.
+        Set to 0 for no limit (default 0).
     - name: restore-schema
       default_value: "false"
       usage: |

--- a/docs/source/sctool/partials/sctool_restore_update.yaml
+++ b/docs/source/sctool/partials/sctool_restore_update.yaml
@@ -105,6 +105,13 @@ options:
       usage: |
         The maximum number of Scylla restore jobs that can be run at the same time (on different SSTables).
         Each node can take part in at most one restore at any given moment.
+    - name: rate-limit
+      default_value: '[]'
+      usage: |
+        Limits the download rate (as expressed in  megabytes (MiB) per second) at which sstables can be downloaded from backup location to Scylla nodes.
+        You can set limits for more than one DC using a comma-separated list expressed in the format `[<dc>:]<limit>`.
+        The <dc>: part is optional and is only needed when different datacenters require different download limits.
+        Set to 0 for no limit (default 0).
     - name: restore-schema
       default_value: "false"
       usage: |

--- a/pkg/command/restore/cmd.go
+++ b/pkg/command/restore/cmd.go
@@ -30,6 +30,7 @@ type command struct {
 	batchSize       int
 	parallel        int
 	transfers       int
+	rateLimit       []string
 	allowCompaction bool
 	restoreSchema   bool
 	restoreTables   bool
@@ -81,6 +82,7 @@ func (cmd *command) init() {
 	w.Unwrap().IntVar(&cmd.batchSize, "batch-size", 2, "")
 	w.Unwrap().IntVar(&cmd.parallel, "parallel", 0, "")
 	w.Unwrap().IntVar(&cmd.transfers, "transfers", 0, "")
+	w.Unwrap().StringSliceVar(&cmd.rateLimit, "rate-limit", nil, "")
 	w.Unwrap().BoolVar(&cmd.allowCompaction, "allow-compaction", false, "")
 	w.Unwrap().BoolVar(&cmd.restoreSchema, "restore-schema", false, "")
 	w.Unwrap().BoolVar(&cmd.restoreTables, "restore-tables", false, "")
@@ -150,6 +152,10 @@ func (cmd *command) run(args []string) error {
 	}
 	if cmd.Flag("transfers").Changed {
 		props["transfers"] = cmd.transfers
+		ok = true
+	}
+	if cmd.Flag("rate-limit").Changed {
+		props["rate_limit"] = cmd.rateLimit
 		ok = true
 	}
 	if cmd.Flag("allow-compaction").Changed {

--- a/pkg/command/restore/res.yaml
+++ b/pkg/command/restore/res.yaml
@@ -38,6 +38,12 @@ transfers: |
   Set to 0 for the fastest download (results in setting transfers to 2*node_shard_count).
   Set to -1 for using the transfers value defined in node's 'scylla-manager-agent.yaml' config file.
 
+rate-limit: |
+  Limits the download rate (as expressed in  megabytes (MiB) per second) at which sstables can be downloaded from backup location to Scylla nodes.
+  You can set limits for more than one DC using a comma-separated list expressed in the format `[<dc>:]<limit>`.
+  The <dc>: part is optional and is only needed when different datacenters require different download limits.
+  Set to 0 for no limit (default 0).
+
 allow-compaction: |
   Defines if auto compactions should be running on Scylla nodes during restore.
   Disabling auto compactions decreases restore time duration, but increases compaction workload after the restore is done.

--- a/pkg/scyllaclient/client_rclone.go
+++ b/pkg/scyllaclient/client_rclone.go
@@ -27,10 +27,23 @@ import (
 func (c *Client) RcloneSetBandwidthLimit(ctx context.Context, host string, limit int) error {
 	p := operations.CoreBwlimitParams{
 		Context:       forceHost(ctx, host),
-		BandwidthRate: &models.Bandwidth{Rate: fmt.Sprintf("%dM", limit)},
+		BandwidthRate: &models.Bandwidth{Rate: marshallRateLimit(limit)},
 	}
 	_, err := c.agentOps.CoreBwlimit(&p) // nolint: errcheck
 	return err
+}
+
+// RcloneGetBandwidthLimit gets bandwidth limit of all the current and future
+// transfers performed under current client session.
+func (c *Client) RcloneGetBandwidthLimit(ctx context.Context, host string) (string, error) {
+	p := operations.CoreBwlimitParams{
+		Context: forceHost(ctx, host),
+	}
+	resp, err := c.agentOps.CoreBwlimit(&p)
+	if err != nil {
+		return "", err
+	}
+	return resp.Payload.Rate, nil
 }
 
 // RcloneSetTransfers sets the default amount of transfers on rclone server.
@@ -737,4 +750,8 @@ func rcloneSplitRemotePath(remotePath string) (fs, path string, err error) {
 		path = dirParts[1]
 	}
 	return
+}
+
+func marshallRateLimit(limit int) string {
+	return fmt.Sprintf("%dM", limit)
 }

--- a/pkg/scyllaclient/client_rclone.go
+++ b/pkg/scyllaclient/client_rclone.go
@@ -314,7 +314,7 @@ const TransfersFromConfig = -1
 // Remotes need to be registered with the server first.
 // Remote path format is "name:bucket/path".
 // Both dstRemoteDir and srRemoteDir must point to a directory.
-func (c *Client) RcloneCopyPaths(ctx context.Context, host string, transfers int, dstRemoteDir, srcRemoteDir string, paths []string) (int64, error) {
+func (c *Client) RcloneCopyPaths(ctx context.Context, host string, transfers, rateLimit int, dstRemoteDir, srcRemoteDir string, paths []string) (int64, error) {
 	dstFs, dstRemote, err := rcloneSplitRemotePath(dstRemoteDir)
 	if err != nil {
 		return 0, err
@@ -330,12 +330,13 @@ func (c *Client) RcloneCopyPaths(ctx context.Context, host string, transfers int
 	p := operations.SyncCopyPathsParams{
 		Context: forceHost(ctx, host),
 		Options: &models.CopyPathsOptions{
-			DstFs:     dstFs,
-			DstRemote: dstRemote,
-			SrcFs:     srcFs,
-			SrcRemote: srcRemote,
-			Paths:     paths,
-			Transfers: int64(transfers),
+			DstFs:         dstFs,
+			DstRemote:     dstRemote,
+			SrcFs:         srcFs,
+			SrcRemote:     srcRemote,
+			Paths:         paths,
+			Transfers:     int64(transfers),
+			BandwidthRate: marshallRateLimit(rateLimit),
 		},
 		Async: true,
 	}

--- a/pkg/scyllaclient/client_rclone_agent_integration_test.go
+++ b/pkg/scyllaclient/client_rclone_agent_integration_test.go
@@ -123,7 +123,7 @@ func TestRcloneDeletePathsInBatchesAgentIntegration(t *testing.T) {
 					t.Fatalf("Create files on Scylla node, err = {%s}, stdOut={%s}, stdErr={%s}", err, stdOut, stdErr)
 				}
 			}
-			id, err := client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, remotePath(dirName), "data:"+dirName, "")
+			id, err := client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, 0, remotePath(dirName), "data:"+dirName, "")
 			if err != nil {
 				t.Fatal(errors.Wrap(err, "copy created files to backup location"))
 			}
@@ -200,7 +200,7 @@ func TestRcloneSkippingFilesAgentIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	id, err := client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, remotePath(""), "data:tmp/copy", "")
+	id, err := client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, remotePath(""), "data:tmp/copy", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func TestRcloneSkippingFilesAgentIntegration(t *testing.T) {
 		}
 	}
 
-	id, err = client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, remotePath(""), "data:tmp/copy", "")
+	id, err = client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, remotePath(""), "data:tmp/copy", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,9 +259,6 @@ func TestRcloneStoppingTransferIntegration(t *testing.T) {
 
 	ctx := context.Background()
 
-	if err := client.RcloneSetBandwidthLimit(ctx, testHost, 1); err != nil {
-		t.Fatal(err)
-	}
 	defer func() {
 		if err := client.RcloneSetBandwidthLimit(ctx, testHost, 0); err != nil {
 			t.Fatal(err)
@@ -283,7 +280,7 @@ func TestRcloneStoppingTransferIntegration(t *testing.T) {
 		}
 	}()
 
-	id, err := client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, remotePath(""), "data:tmp", "")
+	id, err := client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, 1, remotePath(""), "data:tmp", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,9 +324,6 @@ func TestRcloneJobProgressIntegration(t *testing.T) {
 	S3InitBucket(t, testBucket)
 	ctx := context.Background()
 
-	if err := client.RcloneSetBandwidthLimit(ctx, testHost, 1); err != nil {
-		t.Fatal(err)
-	}
 	defer func() {
 		if err := client.RcloneSetBandwidthLimit(ctx, testHost, 0); err != nil {
 			t.Fatal(err)
@@ -351,7 +345,7 @@ func TestRcloneJobProgressIntegration(t *testing.T) {
 	}()
 
 	Print("When: first batch upload")
-	id, err := client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, remotePath(""), "data:tmp", "")
+	id, err := client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, 1, remotePath(""), "data:tmp", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,7 +377,7 @@ func TestRcloneJobProgressIntegration(t *testing.T) {
 	}
 
 	Print("When: second batch upload")
-	id, err = client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, remotePath(""), "data:tmp", "")
+	id, err = client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, remotePath(""), "data:tmp", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -408,7 +402,7 @@ func TestRcloneJobProgressIntegration(t *testing.T) {
 	}
 
 	Print("When: third batch upload")
-	id, err = client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, remotePath(""), "data:tmp", "")
+	id, err = client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, remotePath(""), "data:tmp", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -487,7 +481,7 @@ func TestRcloneSuffixOptionIntegration(t *testing.T) {
 
 	Print("Copy src into dst")
 
-	id, err := client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, dstPath, srcPath, "")
+	id, err := client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, dstPath, srcPath, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -534,7 +528,7 @@ func TestRcloneSuffixOptionIntegration(t *testing.T) {
 
 	Print("Copy src into dst after file modification")
 
-	id, err = client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, dstPath, srcPath, firstSuffix)
+	id, err = client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, dstPath, srcPath, firstSuffix)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -583,7 +577,7 @@ func TestRcloneSuffixOptionIntegration(t *testing.T) {
 
 	Print("Copy src into dst after another file modification")
 
-	id, err = client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, dstPath, srcPath, secondSuffix)
+	id, err = client.RcloneCopyDir(ctx, testHost, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, dstPath, srcPath, secondSuffix)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/scyllaclient/client_rclone_integration_test.go
+++ b/pkg/scyllaclient/client_rclone_integration_test.go
@@ -36,7 +36,7 @@ func TestRcloneLocalToS3CopyDirIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	copyDir := func(dir string) (*scyllaclient.RcloneJobInfo, error) {
-		id, err := client.RcloneCopyDir(ctx, scyllaclienttest.TestHost, scyllaclient.TransfersFromConfig, remotePath("/copy"), "rclonetest:"+dir, "")
+		id, err := client.RcloneCopyDir(ctx, scyllaclienttest.TestHost, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, remotePath("/copy"), "rclonetest:"+dir, "")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -106,7 +106,7 @@ func TestRcloneS3ToLocalCopyDirIntegration(t *testing.T) {
 	defer closeServer()
 	ctx := context.Background()
 
-	id, err := client.RcloneCopyDir(ctx, scyllaclienttest.TestHost, scyllaclient.TransfersFromConfig, "rclonetest:foo", remotePath("/copy"), "")
+	id, err := client.RcloneCopyDir(ctx, scyllaclienttest.TestHost, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, "rclonetest:foo", remotePath("/copy"), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/service/backup/backup.go
+++ b/pkg/service/backup/backup.go
@@ -3,58 +3,11 @@
 package backup
 
 import (
-	"strings"
-
 	"github.com/pkg/errors"
-	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
-	"github.com/scylladb/scylla-manager/v3/pkg/util/slice"
 	"go.uber.org/multierr"
 )
-
-func checkDCs(dcAtPos func(int) (string, string), n int, dcMap map[string][]string) (err error) {
-	allDCs := strset.New()
-	for dc := range dcMap {
-		allDCs.Add(dc)
-	}
-
-	for i := 0; i < n; i++ {
-		dc, str := dcAtPos(i)
-		if dc == "" {
-			continue
-		}
-		if !allDCs.Has(dc) {
-			err = multierr.Append(err, errors.Errorf("%q no such datacenter %s", str, dc))
-		}
-	}
-	return
-}
-
-func checkAllDCsCovered(locations []Location, dcs []string) error {
-	hasDCs := strset.New()
-	hasDefault := false
-
-	for _, l := range locations {
-		if l.DC == "" {
-			hasDefault = true
-			continue
-		}
-		hasDCs.Add(l.DC)
-	}
-
-	if !hasDefault {
-		if d := strset.Difference(strset.New(dcs...), hasDCs); !d.IsEmpty() {
-			msg := "missing location(s) for datacenters %s"
-			if d.Size() == 1 {
-				msg = "missing location for datacenter %s"
-			}
-			return errors.Errorf(msg, strings.Join(d.List(), ", "))
-		}
-	}
-
-	return nil
-}
 
 func makeHostInfo(nodes []scyllaclient.NodeStatusInfo, locations []Location, rateLimits []DCLimit, transfers int) ([]hostInfo, error) {
 	// DC location index
@@ -94,30 +47,4 @@ func makeHostInfo(nodes []scyllaclient.NodeStatusInfo, locations []Location, rat
 	}
 
 	return hi, errs
-}
-
-// filterDCLocations takes list of locations and returns only locations that
-// belong to the provided list of datacenters.
-func filterDCLocations(locations []Location, dcs []string) []Location {
-	var filtered []Location
-	for _, l := range locations {
-		if l.DC == "" || slice.ContainsString(dcs, l.DC) {
-			filtered = append(filtered, l)
-			continue
-		}
-	}
-	return filtered
-}
-
-// filterDCLimits takes list of DCLimits and returns only locations that belong
-// to the provided list of datacenters.
-func filterDCLimits(limits []DCLimit, dcs []string) []DCLimit {
-	var filtered []DCLimit
-	for _, l := range limits {
-		if l.DC == "" || slice.ContainsString(dcs, l.DC) {
-			filtered = append(filtered, l)
-			continue
-		}
-	}
-	return filtered
 }

--- a/pkg/service/backup/backup_test.go
+++ b/pkg/service/backup/backup_test.go
@@ -68,7 +68,7 @@ func TestFilterDCLocations(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 
-			if diff := cmp.Diff(test.Expect, filterDCLocations(test.Locations, test.DCs)); diff != "" {
+			if diff := cmp.Diff(test.Expect, FilterDCs(test.Locations, test.DCs)); diff != "" {
 				t.Error(diff)
 			}
 		})
@@ -134,7 +134,7 @@ func TestFilterDCLimit(t *testing.T) {
 		t.Run(test.Name, func(t *testing.T) {
 			t.Parallel()
 
-			if diff := cmp.Diff(test.Expect, filterDCLimits(test.DCLimits, test.DCs)); diff != "" {
+			if diff := cmp.Diff(test.Expect, FilterDCs(test.DCLimits, test.DCs)); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/pkg/service/backup/backupspec/dclimit.go
+++ b/pkg/service/backup/backupspec/dclimit.go
@@ -1,0 +1,118 @@
+// Copyright (C) 2024 ScyllaDB
+
+package backupspec
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/go-set/strset"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/slice"
+	"go.uber.org/multierr"
+)
+
+// DCLimit specifies a rate limit for a DC.
+type DCLimit struct {
+	DC    string `json:"dc"`
+	Limit int    `json:"limit"`
+}
+
+func (l DCLimit) String() string {
+	p := fmt.Sprint(l.Limit)
+	if l.DC != "" {
+		p = l.DC + ":" + p
+	}
+	return p
+}
+
+// Datacenter returns datacenter that is limited.
+func (l DCLimit) Datacenter() string {
+	return l.DC
+}
+
+func (l DCLimit) MarshalText() (text []byte, err error) {
+	return []byte(l.String()), nil
+}
+
+func (l *DCLimit) UnmarshalText(text []byte) error {
+	pattern := regexp.MustCompile(`^(([a-zA-Z0-9\-\_\.]+):)?([0-9]+)$`)
+
+	m := pattern.FindSubmatch(text)
+	if m == nil {
+		return errors.Errorf("invalid limit %q, the format is [dc:]<number>", string(text))
+	}
+
+	limit, err := strconv.ParseInt(string(m[3]), 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "invalid limit value")
+	}
+
+	l.DC = string(m[2])
+	l.Limit = int(limit)
+
+	return nil
+}
+
+// Datacenterer describes object that is connected to some datacenter.
+type Datacenterer interface {
+	Datacenter() string
+}
+
+// CheckDCs validates that all dcs are exist in provided dcMap .
+func CheckDCs[T Datacenterer](dcs []T, dcMap map[string][]string) (err error) {
+	allDCs := strset.New()
+	for dc := range dcMap {
+		allDCs.Add(dc)
+	}
+
+	for _, dc := range dcs {
+		if dc.Datacenter() == "" {
+			continue
+		}
+		if !allDCs.Has(dc.Datacenter()) {
+			err = multierr.Append(err, errors.Errorf("no such datacenter %s", dc.Datacenter()))
+		}
+	}
+	return
+}
+
+// CheckAllDCsCovered validates that all dcToCover exist in provided dcs.
+func CheckAllDCsCovered[T Datacenterer](dcs []T, dcToCover []string) error {
+	hasDCs := strset.New()
+	hasDefault := false
+
+	for _, dc := range dcs {
+		if dc.Datacenter() == "" {
+			hasDefault = true
+			continue
+		}
+		hasDCs.Add(dc.Datacenter())
+	}
+
+	if !hasDefault {
+		if d := strset.Difference(strset.New(dcToCover...), hasDCs); !d.IsEmpty() {
+			msg := "missing object(s) for datacenters %s"
+			if d.Size() == 1 {
+				msg = "missing object for datacenter %s"
+			}
+			return errors.Errorf(msg, strings.Join(d.List(), ", "))
+		}
+	}
+
+	return nil
+}
+
+// FilterDCs returns dcs present in filteredDCs.
+func FilterDCs[T Datacenterer](dcs []T, filteredDCs []string) []T {
+	var filtered []T
+	for _, dc := range dcs {
+		if dc.Datacenter() == "" || slice.ContainsString(filteredDCs, dc.Datacenter()) {
+			filtered = append(filtered, dc)
+			continue
+		}
+	}
+	return filtered
+}

--- a/pkg/service/backup/backupspec/location.go
+++ b/pkg/service/backup/backupspec/location.go
@@ -109,6 +109,11 @@ func (l Location) String() string {
 	return p
 }
 
+// Datacenter returns location's datacenter.
+func (l Location) Datacenter() string {
+	return l.DC
+}
+
 func (l Location) MarshalText() (text []byte, err error) {
 	return []byte(l.String()), nil
 }

--- a/pkg/service/backup/parallel.go
+++ b/pkg/service/backup/parallel.go
@@ -4,6 +4,7 @@ package backup
 
 import (
 	"github.com/pkg/errors"
+	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
 )
 

--- a/pkg/service/backup/parallel_test.go
+++ b/pkg/service/backup/parallel_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
 )
 
 func TestMakeHostsLimit(t *testing.T) {

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -436,17 +436,17 @@ func TestGetTargetErrorIntegration(t *testing.T) {
 		{
 			Name:  "invalid location dc",
 			JSON:  `{"location": ["foobar:s3:backuptest-get-target"]}`,
-			Error: `invalid location: "foobar:s3:backuptest-get-target" no such datacenter foobar`,
+			Error: `invalid location: no such datacenter foobar`,
 		},
 		{
 			Name:  "no location for dc",
 			JSON:  `{"location": ["dc1:s3:backuptest-get-target"]}`,
-			Error: "invalid location: missing location for datacenter",
+			Error: "invalid location: missing object for datacenter",
 		},
 		{
 			Name:  "no location dc filtered out",
 			JSON:  `{"dc": ["dc2"], "location": ["dc1:s3:backuptest-get-target"]}`,
-			Error: "invalid location: missing location for datacenter",
+			Error: "invalid location: missing object for datacenter",
 		},
 		{
 			Name:  "inaccessible location",
@@ -456,17 +456,17 @@ func TestGetTargetErrorIntegration(t *testing.T) {
 		{
 			Name:  "invalid rate limit dc",
 			JSON:  `{"rate_limit": ["foobar:100"], "location": ["s3:backuptest-get-target"]}`,
-			Error: `invalid rate-limit: "foobar:100" no such datacenter foobar`,
+			Error: `invalid rate-limit: no such datacenter foobar`,
 		},
 		{
 			Name:  "invalid snapshot parallel dc",
 			JSON:  `{"snapshot_parallel": ["foobar:100"], "location": ["s3:backuptest-get-target"]}`,
-			Error: `invalid snapshot-parallel: "foobar:100" no such datacenter foobar`,
+			Error: `invalid snapshot-parallel: no such datacenter foobar`,
 		},
 		{
 			Name:  "invalid upload parallel dc",
 			JSON:  `{"upload_parallel": ["foobar:100"], "location": ["s3:backuptest-get-target"]}`,
-			Error: `invalid upload-parallel: "foobar:100" no such datacenter foobar`,
+			Error: `invalid upload-parallel: no such datacenter foobar`,
 		},
 	}
 
@@ -949,7 +949,7 @@ func TestBackupResumeIntegration(t *testing.T) {
 		DC:        []string{"dc1"},
 		Location:  []Location{location},
 		Retention: 2,
-		RateLimit: []backup.DCLimit{
+		RateLimit: []DCLimit{
 			{"dc1", 1},
 		},
 		Continue: true,

--- a/pkg/service/backup/service_deduplicate_integration_test.go
+++ b/pkg/service/backup/service_deduplicate_integration_test.go
@@ -46,7 +46,7 @@ func TestBackupPauseResumeOnDeduplicationStage(t *testing.T) {
 		DC:        []string{"dc1"},
 		Location:  []backupspec.Location{location},
 		Retention: 2,
-		RateLimit: []backup.DCLimit{
+		RateLimit: []backupspec.DCLimit{
 			{"dc1", 1},
 		},
 		Continue: true,

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/sstable"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
 )

--- a/pkg/service/backup/worker_upload.go
+++ b/pkg/service/backup/worker_upload.go
@@ -186,7 +186,7 @@ func (w *worker) uploadSnapshotDir(ctx context.Context, h hostInfo, d snapshotDi
 
 func (w *worker) uploadDataDir(ctx context.Context, hi hostInfo, dst, src string, d snapshotDir) error {
 	// Ensure file versioning during upload
-	id, err := w.Client.RcloneMoveDir(ctx, d.Host, hi.Transfers, dst, src, VersionedFileExt(w.SnapshotTag))
+	id, err := w.Client.RcloneMoveDir(ctx, d.Host, hi.Transfers, hi.RateLimit.Limit, dst, src, VersionedFileExt(w.SnapshotTag))
 	if err != nil {
 		return err
 	}

--- a/pkg/service/restore/tablesdir_worker.go
+++ b/pkg/service/restore/tablesdir_worker.go
@@ -166,7 +166,7 @@ func (w *tablesWorker) startDownload(ctx context.Context, hi HostInfo, b batch) 
 	for _, sst := range sstables {
 		files = append(files, sst.Files...)
 	}
-	jobID, err = w.client.RcloneCopyPaths(ctx, hi.Host, hi.Transfers, uploadDir, b.RemoteSSTableDir, files)
+	jobID, err = w.client.RcloneCopyPaths(ctx, hi.Host, hi.Transfers, hi.RateLimit, uploadDir, b.RemoteSSTableDir, files)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "download batch to upload dir")
 	}

--- a/pkg/service/restore/worker.go
+++ b/pkg/service/restore/worker.go
@@ -67,7 +67,12 @@ func (w *worker) initTarget(ctx context.Context, properties json.RawMessage) err
 	if err := json.Unmarshal(properties, &t); err != nil {
 		return err
 	}
-	if err := t.validateProperties(); err != nil {
+
+	dcMap, err := w.client.Datacenters(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get data centers")
+	}
+	if err := t.validateProperties(dcMap); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds a way to control rate limit in the context of restore via new `--rate-limit` restore flag with default value 0 - meaning no rate limit at all.
It borrows rate limit syntax from backup pkg for consistency - meaning that it's possible to specify rate limit per dc.

Fixes #3947
