### PR TITLE
feat(restore): adds exclusive cluster lock for restore task

### DIFF
--- a/pkg/service/scheduler/mock_policy_test.go
+++ b/pkg/service/scheduler/mock_policy_test.go
@@ -35,27 +35,27 @@ func (m *mockPolicy) EXPECT() *mockPolicyMockRecorder {
 }
 
 // PostRun mocks base method.
-func (m *mockPolicy) PostRun(arg0, arg1, arg2 uuid.UUID) {
+func (m *mockPolicy) PostRun(arg0, arg1, arg2 uuid.UUID, arg3 TaskType) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "PostRun", arg0, arg1, arg2)
+	m.ctrl.Call(m, "PostRun", arg0, arg1, arg2, arg3)
 }
 
 // PostRun indicates an expected call of PostRun.
-func (mr *mockPolicyMockRecorder) PostRun(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *mockPolicyMockRecorder) PostRun(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRun", reflect.TypeOf((*mockPolicy)(nil).PostRun), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRun", reflect.TypeOf((*mockPolicy)(nil).PostRun), arg0, arg1, arg2, arg3)
 }
 
 // PreRun mocks base method.
-func (m *mockPolicy) PreRun(arg0, arg1, arg2 uuid.UUID) error {
+func (m *mockPolicy) PreRun(arg0, arg1, arg2 uuid.UUID, arg3 TaskType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PreRun", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "PreRun", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PreRun indicates an expected call of PreRun.
-func (mr *mockPolicyMockRecorder) PreRun(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *mockPolicyMockRecorder) PreRun(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreRun", reflect.TypeOf((*mockPolicy)(nil).PreRun), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreRun", reflect.TypeOf((*mockPolicy)(nil).PreRun), arg0, arg1, arg2, arg3)
 }

--- a/pkg/service/scheduler/policy.go
+++ b/pkg/service/scheduler/policy.go
@@ -5,6 +5,7 @@ package scheduler
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -13,55 +14,85 @@ import (
 
 // Policy decides if given task can be run.
 type Policy interface {
-	PreRun(clusterID, taskID, runID uuid.UUID) error
-	PostRun(clusterID, taskID, runID uuid.UUID)
+	PreRun(clusterID, taskID, runID uuid.UUID, taskType TaskType) error
+	PostRun(clusterID, taskID, runID uuid.UUID, taskType TaskType)
 }
 
 // PolicyRunner is a runner that uses policy to check if a task can be run.
 type PolicyRunner struct {
 	Policy Policy
 	Runner Runner
+
+	// TaskType of a task that this runner is executing
+	TaskType TaskType
 }
 
 // Run implements Runner.
 func (pr PolicyRunner) Run(ctx context.Context, clusterID, taskID, runID uuid.UUID, properties json.RawMessage) error {
-	if err := pr.Policy.PreRun(clusterID, taskID, runID); err != nil {
+	if err := pr.Policy.PreRun(clusterID, taskID, runID, pr.TaskType); err != nil {
 		return err
 	}
-	defer pr.Policy.PostRun(clusterID, taskID, runID)
+	defer pr.Policy.PostRun(clusterID, taskID, runID, pr.TaskType)
 	return pr.Runner.Run(ctx, clusterID, taskID, runID, properties)
 }
 
 var errClusterBusy = errors.New("another task is running")
 
-// LockClusterPolicy is a policy that can execute only one task at a time.
-type LockClusterPolicy struct {
-	mu   sync.Mutex
-	busy map[uuid.UUID]struct{}
+// TaskExclusiveLockPolicy is a policy that executes the exclusiveTask only if there are no other tasks in the cluster.
+// Conversely, other tasks can run only if the exclusiveTask is not running.
+// Additionally this policy ensures that only one task of a task type can be executed at a time in a cluster.
+type TaskExclusiveLockPolicy struct {
+	mu      sync.Mutex
+	running map[uuid.UUID]map[TaskType]struct{}
+
+	exclusiveTask TaskType
 }
 
-func NewLockClusterPolicy() *LockClusterPolicy {
-	return &LockClusterPolicy{
-		busy: make(map[uuid.UUID]struct{}),
+func NewTaskExclusiveLockPolicy(exclusiveTask TaskType) *TaskExclusiveLockPolicy {
+	return &TaskExclusiveLockPolicy{
+		running: map[uuid.UUID]map[TaskType]struct{}{},
+
+		exclusiveTask: exclusiveTask,
 	}
 }
 
-// PreRun implements Policy.
-func (p *LockClusterPolicy) PreRun(clusterID, _, _ uuid.UUID) error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+// PreRun acquires exclusive lock on a cluster for a provided taskType.
+func (t *TaskExclusiveLockPolicy) PreRun(clusterID, _, _ uuid.UUID, taskType TaskType) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
-	if _, ok := p.busy[clusterID]; ok {
+	cluster, ok := t.running[clusterID]
+	if !ok {
+		t.running[clusterID] = map[TaskType]struct{}{}
+	}
+	if len(cluster) == 0 {
+		t.running[clusterID][taskType] = struct{}{}
+		return nil
+	}
+
+	// Exclusive task can be run only when no other tasks is running.
+	if taskType == t.exclusiveTask {
+		return fmt.Errorf("run exclusive task %s: %w", taskType, errClusterBusy)
+	}
+
+	// Any other task can't be run when exclusive task is running.
+	if _, ok := cluster[t.exclusiveTask]; ok {
+		return fmt.Errorf("exclusive task (%s) is running: %w", taskType, errClusterBusy)
+	}
+
+	// Only one task of a taskType can run in a cluster at a time.
+	if _, ok := cluster[taskType]; ok {
 		return errClusterBusy
 	}
 
-	p.busy[clusterID] = struct{}{}
+	t.running[clusterID][taskType] = struct{}{}
+
 	return nil
 }
 
-// PostRun implements Policy.
-func (p *LockClusterPolicy) PostRun(clusterID, _, _ uuid.UUID) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	delete(p.busy, clusterID)
+// PostRun releases a lock on a cluster for a provided taskType.
+func (t *TaskExclusiveLockPolicy) PostRun(clusterID, _, _ uuid.UUID, taskType TaskType) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.running[clusterID], taskType)
 }


### PR DESCRIPTION
This makes the scheduler run the restore task only if no other tasks (backup or repair) are running in the cluster. Conversely, other tasks (backup or repair) won't start if the restore task is running in the cluster at that time.

Refs: #4045.


---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
