### PR TITLE
Parallelized cluster hosts discovering + async config cache update

### DIFF
--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -164,7 +164,7 @@ func (s *server) makeServices(ctx context.Context) error {
 func (s *server) onClusterChange(ctx context.Context, c cluster.Change) error {
 	switch c.Type {
 	case cluster.Update:
-		s.configCacheSvc.ForceUpdateCluster(ctx, c.ID)
+		go s.configCacheSvc.ForceUpdateCluster(ctx, c.ID)
 	case cluster.Create:
 		s.configCacheSvc.ForceUpdateCluster(ctx, c.ID)
 		for _, t := range makeAutoHealthCheckTasks(c.ID) {

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -178,6 +178,15 @@ func (c *Client) Datacenters(ctx context.Context) (map[string][]string, error) {
 	return res, errs
 }
 
+// GossiperEndpointLiveGet finds live nodes (according to gossiper).
+func (c *Client) GossiperEndpointLiveGet(ctx context.Context) ([]string, error) {
+	live, err := c.scyllaOps.GossiperEndpointLiveGet(&operations.GossiperEndpointLiveGetParams{Context: ctx})
+	if err != nil {
+		return nil, err
+	}
+	return live.GetPayload(), nil
+}
+
 // HostDatacenter looks up the datacenter that the given host belongs to.
 func (c *Client) HostDatacenter(ctx context.Context, host string) (dc string, err error) {
 	// Try reading from cache

--- a/pkg/scyllaclient/retry_integration_test.go
+++ b/pkg/scyllaclient/retry_integration_test.go
@@ -57,7 +57,7 @@ func TestRetryWithTimeoutIntegration(t *testing.T) {
 		test := table[i]
 
 		t.Run(fmt.Sprintf("block %d nodes", test.block), func(t *testing.T) {
-			if err := testRetry(hosts, test.block, test.timeout); err != nil {
+			if err := testRetry(t, hosts, test.block, test.timeout); err != nil {
 				t.Fatal(err)
 			}
 		})
@@ -72,12 +72,12 @@ func allHosts() ([]string, error) {
 	return client.Hosts(context.Background())
 }
 
-func testRetry(hosts []string, n int, shouldTimeout bool) error {
+func testRetry(t *testing.T, hosts []string, n int, shouldTimeout bool) error {
 	blockedHosts := make([]string, 0, len(hosts))
 
 	block := func(ctx context.Context, hosts []string) error {
 		for _, h := range hosts {
-			err := RunIptablesCommand(h, CmdBlockScyllaREST)
+			err := RunIptablesCommand(t, h, CmdBlockScyllaREST)
 			if err != nil {
 				return err
 			}
@@ -88,7 +88,7 @@ func testRetry(hosts []string, n int, shouldTimeout bool) error {
 
 	unblock := func(ctx context.Context) error {
 		for _, h := range blockedHosts {
-			err := RunIptablesCommand(h, CmdUnblockScyllaREST)
+			err := RunIptablesCommand(t, h, CmdUnblockScyllaREST)
 			if err != nil {
 				return err
 			}

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -859,10 +859,10 @@ func TestBackupWithNodesDownIntegration(t *testing.T) {
 	WriteData(t, clusterSession, testKeyspace, 1)
 
 	Print("Given: downed node")
-	if err := RunIptablesCommand(IPFromTestNet("11"), CmdBlockScyllaREST); err != nil {
+	if err := RunIptablesCommand(t, IPFromTestNet("11"), CmdBlockScyllaREST); err != nil {
 		t.Fatal(err)
 	}
-	defer RunIptablesCommand(IPFromTestNet("11"), CmdUnblockScyllaREST)
+	defer RunIptablesCommand(t, IPFromTestNet("11"), CmdUnblockScyllaREST)
 
 	Print("When: get target")
 	target := backup.Target{

--- a/pkg/service/cluster/service.go
+++ b/pkg/service/cluster/service.go
@@ -230,11 +230,12 @@ func (s *Service) discoverClusterHosts(ctx context.Context, c *Cluster) (knownHo
 	}()
 
 	// Read results until the channel is closed
-	for hosts := range result {
+	hosts, ok := <-result
+	if ok {
 		return hosts.known, hosts.live, nil
 	}
 
-	// If no valid results, return error<
+	// If no valid results, return error
 	return nil, nil, ErrNoValidKnownHost
 }
 

--- a/pkg/service/cluster/service_integration_test.go
+++ b/pkg/service/cluster/service_integration_test.go
@@ -98,6 +98,13 @@ func TestValidateHostConnectivityIntegration(t *testing.T) {
 					}
 				}
 			}()
+			TryUnblockCQL(t, ManagedClusterHosts())
+			TryUnblockREST(t, ManagedClusterHosts())
+			TryUnblockAlternator(t, ManagedClusterHosts())
+			TryStartAgent(t, ManagedClusterHosts())
+			if err := EnsureNodesAreUP(t, ManagedClusterHosts(), time.Minute); err != nil {
+				t.Fatalf("not all nodes are UP, err = {%v}", err)
+			}
 
 			Printf("then: validate that call to validate host connectivity takes less than %v seconds", tc.timeout.Seconds())
 			testCluster, err := s.GetClusterByID(context.Background(), c.ID)

--- a/pkg/service/cluster/service_integration_test.go
+++ b/pkg/service/cluster/service_integration_test.go
@@ -93,7 +93,7 @@ func TestValidateHostConnectivityIntegration(t *testing.T) {
 					if err := StartService(host, "scylla"); err != nil {
 						t.Logf("error on starting stopped scylla service on host={%s}, err={%s}", host, err)
 					}
-					if err := RunIptablesCommand(host, CmdUnblockScyllaREST); err != nil {
+					if err := RunIptablesCommand(t, host, CmdUnblockScyllaREST); err != nil {
 						t.Logf("error trying to unblock REST API on host = {%s}, err={%s}", host, err)
 					}
 				}
@@ -122,7 +122,7 @@ func TestValidateHostConnectivityIntegration(t *testing.T) {
 				if err := StopService(host, "scylla"); err != nil {
 					t.Fatal(err)
 				}
-				if err := RunIptablesCommand(host, CmdBlockScyllaREST); err != nil {
+				if err := RunIptablesCommand(t, host, CmdBlockScyllaREST); err != nil {
 					t.Error(err)
 				}
 			}
@@ -675,10 +675,10 @@ func TestServiceStorageIntegration(t *testing.T) {
 
 		c := validCluster()
 		c.Host = h1
-		if err := RunIptablesCommand(h2, CmdBlockScyllaREST); err != nil {
+		if err := RunIptablesCommand(t, h2, CmdBlockScyllaREST); err != nil {
 			t.Fatal(err)
 		}
-		defer RunIptablesCommand(h2, CmdUnblockScyllaREST)
+		defer RunIptablesCommand(t, h2, CmdUnblockScyllaREST)
 
 		if err := s.PutCluster(ctx, c); err == nil {
 			t.Fatal("expected put cluster to fail because of connectivity issues")

--- a/pkg/service/cluster/service_integration_test.go
+++ b/pkg/service/cluster/service_integration_test.go
@@ -34,6 +34,10 @@ import (
 )
 
 func TestValidateHostConnectivityIntegration(t *testing.T) {
+	if IsIPV6Network() {
+		t.Skip("DB node do not have ip6tables and related modules to make it work properly")
+	}
+
 	Print("given: the fresh cluster")
 	var (
 		ctx          = context.Background()

--- a/pkg/service/healthcheck/service_integration_test.go
+++ b/pkg/service/healthcheck/service_integration_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -23,7 +22,6 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/configcache"
-	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/scylladb/scylla-manager/v3/pkg/schema/table"
@@ -51,11 +49,11 @@ func TestStatus_Ping_Independent_From_REST_Integration(t *testing.T) {
 	}
 
 	// Given
-	tryUnblockCQL(t, ManagedClusterHosts())
-	tryUnblockREST(t, ManagedClusterHosts())
-	tryUnblockAlternator(t, ManagedClusterHosts())
-	tryStartAgent(t, ManagedClusterHosts())
-	if err := ensureNodesAreUP(t, ManagedClusterHosts(), time.Minute); err != nil {
+	TryUnblockCQL(t, ManagedClusterHosts())
+	TryUnblockREST(t, ManagedClusterHosts())
+	TryUnblockAlternator(t, ManagedClusterHosts())
+	TryStartAgent(t, ManagedClusterHosts())
+	if err := EnsureNodesAreUP(t, ManagedClusterHosts(), time.Minute); err != nil {
 		t.Fatalf("not all nodes are UP, err = {%v}", err)
 	}
 
@@ -122,8 +120,8 @@ func TestStatus_Ping_Independent_From_REST_Integration(t *testing.T) {
 	}
 
 	// When #2 -> one of the hosts has unresponsive REST API
-	defer unblockREST(t, hostWithUnresponsiveREST)
-	blockREST(t, hostWithUnresponsiveREST)
+	defer UnblockREST(t, hostWithUnresponsiveREST)
+	BlockREST(t, hostWithUnresponsiveREST)
 
 	// Then #2 -> only REST ping fails, CQL and Alternator are fine
 	status, err = healthSvc.Status(context.Background(), testCluster.ID)
@@ -216,16 +214,16 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 	// Tests here do not test the dynamic t/o functionality
 	c := DefaultConfig()
 
-	tryUnblockCQL(t, ManagedClusterHosts())
-	tryUnblockREST(t, ManagedClusterHosts())
-	tryUnblockAlternator(t, ManagedClusterHosts())
-	tryStartAgent(t, ManagedClusterHosts())
+	TryUnblockCQL(t, ManagedClusterHosts())
+	TryUnblockREST(t, ManagedClusterHosts())
+	TryUnblockAlternator(t, ManagedClusterHosts())
+	TryStartAgent(t, ManagedClusterHosts())
 
 	defer func() {
-		tryUnblockCQL(t, ManagedClusterHosts())
-		tryUnblockREST(t, ManagedClusterHosts())
-		tryUnblockAlternator(t, ManagedClusterHosts())
-		tryStartAgent(t, ManagedClusterHosts())
+		TryUnblockCQL(t, ManagedClusterHosts())
+		TryUnblockREST(t, ManagedClusterHosts())
+		TryUnblockAlternator(t, ManagedClusterHosts())
+		TryStartAgent(t, ManagedClusterHosts())
 	}()
 
 	hrt := NewHackableRoundTripper(scyllaclient.DefaultTransport())
@@ -288,8 +286,8 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 
 	t.Run("node REST TIMEOUT", func(t *testing.T) {
 		host := IPFromTestNet("12")
-		blockREST(t, host)
-		defer unblockREST(t, host)
+		BlockREST(t, host)
+		defer UnblockREST(t, host)
 
 		status, err := s.Status(context.Background(), clusterID)
 		if err != nil {
@@ -314,8 +312,8 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 
 	t.Run("node CQL TIMEOUT", func(t *testing.T) {
 		host := IPFromTestNet("12")
-		blockCQL(t, host, sslEnabled)
-		defer unblockCQL(t, host, sslEnabled)
+		BlockCQL(t, host, sslEnabled)
+		defer UnblockCQL(t, host, sslEnabled)
 
 		status, err := s.Status(context.Background(), clusterID)
 		if err != nil {
@@ -340,8 +338,8 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 
 	t.Run("node Alternator TIMEOUT", func(t *testing.T) {
 		host := IPFromTestNet("12")
-		blockAlternator(t, host)
-		defer unblockAlternator(t, host)
+		BlockAlternator(t, host)
+		defer UnblockAlternator(t, host)
 
 		status, err := s.Status(context.Background(), clusterID)
 		if err != nil {
@@ -366,8 +364,8 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 
 	t.Run("node REST DOWN", func(t *testing.T) {
 		host := IPFromTestNet("12")
-		stopAgent(t, host)
-		defer startAgent(t, host)
+		StopAgent(t, host)
+		defer StartAgent(t, host)
 
 		status, err := s.Status(context.Background(), clusterID)
 		if err != nil {
@@ -445,11 +443,11 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 		defer cancel()
 
 		for _, h := range ManagedClusterHosts() {
-			blockREST(t, h)
+			BlockREST(t, h)
 		}
 		defer func() {
 			for _, h := range ManagedClusterHosts() {
-				unblockREST(t, h)
+				UnblockREST(t, h)
 			}
 		}()
 
@@ -471,127 +469,6 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 			t.Error("Expected error got nil")
 		}
 	})
-}
-
-func blockREST(t *testing.T, h string) {
-	t.Helper()
-	if err := RunIptablesCommand(h, CmdBlockScyllaREST); err != nil {
-		t.Error(err)
-	}
-}
-
-func unblockREST(t *testing.T, h string) {
-	t.Helper()
-	if err := RunIptablesCommand(h, CmdUnblockScyllaREST); err != nil {
-		t.Error(err)
-	}
-}
-
-func tryUnblockREST(t *testing.T, hosts []string) {
-	t.Helper()
-	for _, host := range hosts {
-		_ = RunIptablesCommand(host, CmdUnblockScyllaREST)
-	}
-}
-
-func blockCQL(t *testing.T, h string, sslEnabled bool) {
-	t.Helper()
-	cmd := CmdBlockScyllaCQL
-	if sslEnabled {
-		cmd = CmdBlockScyllaCQLSSL
-	}
-	if err := RunIptablesCommand(h, cmd); err != nil {
-		t.Error(err)
-	}
-}
-
-func unblockCQL(t *testing.T, h string, sslEnabled bool) {
-	t.Helper()
-	cmd := CmdUnblockScyllaCQL
-	if sslEnabled {
-		cmd = CmdUnblockScyllaCQLSSL
-	}
-	if err := RunIptablesCommand(h, cmd); err != nil {
-		t.Error(err)
-	}
-}
-
-func tryUnblockCQL(t *testing.T, hosts []string) {
-	t.Helper()
-	for _, host := range hosts {
-		_ = RunIptablesCommand(host, CmdUnblockScyllaCQL)
-	}
-}
-
-func blockAlternator(t *testing.T, h string) {
-	t.Helper()
-	if err := RunIptablesCommand(h, CmdBlockScyllaAlternator); err != nil {
-		t.Error(err)
-	}
-}
-
-func unblockAlternator(t *testing.T, h string) {
-	t.Helper()
-	if err := RunIptablesCommand(h, CmdUnblockScyllaAlternator); err != nil {
-		t.Error(err)
-	}
-}
-
-func tryUnblockAlternator(t *testing.T, hosts []string) {
-	t.Helper()
-	for _, host := range hosts {
-		_ = RunIptablesCommand(host, CmdUnblockScyllaAlternator)
-	}
-}
-
-const agentService = "scylla-manager-agent"
-
-func stopAgent(t *testing.T, h string) {
-	t.Helper()
-	if err := StopService(h, agentService); err != nil {
-		t.Error(err)
-	}
-}
-
-func startAgent(t *testing.T, h string) {
-	t.Helper()
-	if err := StartService(h, agentService); err != nil {
-		t.Error(err)
-	}
-}
-
-func tryStartAgent(t *testing.T, hosts []string) {
-	t.Helper()
-	for _, host := range hosts {
-		_ = StartService(host, agentService)
-	}
-}
-
-func ensureNodesAreUP(t *testing.T, hosts []string, timeout time.Duration) error {
-	t.Helper()
-
-	var (
-		allErrors error
-		mu        sync.Mutex
-	)
-
-	wg := sync.WaitGroup{}
-	for _, host := range hosts {
-		wg.Add(1)
-
-		go func(h string) {
-			defer wg.Done()
-
-			if err := WaitForNodeUPOrTimeout(h, timeout); err != nil {
-				mu.Lock()
-				allErrors = multierr.Combine(allErrors, err)
-				mu.Unlock()
-			}
-		}(host)
-	}
-	wg.Wait()
-
-	return allErrors
 }
 
 const pingPath = "/storage_service/scylla_release_version"

--- a/pkg/testutils/exec.go
+++ b/pkg/testutils/exec.go
@@ -40,6 +40,9 @@ const (
 
 	// CmdUnblockScyllaAlternator defines the command used for unblocking the Scylla Alternator access.
 	CmdUnblockScyllaAlternator = "iptables -D INPUT -p tcp --destination-port 8000 -j DROP"
+
+	// CmdOrTrueAppend let to accept shell command failure and proceed
+	CmdOrTrueAppend = " || true"
 )
 
 func makeIPV6Rule(rule string) string {
@@ -176,7 +179,7 @@ func UnblockREST(t *testing.T, h string) {
 func TryUnblockREST(t *testing.T, hosts []string) {
 	t.Helper()
 	for _, host := range hosts {
-		if err := RunIptablesCommand(t, host, CmdUnblockScyllaREST); err != nil {
+		if err := RunIptablesCommand(t, host, CmdUnblockScyllaREST+CmdOrTrueAppend); err != nil {
 			t.Log(err)
 		}
 	}
@@ -211,7 +214,7 @@ func UnblockCQL(t *testing.T, h string, sslEnabled bool) {
 func TryUnblockCQL(t *testing.T, hosts []string) {
 	t.Helper()
 	for _, host := range hosts {
-		if err := RunIptablesCommand(t, host, CmdUnblockScyllaCQL); err != nil {
+		if err := RunIptablesCommand(t, host, CmdUnblockScyllaCQL+CmdOrTrueAppend); err != nil {
 			t.Log(err)
 		}
 	}
@@ -238,7 +241,7 @@ func UnblockAlternator(t *testing.T, h string) {
 func TryUnblockAlternator(t *testing.T, hosts []string) {
 	t.Helper()
 	for _, host := range hosts {
-		if err := RunIptablesCommand(t, host, CmdUnblockScyllaAlternator); err != nil {
+		if err := RunIptablesCommand(t, host, CmdUnblockScyllaAlternator+CmdOrTrueAppend); err != nil {
 			t.Log(err)
 		}
 	}
@@ -267,7 +270,7 @@ func StartAgent(t *testing.T, h string) {
 func TryStartAgent(t *testing.T, hosts []string) {
 	t.Helper()
 	for _, host := range hosts {
-		if err := StartService(host, agentService); err != nil {
+		if err := StartService(host, agentService+CmdOrTrueAppend); err != nil {
 			t.Log(err)
 		}
 	}

--- a/pkg/testutils/exec.go
+++ b/pkg/testutils/exec.go
@@ -41,7 +41,7 @@ const (
 	// CmdUnblockScyllaAlternator defines the command used for unblocking the Scylla Alternator access.
 	CmdUnblockScyllaAlternator = "iptables -D INPUT -p tcp --destination-port 8000 -j DROP"
 
-	// CmdOrTrueAppend let to accept shell command failure and proceed
+	// CmdOrTrueAppend let to accept shell command failure and proceed.
 	CmdOrTrueAppend = " || true"
 )
 

--- a/pkg/testutils/exec.go
+++ b/pkg/testutils/exec.go
@@ -47,16 +47,20 @@ func makeIPV6Rule(rule string) string {
 }
 
 // RunIptablesCommand executes iptables command, repeats same command for IPV6 iptables rule.
-func RunIptablesCommand(host, cmd string) error {
+func RunIptablesCommand(t *testing.T, host, cmd string) error {
+	t.Helper()
 	if IsIPV6Network() {
-		return ExecOnHostStatus(host, makeIPV6Rule(cmd))
+		return ExecOnHostStatus(t, host, makeIPV6Rule(cmd))
 	}
-	return ExecOnHostStatus(host, cmd)
+	return ExecOnHostStatus(t, host, cmd)
 }
 
 // ExecOnHostStatus executes the given command on the given host and returns on error.
-func ExecOnHostStatus(host, cmd string) error {
-	_, _, err := ExecOnHost(host, cmd)
+func ExecOnHostStatus(t *testing.T, host, cmd string) error {
+	stdOut, stdErr, err := ExecOnHost(host, cmd)
+	if err != nil {
+		t.Logf("cnd: {%s}, stdout: {%s}, stderr: {%s}", cmd, stdOut, stdErr)
+	}
 	return errors.Wrapf(err, "run command %s", cmd)
 }
 
@@ -153,7 +157,7 @@ func WaitForNodeUPOrTimeout(h string, timeout time.Duration) error {
 // BlockREST blocks the Scylla API ports on h machine by dropping TCP packets.
 func BlockREST(t *testing.T, h string) {
 	t.Helper()
-	if err := RunIptablesCommand(h, CmdBlockScyllaREST); err != nil {
+	if err := RunIptablesCommand(t, h, CmdBlockScyllaREST); err != nil {
 		t.Error(err)
 	}
 }
@@ -161,7 +165,7 @@ func BlockREST(t *testing.T, h string) {
 // UnblockREST unblocks the Scylla API ports on []hosts machines.
 func UnblockREST(t *testing.T, h string) {
 	t.Helper()
-	if err := RunIptablesCommand(h, CmdUnblockScyllaREST); err != nil {
+	if err := RunIptablesCommand(t, h, CmdUnblockScyllaREST); err != nil {
 		t.Error(err)
 	}
 }
@@ -171,7 +175,7 @@ func UnblockREST(t *testing.T, h string) {
 func TryUnblockREST(t *testing.T, hosts []string) {
 	t.Helper()
 	for _, host := range hosts {
-		if err := RunIptablesCommand(host, CmdUnblockScyllaREST); err != nil {
+		if err := RunIptablesCommand(t, host, CmdUnblockScyllaREST); err != nil {
 			t.Log(err)
 		}
 	}
@@ -184,7 +188,7 @@ func BlockCQL(t *testing.T, h string, sslEnabled bool) {
 	if sslEnabled {
 		cmd = CmdBlockScyllaCQLSSL
 	}
-	if err := RunIptablesCommand(h, cmd); err != nil {
+	if err := RunIptablesCommand(t, h, cmd); err != nil {
 		t.Error(err)
 	}
 }
@@ -196,7 +200,7 @@ func UnblockCQL(t *testing.T, h string, sslEnabled bool) {
 	if sslEnabled {
 		cmd = CmdUnblockScyllaCQLSSL
 	}
-	if err := RunIptablesCommand(h, cmd); err != nil {
+	if err := RunIptablesCommand(t, h, cmd); err != nil {
 		t.Error(err)
 	}
 }
@@ -206,7 +210,7 @@ func UnblockCQL(t *testing.T, h string, sslEnabled bool) {
 func TryUnblockCQL(t *testing.T, hosts []string) {
 	t.Helper()
 	for _, host := range hosts {
-		if err := RunIptablesCommand(host, CmdUnblockScyllaCQL); err != nil {
+		if err := RunIptablesCommand(t, host, CmdUnblockScyllaCQL); err != nil {
 			t.Log(err)
 		}
 	}
@@ -215,7 +219,7 @@ func TryUnblockCQL(t *testing.T, hosts []string) {
 // BlockAlternator blocks the Scylla Alternator ports on h machine by dropping TCP packets.
 func BlockAlternator(t *testing.T, h string) {
 	t.Helper()
-	if err := RunIptablesCommand(h, CmdBlockScyllaAlternator); err != nil {
+	if err := RunIptablesCommand(t, h, CmdBlockScyllaAlternator); err != nil {
 		t.Error(err)
 	}
 }
@@ -223,7 +227,7 @@ func BlockAlternator(t *testing.T, h string) {
 // UnblockAlternator unblocks the Alternator ports on []hosts machines.
 func UnblockAlternator(t *testing.T, h string) {
 	t.Helper()
-	if err := RunIptablesCommand(h, CmdUnblockScyllaAlternator); err != nil {
+	if err := RunIptablesCommand(t, h, CmdUnblockScyllaAlternator); err != nil {
 		t.Error(err)
 	}
 }
@@ -233,7 +237,7 @@ func UnblockAlternator(t *testing.T, h string) {
 func TryUnblockAlternator(t *testing.T, hosts []string) {
 	t.Helper()
 	for _, host := range hosts {
-		if err := RunIptablesCommand(host, CmdUnblockScyllaAlternator); err != nil {
+		if err := RunIptablesCommand(t, host, CmdUnblockScyllaAlternator); err != nil {
 			t.Log(err)
 		}
 	}

--- a/pkg/testutils/exec.go
+++ b/pkg/testutils/exec.go
@@ -57,6 +57,7 @@ func RunIptablesCommand(t *testing.T, host, cmd string) error {
 
 // ExecOnHostStatus executes the given command on the given host and returns on error.
 func ExecOnHostStatus(t *testing.T, host, cmd string) error {
+	t.Helper()
 	stdOut, stdErr, err := ExecOnHost(host, cmd)
 	if err != nil {
 		t.Logf("cnd: {%s}, stdout: {%s}, stderr: {%s}", cmd, stdOut, stdErr)

--- a/pkg/testutils/netwait_integration_test.go
+++ b/pkg/testutils/netwait_integration_test.go
@@ -22,11 +22,11 @@ func TestWaiterTimeoutIntegration(t *testing.T) {
 	}
 	host := ManagedClusterHost()
 
-	err := RunIptablesCommand(host, CmdBlockScyllaCQL)
+	err := RunIptablesCommand(t, host, CmdBlockScyllaCQL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer RunIptablesCommand(host, CmdUnblockScyllaCQL)
+	defer RunIptablesCommand(t, host, CmdUnblockScyllaCQL)
 
 	w := &netwait.Waiter{
 		DialTimeout:  5 * time.Millisecond,


### PR DESCRIPTION
Fixes #4074

This PR makes the cluster hosts discovery more robust, as when the cluster.host is DOWN,
it probes all other hosts in parallel and returns response from the fastest one.
Additionally, this PR makes the call to cluster config cache async on updating cluster.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
