### PR TITLE
docs: adds info about restore and backup/repair tasks interference

### DIFF
--- a/docs/source/restore/index.rst
+++ b/docs/source/restore/index.rst
@@ -89,14 +89,15 @@ and :ref:`resume <task-start>` it.
 Interference with backup and repair tasks
 =========================================
 
-It is advisable to manually make sure that the restore task does not interfere with backup or repair tasks.
+The restore task will not start if backup or repair tasks are running in the cluster at that time, and vice versa, if a restore task is running, backup or repair tasks will not start. 
+You will see an error in the output of the ``sctool tasks`` command if there is a conflict between tasks. 
+Here is an example output of ``sctool progress -c ${cluster_name} {task_id}`` when there is an interference between tasks::
 
-#. Do not start backup or repair tasks when restore task is running.
-#. If scheduled runs of backup or repair tasks can interfier with restore task, then disable them until restore is complete::
-
-    # check Next column to determine when next run of a task is scheduled 
-    $ sctool tasks -a
-
-    # disable repair/backup tasks if needed
-    $ sctool repair update -c CLUSTER-ID SCHEDULED-REPAIR-TASK-ID --enabled=false
-    $ sctool backup update -c CLUSTER-ID SCHEDULED-BACKUP-TASK-ID --enabled=false
+    $  ./sctool.dev progress -c my-cluster backup/06cd5d90-6daa-4215-acd3-d19f6782b5b6
+    Run:            351378ee-ab05-11ef-aa2d-0242c0a8c802
+    Status:         ERROR (initialising)
+    Cause:          exclusive task (restore) is running: another task is running
+    Start time:     25 Nov 24 09:13:52 CET
+    End time:       25 Nov 24 09:13:52 CET
+    Duration:       0s
+    Progress:       -

--- a/docs/source/sctool/partials/sctool_repair.yaml
+++ b/docs/source/sctool/partials/sctool_repair.yaml
@@ -129,7 +129,7 @@ options:
       usage: |
         Prints table names together with keyspace, used in combination with --dry-run.
     - name: small-table-threshold
-      default_value: 1G
+      default_value: 1GiB
       usage: |
         Enables small table optimization for tables of size lower than given threshold, supported units [B, M, G, T].
     - name: start-date

--- a/docs/source/sctool/partials/sctool_repair_update.yaml
+++ b/docs/source/sctool/partials/sctool_repair_update.yaml
@@ -130,7 +130,7 @@ options:
       usage: |
         Prints table names together with keyspace, used in combination with --dry-run.
     - name: small-table-threshold
-      default_value: 1G
+      default_value: 1GiB
       usage: |
         Enables small table optimization for tables of size lower than given threshold, supported units [B, M, G, T].
     - name: start-date


### PR DESCRIPTION
This extends restore procedure docs with how to avoid conflicts between restore and backup/repair tasks in a cluster.

Fixes: #3742

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
