### PR TITLE
Managerclient: improve post-restore repair progress display

### DIFF
--- a/v3/pkg/managerclient/model.go
+++ b/v3/pkg/managerclient/model.go
@@ -1080,25 +1080,59 @@ func (rp RestoreProgress) Render(w io.Writer) error {
 	// Check if there is repair progress to display
 	if rp.Progress.RepairProgress != nil {
 		fmt.Fprintf(w, "\nPost-restore repair progress\n")
-
-		repairRunPr := &models.TaskRunRepairProgress{
-			Progress: rp.Progress.RepairProgress,
-			Run:      rp.Run,
-		}
-		repairPr := RepairProgress{
-			TaskRunRepairProgress: repairRunPr,
-			Task:                  rp.Task,
-			Detailed:              rp.Detailed,
-			keyspaceFilter:        rp.KeyspaceFilter,
-		}
-
-		if err := repairPr.Render(w); err != nil {
+		if err := rp.postRestoreRepairProgress().Render(w); err != nil {
 			return err
 		}
 	}
 
 	rp.addViewProgress(w)
 	return nil
+}
+
+func (rp RestoreProgress) postRestoreRepairProgress() RepairProgress {
+	repair := rp.Progress.RepairProgress
+
+	repairRun := &models.TaskRun{
+		ClusterID: rp.Task.ClusterID,
+		Type:      RepairTask,
+	}
+	if repair.StartedAt != nil {
+		repairRun.StartTime = *repair.StartedAt
+	}
+	if repair.CompletedAt != nil {
+		repairRun.EndTime = *repair.CompletedAt
+	}
+	if rp.Progress.Stage == RestoreStageRepair {
+		repairRun.Cause = rp.Run.Cause
+		repairRun.Status = rp.Run.Status
+	} else {
+		switch {
+		case repair.Success == repair.TokenRanges:
+			repairRun.Status = TaskStatusDone
+		case repair.Error > 0:
+			repairRun.Status = TaskStatusError
+		}
+	}
+
+	repairTask := &models.Task{
+		ClusterID: rp.Task.ClusterID,
+		Enabled:   true,
+		Properties: map[string]any{
+			"intensity": repair.Intensity,
+			"parallel":  repair.Parallel,
+		},
+		Type: RepairTask,
+	}
+
+	return RepairProgress{
+		TaskRunRepairProgress: &models.TaskRunRepairProgress{
+			Progress: repair,
+			Run:      repairRun,
+		},
+		Task:           repairTask,
+		Detailed:       rp.Detailed,
+		keyspaceFilter: rp.KeyspaceFilter,
+	}
 }
 
 func (rp RestoreProgress) addKeyspaceProgress(t *table.Table) {


### PR DESCRIPTION
Previously all run/task properties of post-restore repair progress were taken directly from the restore progress.
This included things like start/end time, properties, status, cause and others. It resulted in misleading progress display. This commit fixes that by deliberately leaving out, inheriting, or setting interesting repair progress fields.

Fixes #4046