### PR TITLE
PoC for 1-1 restore (VNODES)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,3 +257,212 @@ vendor: ## Fix dependencies and make vendored copies
 .PHONY: help
 help:
 	@awk -F ':|##' '/^[^\t].+?:.*?##/ {printf "\033[36m%-25s\033[0m %s\n", $$1, $$NF}' $(MAKEFILE_LIST)
+
+.PHONY: extract_tokens_and_schema
+extract_tokens_and_schema:
+	@echo "Extracting tokens from .1-1-restore-poc/256000_rows_backuptest_data_big_table.tar..."
+	@mkdir -p extracted_data
+	@tar -xzf .1-1-restore-poc/256000_rows_backuptest_data_big_table.tar -C extracted_data
+
+	# Extract tokens from meta/cluster/<cluster_id>/dc/<dc_id>/node/<node_id>
+	@echo "Finding archives in extracted_data/meta/cluster/*/dc/*/node/*..."
+	@find extracted_data/meta/cluster/*/dc/*/node/* -type f -name "*.gz" | while read inner_archive; do \
+		echo "Processing archive: $$inner_archive"; \
+		dc=$$(echo "$$inner_archive" | awk -F'/' '{for (i=1; i<=NF; i++) if ($$i == "dc") print $$(i+1)}'); \
+		node=$$(echo "$$inner_archive" | awk -F'/' '{for (i=1; i<=NF; i++) if ($$i == "node") print $$(i+1)}'); \
+		echo "  Found DC: $$dc"; \
+		echo "  Found Node: $$node"; \
+		tmp_dir=$$(mktemp -d); \
+		gunzip -c "$$inner_archive" > "$$tmp_dir/extracted.json"; \
+		if [ -s "$$tmp_dir/extracted.json" ]; then \
+			echo "    Extracted JSON file: $$tmp_dir/extracted.json"; \
+			tokens=$$(jq -r '.tokens | join(",")' "$$tmp_dir/extracted.json"); \
+			echo "    Extracted Tokens: $$tokens"; \
+			output_file=".1-1-restore-poc/$$dc-$$node.tokens"; \
+			echo "$$tokens" > "$$output_file"; \
+			echo "    Tokens saved to $$output_file"; \
+		else \
+			echo "    No valid JSON file found in $$inner_archive"; \
+		fi; \
+		rm -rf "$$tmp_dir"; \
+	done
+
+	# Extract schema CQL from schema/cluster/<cluster_id>/<file>.gz
+	@echo "Processing schema files in extracted_data/schema/cluster/..."
+	@find extracted_data/schema/cluster/* -type f -name "*.gz" | while read schema_archive; do \
+		echo "Processing schema archive: $$schema_archive"; \
+		tmp_dir=$$(mktemp -d); \
+		gunzip -c "$$schema_archive" > "$$tmp_dir/schema.json"; \
+		if [ -s "$$tmp_dir/schema.json" ]; then \
+			echo "    Extracted schema JSON file: $$tmp_dir/schema.json"; \
+			cql_stmts=$$(jq -r '.[].cql_stmt' "$$tmp_dir/schema.json"); \
+			output_schema=".1-1-restore-poc/schema.CQL"; \
+			echo "$$cql_stmts" > "$$output_schema"; \
+			echo "    CQL statements saved to $$output_schema"; \
+		else \
+			echo "    No valid JSON schema file found in $$schema_archive"; \
+		fi; \
+		rm -rf "$$tmp_dir"; \
+	done
+
+	@rm -rf extracted_data
+	@echo "All extracted data has been removed."
+
+tokens_dir := ./.1-1-restore-poc
+restore_dir := ./testing/scylla
+
+.PHONY: set_initial_tokens
+set_initial_tokens:
+	@echo "Creating mapping and setting initial tokens..."
+	@echo "Tokens directory: $(tokens_dir)"
+	@echo "Restore directory: $(restore_dir)"
+	@if [ ! -d "$(tokens_dir)" ]; then echo "Tokens directory does not exist: $(tokens_dir)"; exit 1; fi
+	@if [ ! -d "$(restore_dir)" ]; then echo "Restore directory does not exist: $(restore_dir)"; exit 1; fi
+	@tokens_files=$$(ls $(tokens_dir)/*.tokens 2>/dev/null | sort); \
+	restore_files=$$(ls $(restore_dir)/scylla-PoC-restore-*.yaml 2>/dev/null | sort); \
+	if [ -z "$$tokens_files" ]; then echo "No tokens files found in $(tokens_dir)"; exit 1; fi; \
+	if [ -z "$$restore_files" ]; then echo "No restore YAML files found in $(restore_dir)"; exit 1; fi; \
+	echo "Found tokens files: $$tokens_files"; \
+	echo "Found scylla.yaml config files: $$restore_files"; \
+	for tokens_file in $$tokens_files; do \
+		tokens_dc=$$(basename $$tokens_file | awk -F'-' '{print $$1}'); \
+		tokens_node=$$(basename $$tokens_file | awk -F'-' '{print $$2}' | sed 's/.tokens//'); \
+		restore_file=$$(echo "$$restore_files" | grep "scylla-PoC-restore-$$tokens_dc" | head -1); \
+		restore_files=$$(echo "$$restore_files" | sed "s|$$restore_file||"); \
+		tokens=$$(cat $$tokens_file); \
+		if [ -n "$$restore_file" ]; then \
+			echo "Mapping $$tokens_file -> $$restore_file"; \
+			awk -v tokens="initial_token: '$$tokens'" '/^initial_token:/ {sub(/^initial_token:.*/, tokens); found=1} {print} END {if (!found) print tokens}' $$restore_file > $$restore_file.tmp && mv $$restore_file.tmp $$restore_file; \
+		else \
+			echo "No matching restore file found for $$tokens_file"; \
+		fi; \
+	done
+	@echo "Mapping and token updates complete."
+
+cql_file := .1-1-restore-poc/schema.CQL
+docker_container := scylla_manager-dc1_node_1-1
+
+.PHONY: recreate_schema
+recreate_schema:
+	@echo "Executing CQL statements from $(cql_file) on Docker container $(docker_container)..."
+	@if [ ! -f "$(cql_file)" ]; then echo "CQL file not found: $(cql_file)"; exit 1; fi
+	@docker exec -i $(docker_container) cqlsh 192.168.100.11 -u cassandra -p cassandra --request-timeout=60 < $(cql_file)
+	@echo "CQL execution completed."
+
+extract_sstables:
+	@echo "Extracting archive .1-1-restore-poc/256000_rows_backuptest_data_big_table.tar..."
+	@mkdir -p extracted_data
+	@tar -xf .1-1-restore-poc/256000_rows_backuptest_data_big_table.tar -C extracted_data
+
+	@echo "Copying keyspaces for all nodes, excluding system keyspaces..."
+	@find extracted_data/sst/cluster/*/dc/*/node/*/keyspace/* -maxdepth 0 -type d | while read keyspace_dir; do \
+		keyspace_name=$$(basename "$$keyspace_dir"); \
+		if [[ "$$keyspace_name" != system* ]]; then \
+			split1=$$(dirname "$$keyspace_dir"); \
+			node_dir=$$(dirname "$$split1"); \
+			node_name=$$(basename "$$node_dir"); \
+			split2=$$(dirname "$$node_dir"); \
+			dc_dir=$$(dirname "$$split2"); \
+			dc_name=$$(basename "$$dc_dir"); \
+			output_dir=".1-1-restore-poc/$$dc_name-$$node_name/keyspace/$$keyspace_name"; \
+			echo "DEBUG: Processing keyspace $$keyspace_name"; \
+			echo "DEBUG: Node directory: $$node_dir"; \
+			echo "DEBUG: Node name: $$node_name"; \
+			echo "DEBUG: Data center name: $$dc_name"; \
+			echo "DEBUG: Output directory: $$output_dir"; \
+			echo "Copying keyspace $$keyspace_name to $$output_dir..."; \
+			mkdir -p "$$output_dir"; \
+			cp -r "$$keyspace_dir/"* "$$output_dir/"; \
+		else \
+			echo "Skipping system keyspace: $$keyspace_name"; \
+		fi; \
+	done
+
+	@rm -rf extracted_data
+	@echo "Keyspace copying complete, and extracted data removed."
+
+# Define variables
+SRC_DIR := .1-1-restore-poc
+DEST_DIR := testing/scylla/data
+
+# Target to generate the mapping from dc-host-id to dcXnY
+generate_mapping:
+	@echo "Generating mapping..."
+	@rm -f .mapping
+	@dc_list=$$(for dc_host_dir in $(SRC_DIR)/*; do \
+		if [ -d "$$dc_host_dir" ]; then \
+			dc_host_name=$$(basename "$$dc_host_dir"); \
+			dc=$$(echo "$$dc_host_name" | cut -d'-' -f1); \
+			echo "$$dc"; \
+		fi; \
+	done | sort -u); \
+	for dc in $$dc_list; do \
+		echo "Processing DC $$dc"; \
+		host_dirs=$$(find $(SRC_DIR) -mindepth 1 -maxdepth 1 -type d -name "$$dc-*" | sort); \
+		seq=1; \
+		for host_dir in $$host_dirs; do \
+			dc_host_name=$$(basename "$$host_dir"); \
+			host_id=$$(echo "$$dc_host_name" | cut -d'-' -f2-); \
+			dc_host_id="$$dc-$$host_id"; \
+			dest_dc_n="$$dc""n""$$seq"; \
+			echo "$$dc_host_id=$$dest_dc_n" >> .mapping; \
+			seq=$$((seq+1)); \
+		done; \
+	done
+
+# Target to copy files from source to destination
+.PHONY: copy_sstables
+copy_sstables: generate_mapping
+	@echo "Copying files..."
+	@while IFS='=' read -r dc_host_id dest_dc_n; do \
+		echo "Processing $$dc_host_id => $$dest_dc_n"; \
+		for src_path in $(SRC_DIR)/$$dc_host_id/keyspace/*/table/*/*; do \
+			if [ ! -d "$$src_path" ]; then \
+				continue; \
+			fi; \
+			keyspace=$$(echo "$$src_path" | sed -E 's|.*/keyspace/([^/]+)/table/.*|\1|'); \
+			table=$$(echo "$$src_path" | sed -E 's|.*/table/([^/]+)/.*|\1|'); \
+			dest_path="$(DEST_DIR)/$$dest_dc_n/$$keyspace/$$table-*"; \
+			dest_upload_dir=$$(find $$dest_path -type d -name upload 2>/dev/null); \
+			if [ -z "$$dest_upload_dir" ]; then \
+				echo "Warning: No destination upload directory found for $$dest_path"; \
+				continue; \
+			fi; \
+			echo "Setting permissions on $$(dirname "$$dest_upload_dir")"; \
+			sudo chmod -R 777 "$$(dirname "$$dest_upload_dir")"; \
+			echo "Copying from $$src_path to $$dest_upload_dir"; \
+			cp -r "$$src_path"/* "$$dest_upload_dir"/; \
+		done; \
+	done < .mapping
+
+# Define the list of Docker containers
+CONTAINERS := \
+    scylla_manager-dc1_node_1-1 \
+    scylla_manager-dc1_node_2-1 \
+    scylla_manager-dc1_node_3-1 \
+    scylla_manager-dc2_node_1-1 \
+    scylla_manager-dc2_node_2-1 \
+    scylla_manager-dc2_node_3-1
+
+.PHONY: refresh_nodes
+refresh_nodes:
+	@echo "Refreshing nodes..."
+	@for container in $(CONTAINERS); do \
+		echo "Refreshing $$container"; \
+		docker exec $$container nodetool refresh backuptest_data big_table; \
+	done
+
+.PHONY: query_data
+query_data:
+	@echo "Executing CQL query on 192.168.100.11..."
+	@cqlsh 192.168.100.11 -u cassandra -p cassandra -e "SELECT count(*) FROM backuptest_data.big_table;"
+
+.PHONY: clean_restore
+clean_restore:
+	@echo "Cleaning nodes scylla data folder"
+	sudo rm -rf ./testing/scylla/data/dc1n1/*
+	sudo rm -rf ./testing/scylla/data/dc1n2/*
+	sudo rm -rf ./testing/scylla/data/dc1n3/*
+	sudo rm -rf ./testing/scylla/data/dc2n1/*
+	sudo rm -rf ./testing/scylla/data/dc2n2/*
+	sudo rm -rf ./testing/scylla/data/dc2n3/*

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -626,7 +626,7 @@ func TestBackupSmokeIntegration(t *testing.T) {
 		clusterSession = CreateSessionAndDropAllKeyspaces(t, h.Client)
 	)
 
-	WriteData(t, clusterSession, testKeyspace, 1)
+	WriteData(t, clusterSession, testKeyspace, 1000)
 
 	target := backup.Target{
 		Units: []backup.Unit{

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -76,15 +76,27 @@ endif
 
 ifeq ($(RAFT_SCHEMA),enabled)
 	@$(YQ) write -i scylla/scylla.yaml 'consistent_cluster_management' true
+	for file in $(wildcard scylla_PoC*); do \
+    	$(YQ) write -i $$file 'consistent_cluster_management' true; \
+    done
 endif
 ifeq ($(RAFT_SCHEMA),disabled)
 	@$(YQ) write -i scylla/scylla.yaml 'consistent_cluster_management' false
+	for file in $(wildcard scylla_PoC*); do \
+    	$(YQ) write -i $$file 'consistent_cluster_management' false; \
+    done
 endif
 ifeq ($(TABLETS),enabled)
 	@$(YQ) write -i scylla/scylla.yaml 'enable_tablets' true
+	for file in $(wildcard scylla_PoC*); do \
+       	$(YQ) write -i $$file 'enable_tablets' true; \
+    done
 endif
 ifeq ($(TABLETS),disabled)
 	@$(YQ) write -i scylla/scylla.yaml 'enable_tablets' false
+	for file in $(wildcard scylla_PoC*); do \
+       	$(YQ) write -i $$file 'enable_tablets' false; \
+    done
 endif
 	@cp scylla/scylla.yaml scylla/scylla-second-cluster.yaml
 	@$(YQ) write -i scylla/scylla-second-cluster.yaml 'cluster_name' 'Managed Other Cluster'

--- a/testing/docker-compose.yaml
+++ b/testing/docker-compose.yaml
@@ -7,11 +7,14 @@ services:
         source: ./scylla/cassandra-rackdc.1.properties
         target: /etc/scylla/cassandra-rackdc.properties
       - type: bind
-        source: ./scylla/scylla.yaml
+        source: ./scylla/scylla-PoC-restore-dc1-n1.yaml
         target: /etc/scylla/scylla.yaml
       - type: bind
         source: ./scylla/certs/
         target: /etc/scylla/certs
+      - type: bind
+        source: ./scylla/data/dc1n1/
+        target: /var/lib/scylla/data
     networks:
       public:
       second:
@@ -24,11 +27,14 @@ services:
         source: ./scylla/cassandra-rackdc.1.properties
         target: /etc/scylla/cassandra-rackdc.properties
       - type: bind
-        source: ./scylla/scylla.yaml
+        source: ./scylla/scylla-PoC-restore-dc1-n2.yaml
         target: /etc/scylla/scylla.yaml
       - type: bind
         source: ./scylla/certs/
         target: /etc/scylla/certs
+      - type: bind
+        source: ./scylla/data/dc1n2/
+        target: /var/lib/scylla/data
     networks:
       public:
       second:
@@ -41,11 +47,14 @@ services:
         source: ./scylla/cassandra-rackdc.1.properties
         target: /etc/scylla/cassandra-rackdc.properties
       - type: bind
-        source: ./scylla/scylla.yaml
+        source: ./scylla/scylla-PoC-restore-dc1-n3.yaml
         target: /etc/scylla/scylla.yaml
       - type: bind
         source: ./scylla/certs/
         target: /etc/scylla/certs/
+      - type: bind
+        source: ./scylla/data/dc1n3/
+        target: /var/lib/scylla/data
     networks:
       public:
       second:
@@ -58,11 +67,14 @@ services:
         source: ./scylla/cassandra-rackdc.2.properties
         target: /etc/scylla/cassandra-rackdc.properties
       - type: bind
-        source: ./scylla/scylla.yaml
+        source: ./scylla/scylla-PoC-restore-dc2-n1.yaml
         target: /etc/scylla/scylla.yaml
       - type: bind
         source: ./scylla/certs/
         target: /etc/scylla/certs
+      - type: bind
+        source: ./scylla/data/dc2n1/
+        target: /var/lib/scylla/data
     networks:
       public:
       second:
@@ -75,11 +87,14 @@ services:
         source: ./scylla/cassandra-rackdc.2.properties
         target: /etc/scylla/cassandra-rackdc.properties
       - type: bind
-        source: ./scylla/scylla.yaml
+        source: ./scylla/scylla-PoC-restore-dc2-n2.yaml
         target: /etc/scylla/scylla.yaml
       - type: bind
         source: ./scylla/certs/
         target: /etc/scylla/certs
+      - type: bind
+        source: ./scylla/data/dc2n2/
+        target: /var/lib/scylla/data
     networks:
       public:
       second:
@@ -92,11 +107,14 @@ services:
         source: ./scylla/cassandra-rackdc.2.properties
         target: /etc/scylla/cassandra-rackdc.properties
       - type: bind
-        source: ./scylla/scylla.yaml
+        source: ./scylla/scylla-PoC-restore-dc2-n3.yaml
         target: /etc/scylla/scylla.yaml
       - type: bind
         source: ./scylla/certs/
         target: /etc/scylla/certs
+      - type: bind
+        source: ./scylla/data/dc2n3/
+        target: /var/lib/scylla/data
     networks:
       public:
       second:

--- a/testing/scylla/scylla-PoC-restore-dc1-n1.yaml
+++ b/testing/scylla/scylla-PoC-restore-dc1-n1.yaml
@@ -1,0 +1,651 @@
+# Scylla storage config YAML
+
+#######################################
+# This file is split to two sections:
+# 1. Supported parameters
+# 2. Unsupported parameters: reserved for future use or backwards
+#    compatibility.
+# Scylla will only read and use the first segment
+#######################################
+
+### Supported Parameters
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+# It is recommended to change the default value when creating a new cluster.
+# You can NOT modify this value for an existing cluster
+cluster_name: 'Managed Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+num_tokens: 256
+
+# Directory where Scylla should store all its files, which are commitlog,
+# data, hints, view_hints and saved_caches subdirectories. All of these
+# subs can be overridden by the respective options below.
+# If unset, the value defaults to /var/lib/scylla
+# workdir: /var/lib/scylla
+
+# Directory where Scylla should store data on disk.
+data_file_directories:
+  - /var/lib/scylla/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+commitlog_directory: /var/lib/scylla/commitlog
+
+# schema commit log. A special commitlog instance
+# used for schema and system tables.
+# When running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# schema_commitlog_directory: /var/lib/scylla/commitlog/schema
+
+# commitlog_sync may be either "periodic" or "batch."
+#
+# When in batch mode, Scylla won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# The size of the individual schema commitlog file segments.
+#
+# The default size is 128, which is 4 times larger than the default
+# size of the data commitlog. It's because the segment size puts
+# a limit on the mutation size that can be written at once, and some
+# schema mutation writes are much larger than average.
+schema_commitlog_segment_size_in_mb: 128
+
+# seed_provider class_name is saved for future use.
+# A seed address is mandatory.
+seed_provider:
+  # The addresses of hosts that will serve as contact points for the joining node.
+  # It allows the node to discover the cluster ring topology on startup (when
+  # joining the cluster).
+  # Once the node has joined the cluster, the seed list has no function.
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      # In a new cluster, provide the address of the first node.
+      # In an existing cluster, specify the address of at least one existing node.
+      # If you specify addresses of more than one node, use a comma to separate them.
+      # For example: "<IP1>,<IP2>,<IP3>"
+      - seeds: "127.0.0.1"
+
+# Address to bind to and tell other Scylla nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# If you leave broadcast_address (below) empty, then setting listen_address
+# to 0.0.0.0 is wrong as other nodes will not know how to reach this node.
+# If you set broadcast_address, then you can set listen_address to 0.0.0.0.
+listen_address: localhost
+
+# Address to broadcast to other Scylla nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+
+# When using multiple physical network interfaces, set this to true to listen on broadcast_address
+# in addition to the listen_address, allowing nodes to communicate in both interfaces.
+# Ignore this property if the network configuration automatically routes between the public and private networks such as EC2.
+#
+# listen_on_broadcast_address: false
+
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+# To disable the CQL native transport, remove this option and configure native_transport_port_ssl.
+native_transport_port: 9042
+
+# Like native_transport_port, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+native_shard_aware_transport_port: 19042
+
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+#native_transport_port_ssl: 9142
+
+# Like native_transport_port_ssl, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+#native_shard_aware_transport_port_ssl: 19142
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# how long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Scylla enough about your network topology to route
+#   requests efficiently
+# - it allows Scylla to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Scylla will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Scylla provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Scylla will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: GossipingPropertyFileSnitch
+
+# The address or interface to bind the native transport server to.
+#
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+rpc_address: localhost
+# rpc_interface: eth1
+# rpc_interface_prefer_ipv6: false
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# port for REST API server
+api_port: 10000
+
+# IP for the REST API server
+api_address: 127.0.0.1
+
+# Log WARN on any batch size exceeding this value. 128 kiB per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 128
+
+# Fail any multiple-partition batch exceeding this value. 1 MiB (8x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 1024
+
+  # Authentication backend, identifying users
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+  # PasswordAuthenticator}.
+  #
+  # - AllowAllAuthenticator performs no checks - set it to disable authentication.
+  # - PasswordAuthenticator relies on username/password pairs to authenticate
+  #   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+  #   Please increase system_auth keyspace replication factor if you use this authenticator.
+  # - com.scylladb.auth.TransitionalAuthenticator requires username/password pair
+  #   to authenticate in the same manner as PasswordAuthenticator, but improper credentials
+#   result in being logged in as an anonymous user. Use for upgrading clusters' auth.
+authenticator: PasswordAuthenticator
+
+  # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+  # CassandraAuthorizer}.
+  #
+  # - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+  # - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+  #   increase system_auth keyspace replication factor if you use this authorizer.
+  # - com.scylladb.auth.TransitionalAuthorizer wraps around the CassandraAuthorizer, using it for
+  #   authorizing permission management. Otherwise, it allows all. Use for upgrading
+#   clusters' auth.
+authorizer: CassandraAuthorizer
+
+  # initial_token allows you to specify tokens manually.  While you can use # it with
+  # vnodes (num_tokens > 1, above) -- in which case you should provide a
+  # comma-separated list -- it's primarily used when adding nodes # to legacy clusters
+  # that do not have vnodes enabled.
+  # initial_token:
+
+  # RPC address to broadcast to drivers and other Scylla nodes. This cannot
+  # be set to 0.0.0.0. If left blank, this will be set to the value of
+  # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+  # be set.
+  # broadcast_rpc_address: 1.2.3.4
+
+  # Uncomment to enable experimental features
+  # experimental_features:
+  #     - udf
+  #     - alternator-streams
+  #     - broadcast-tables
+  #     - keyspace-storage-options
+
+  # The directory where hints files are stored if hinted handoff is enabled.
+# hints_directory: /var/lib/scylla/hints
+
+# The directory where hints files are stored for materialized-view updates
+# view_hints_directory: /var/lib/scylla/view_hints
+
+# See https://docs.scylladb.com/architecture/anti-entropy/hinted-handoff
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+# hinted_handoff_enabled: true
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+# max_hint_window_in_ms: 10800000 # 3 hours
+
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 10000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+# permissions_validity_in_ms: 10000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this also must have
+# a non-zero value. Defaults to 2000. It's recommended to set this value to
+# be at least 3 times smaller than the permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Murmur3Partitioner is currently the only supported partitioner,
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Total space to use for commitlogs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Scylla will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+#
+# A value of -1 (default) will automatically equate it to the total amount of memory
+# available for Scylla.
+commitlog_total_space_in_mb: -1
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# ssl_storage_port: 7001
+
+# listen_interface: eth0
+# listen_interface_prefer_ipv6: false
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+# start_native_transport: true
+
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# Whether to start the thrift rpc server.
+# start_rpc: true
+
+# enable or disable keepalive on rpc/native connections
+# rpc_keepalive: true
+
+# Set to true to have Scylla create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+# incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Scylla won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+# snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: false
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exhaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+# tombstone_warn_threshold: 1000
+# tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows within the partition by collation column
+#      is faster
+#   2) but, Scylla will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+# column_index_size_in_kb: 64
+
+# Auto-scaling of the promoted index prevents running out of memory
+# when the promoted index grows too large (due to partitions with many rows
+# vs. too small column_index_size_in_kb).  When the serialized representation
+# of the promoted index grows by this threshold, the desired block size
+# for this partition (initialized to column_index_size_in_kb)
+# is doubled, to decrease the sampling resolution by half.
+#
+# To disable promoted index auto-scaling, set the threshold to 0.
+# column_index_auto_scale_threshold_in_kb: 10240
+
+# Log a warning when writing partitions larger than this value
+# compaction_large_partition_warning_threshold_mb: 1000
+
+# Log a warning when writing rows larger than this value
+# compaction_large_row_warning_threshold_mb: 10
+
+# Log a warning when writing cells larger than this value
+# compaction_large_cell_warning_threshold_mb: 1
+
+# Log a warning when row number is larger than this value
+# compaction_rows_count_warning_threshold: 100000
+
+# Log a warning when writing a collection containing more elements than this value
+# compaction_collection_elements_count_warning_threshold: 10000
+
+# How long the coordinator should wait for seq or index scans to complete
+# range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+# counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+# cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+# truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+# request_timeout_in_ms: 10000
+
+# Enable or disable inter-node encryption.
+# You must also generate keys and provide the appropriate key and trust store locations and passwords.
+#
+# The available internode options are : all, none, dc, rack
+# If set to dc scylla  will encrypt the traffic between the DCs
+# If set to rack scylla  will encrypt the traffic between the racks
+#
+# SSL/TLS algorithm and ciphers used can be controlled by
+# the priority_string parameter. Info on priority string
+# syntax and values is available at:
+#   https://gnutls.org/manual/html_node/Priority-Strings.html
+#
+# The require_client_auth parameter allows you to
+# restrict access to service based on certificate
+# validation. Client must provide a certificate
+# accepted by the used trust store to connect.
+#
+# server_encryption_options:
+#    internode_encryption: none
+#    certificate: conf/scylla.crt
+#    keyfile: conf/scylla.key
+#    truststore: <not set, use system trust>
+#    certficate_revocation_list: <not set>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# enable or disable client/server encryption.
+client_encryption_options:
+  enabled: false
+  certificate: /etc/scylla/db.crt
+  keyfile: /etc/scylla/db.key
+#    truststore: <none, use system trust>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+# internode_compression: none
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+# inter_dc_tcp_nodelay: false
+
+# Relaxation of environment checks.
+#
+# Scylla places certain requirements on its environment.  If these requirements are
+# not met, performance and reliability can be degraded.
+#
+# These requirements include:
+#    - A filesystem with good support for asynchronous I/O (AIO). Currently,
+#      this means XFS.
+#
+# false: strict environment checks are in place; do not start if they are not met.
+# true: relaxed environment checks; performance and reliability may degraade.
+#
+# developer_mode: false
+
+
+# Idle-time background processing
+#
+# Scylla can perform certain jobs in the background while the system is otherwise idle,
+# freeing processor resources when there is other work to be done.
+#
+# defragment_memory_on_idle: true
+#
+# prometheus port
+# By default, Scylla opens prometheus API port on port 9180
+# setting the port to 0 will disable the prometheus API.
+# prometheus_port: 9180
+#
+# prometheus address
+# Leaving this blank will set it to the same value as listen_address.
+# This means that by default, Scylla listens to the prometheus API on the same
+# listening address (and therefore network interface) used to listen for
+# internal communication. If the monitoring node is not in this internal
+# network, you can override prometheus_address explicitly - e.g., setting
+# it to 0.0.0.0 to listen on all interfaces.
+# prometheus_address: 1.2.3.4
+
+# Distribution of data among cores (shards) within a node
+#
+# Scylla distributes data within a node among shards, using a round-robin
+# strategy:
+#  [shard0] [shard1] ... [shardN-1] [shard0] [shard1] ... [shardN-1] ...
+#
+# Scylla versions 1.6 and below used just one repetition of the pattern;
+# this interfered with data placement among nodes (vnodes).
+#
+# Scylla versions 1.7 and above use 4096 repetitions of the pattern; this
+# provides for better data distribution.
+#
+# the value below is log (base 2) of the number of repetitions.
+#
+# Set to 0 to avoid rewriting all data when upgrading from Scylla 1.6 and
+# below.
+#
+# Keep at 12 for new clusters.
+murmur3_partitioner_ignore_msb_bits: 12
+
+# Bypass in-memory data cache (the row cache) when performing reversed queries.
+# reversed_reads_auto_bypass_cache: false
+
+# Use a new optimized algorithm for performing reversed reads.
+# Set to `false` to fall-back to the old algorithm.
+# enable_optimized_reversed_reads: true
+
+# Use on a new, parallel algorithm for performing aggregate queries.
+# Set to `false` to fall-back to the old algorithm.
+# enable_parallelized_aggregation: true
+
+# When enabled, the node will start using separate commit log for schema changes
+# right from the boot. Without this, it only happens following a restart after
+# all nodes in the cluster were upgraded.
+#
+# Having this option ensures that new installations don't need a rolling restart
+# to use the feature, but upgrades do.
+#
+# WARNING: It's unsafe to set this to false if the node previously booted
+# with the schema commit log enabled. In such case, some schema changes
+# may be lost if the node was not cleanly stopped.
+force_schema_commit_log: true
+
+# Time for which task manager task is kept in memory after it completes.
+task_ttl_in_seconds: 10
+
+# Use Raft to consistently manage schema information in the cluster.
+# Refer to https://docs.scylladb.com/master/architecture/raft.html for more details.
+# The 'Handling Failures' section is especially important.
+#
+# Once enabled in a cluster, this cannot be turned off.
+# If you want to bootstrap a new cluster without Raft, make sure to set this to `false`
+# before starting your nodes for the first time.
+#
+# A cluster not using Raft can be 'upgraded' to use Raft. Refer to the aforementioned
+# documentation, section 'Enabling Raft in ScyllaDB 5.2 and further', for the procedure.
+consistent_cluster_management: true
+
+# In materialized views, restrictions are allowed only on the view's primary key columns.
+# In old versions Scylla mistakenly allowed IS NOT NULL restrictions on columns which were not part
+# of the view's primary key. These invalid restrictions were ignored.
+# This option controls the behavior when someone tries to create a view with such invalid IS NOT NULL restrictions.
+#
+# Can be true, false, or warn.
+# * `true`: IS NOT NULL is allowed only on the view's primary key columns,
+#           trying to use it on other columns will cause an error, as it should.
+# * `false`: Scylla accepts IS NOT NULL restrictions on regular columns, but they're silently ignored.
+#            It's useful for backwards compatibility.
+# * `warn`: The same as false, but there's a warning about invalid view restrictions.
+#
+# To preserve backwards compatibility on old clusters, Scylla's default setting is `warn`.
+# New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`)
+# to make sure that trying to create an invalid view causes an error.
+strict_is_not_null_in_views: true
+
+# The Unix Domain Socket the node uses for maintenance socket.
+# The possible options are:
+# * ignore: the node will not open the maintenance socket,
+# * workdir: the node will open the maintenance socket on the path <scylla's workdir>/cql.m,
+#            where <scylla's workdir> is a path defined by the workdir configuration option,
+# * <socket path>: the node will open the maintenance socket on the path <socket path>.
+maintenance_socket: ignore
+
+# If set to true, configuration parameters defined with LiveUpdate option can be updated in runtime with CQL
+# by updating system.config virtual table. If we don't want any configuration parameter to be changed in runtime
+# via CQL, this option should be set to false. This parameter doesn't impose any limits on other mechanisms updating
+# configuration parameters in runtime, e.g. sending SIGHUP or using API. This option should be set to false
+# e.g. for cloud users, for whom scylla's configuration should be changed only by support engineers.
+# live_updatable_config_params_changeable_via_cql: true
+
+# ****************
+# *  GUARDRAILS  *
+# ****************
+
+# Guardrails to warn or fail when Replication Factor is smaller/greater than the threshold.
+# Please note that the value of 0 is always allowed,
+# which means that having no replication at all, i.e. RF = 0, is always valid.
+# A guardrail value smaller than 0, e.g. -1, means that the guardrail is disabled.
+# Commenting out a guardrail also means it is disabled.
+# minimum_replication_factor_fail_threshold: -1
+# minimum_replication_factor_warn_threshold:  3
+# maximum_replication_factor_warn_threshold: -1
+# maximum_replication_factor_fail_threshold: -1
+
+# Guardrails to warn about or disallow creating a keyspace with specific replication strategy.
+# Each of these 2 settings is a list storing replication strategies considered harmful.
+# The replication strategies to choose from are:
+# 1) SimpleStrategy,
+# 2) NetworkTopologyStrategy,
+# 3) LocalStrategy,
+# 4) EverywhereStrategy
+#
+# replication_strategy_warn_list:
+#  - SimpleStrategy
+# replication_strategy_fail_list:
+
+api_ui_dir: /usr/lib/scylla/swagger-ui/dist/
+api_doc_dir: /usr/lib/scylla/api/api-doc/
+alternator_port: 8000
+alternator_write_isolation: only_rmw_uses_lwt
+alternator_enforce_authorization: true
+enable_ipv6_dns_lookup: true
+
+uuid_sstable_identifiers_enabled: false
+initial_token: '-9040652564247705304,-8994504173237689087,-8993530109982166929,-8937389085828670558,-8871279059626678845,-8844234181955106595,-8809045656145185309,-8793549048060327725,-8698243259272915386,-8681978112315889556,-8654403781292599262,-8597170723093678825,-8499344793132009313,-8494731803243646089,-8351172022874438374,-8287364542363286803,-8150134622659704870,-8086798359582986889,-8058351879233172458,-8026612894138609009,-7958306477488169850,-7902926772310318739,-7693699892002585079,-7566971356889834424,-7542066768364858642,-7439669570153626790,-7415793494758175787,-7395818478490860842,-7308536578184018282,-7269116505811213344,-7126100691601785047,-7111953426771662695,-7071160296296636852,-7051930922251660267,-7049502185139184133,-6909932900849478567,-6852619017176008569,-6682882743893458632,-6676418898527052921,-6590795214317600130,-6546726093376342451,-6206386519273265233,-6160492950667035608,-6097766431688972435,-5987400170683735894,-5966170129381615089,-5965744329434261996,-5905718455486065617,-5813573639188122887,-5699615041572373115,-5699258346042113915,-5505336074393703309,-5452364728696529815,-5375345206917601898,-5318710354297402300,-5296869658356434615,-5287604087261356659,-5095448377403207384,-5040413822793180145,-4925714505026147095,-4868566023985084416,-4715610609155845994,-4604676847533348801,-4488107613074252436,-4430021189735270253,-4324173995538584528,-4254974119914609307,-4252346509227682202,-4238024927490772128,-4186700733968654547,-4176209461957439640,-3832238629945672631,-3813440961474278083,-3491750188963693000,-3467597844077448100,-3430191708367103275,-3346861498806577154,-3285248911936057288,-3069115747481071786,-3019826467405822416,-2722933690087711201,-2668988925385134643,-2662711221063027678,-2657677323233343295,-2626677752609804506,-2617970314735011215,-2603188946708578870,-2565566703732630943,-2553013979463949651,-2428412872117599253,-2312306329516138068,-2271082498497725386,-2109715418883601716,-1806998871594154576,-1770202722650015748,-1753939536360920313,-1748150800711974630,-1695385041675668185,-1694869476209379692,-1640230452527820511,-1600793056268861222,-1590788884605447099,-1494127672989533891,-1494117362839859038,-1469852557649874628,-1420306120837879867,-1390160763617081759,-1375178456120745851,-1348828866080873211,-1332854054742625234,-1166694563724773837,-1163867957055853134,-1130336513463082433,-1031901371982853651,-1024624596762432537,-931577984894212005,-929809136015968229,-908624419858408442,-895384536247242145,-881565430961342723,-879100712478776574,-872411626527357958,-780005334869242048,-721177156283758241,-692423714366658831,-691866197479020983,-576528417089775156,-558034576982487854,-463574443808510991,-281615186361852906,-118467014969402907,-76802776705572632,30486837710499058,223362975988168020,275421786465281453,347362849780142043,373709124079315251,413546780062740104,523555903152624127,533455779309037852,561254964367276317,608597331269203704,734582751767665986,777464184698322073,896360055508340334,1020526190932919682,1083883978406678082,1136284978048507506,1196899597835946065,1206432506967417085,1312942477786461259,1477318521217989386,1589700189923496345,1647299762024747098,1706972292690891410,1715396037165841589,1772437143184254268,1800007907209308935,1838535935811376338,1885091982537401445,1905132626418560070,1926209632543382383,1935013770216107423,2046082626797085133,2159256864904829408,2274525607449512191,2345443126950896244,2386385596754940966,2434615839129209809,2438266903434611231,2497093492869759818,2511556532609026261,2538736973394211395,2628868263202280535,2630491290357247446,2840813587023635453,2854614279640634047,2897868943855054240,3016068088208052575,3018166286345787049,3071539581850282618,3080662977677852903,3183524575009580070,3187977655571694749,3197148813956840207,3212032237647317277,3305301790127565551,3376244068161689047,3450394164260163894,3503430961476160728,3531352146035134123,3816070592959417164,3860229988377234410,3890607604214542633,3947254265939716472,4117271101566482659,4146047987746027470,4157813311646045011,4171198875245458275,4424238565872882705,4507800604549828341,4556702196368264009,4650580079891902630,4730598974751228712,4780211606117203551,4820355667465262444,4896427836599302617,5020861164030261031,5048236786836618429,5291240870688997722,5376094096160877285,5572442568723729032,5624985906843083749,5626178768182293424,5652203709841166983,5688669893193185102,5710752964625296985,5711318723619673447,5763045728096794756,5815954102638168125,5837733742993773373,5943502959301510215,6037722385592211667,6334071733625656714,6445530028676317321,6628921114870093562,6805251745711596638,6833566464023616801,6952923343050915090,7089596175366949775,7283602334825555920,7302128690237202095,7313402253713469454,7327576261366733015,7332379801117808188,7408133231792095936,7435994458138438377,7485777772840417656,7528402759856961489,7939154505802289641,8027165061602887331,8106739325083387963,8132982493590811735,8196012473710387885,8300659028321256781,8608747406259189643,8720541463005693606,8770815047766125491,8818130394817370038,8849264600834309209,8878335378893365235,8886931002862072175,8900109373470262740,9030865678827895071,9082663460624946354,9136684188861046881'

--- a/testing/scylla/scylla-PoC-restore-dc1-n2.yaml
+++ b/testing/scylla/scylla-PoC-restore-dc1-n2.yaml
@@ -1,0 +1,651 @@
+# Scylla storage config YAML
+
+#######################################
+# This file is split to two sections:
+# 1. Supported parameters
+# 2. Unsupported parameters: reserved for future use or backwards
+#    compatibility.
+# Scylla will only read and use the first segment
+#######################################
+
+### Supported Parameters
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+# It is recommended to change the default value when creating a new cluster.
+# You can NOT modify this value for an existing cluster
+cluster_name: 'Managed Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+num_tokens: 256
+
+# Directory where Scylla should store all its files, which are commitlog,
+# data, hints, view_hints and saved_caches subdirectories. All of these
+# subs can be overridden by the respective options below.
+# If unset, the value defaults to /var/lib/scylla
+# workdir: /var/lib/scylla
+
+# Directory where Scylla should store data on disk.
+data_file_directories:
+  - /var/lib/scylla/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+commitlog_directory: /var/lib/scylla/commitlog
+
+# schema commit log. A special commitlog instance
+# used for schema and system tables.
+# When running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# schema_commitlog_directory: /var/lib/scylla/commitlog/schema
+
+# commitlog_sync may be either "periodic" or "batch."
+#
+# When in batch mode, Scylla won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# The size of the individual schema commitlog file segments.
+#
+# The default size is 128, which is 4 times larger than the default
+# size of the data commitlog. It's because the segment size puts
+# a limit on the mutation size that can be written at once, and some
+# schema mutation writes are much larger than average.
+schema_commitlog_segment_size_in_mb: 128
+
+# seed_provider class_name is saved for future use.
+# A seed address is mandatory.
+seed_provider:
+  # The addresses of hosts that will serve as contact points for the joining node.
+  # It allows the node to discover the cluster ring topology on startup (when
+  # joining the cluster).
+  # Once the node has joined the cluster, the seed list has no function.
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      # In a new cluster, provide the address of the first node.
+      # In an existing cluster, specify the address of at least one existing node.
+      # If you specify addresses of more than one node, use a comma to separate them.
+      # For example: "<IP1>,<IP2>,<IP3>"
+      - seeds: "127.0.0.1"
+
+# Address to bind to and tell other Scylla nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# If you leave broadcast_address (below) empty, then setting listen_address
+# to 0.0.0.0 is wrong as other nodes will not know how to reach this node.
+# If you set broadcast_address, then you can set listen_address to 0.0.0.0.
+listen_address: localhost
+
+# Address to broadcast to other Scylla nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+
+# When using multiple physical network interfaces, set this to true to listen on broadcast_address
+# in addition to the listen_address, allowing nodes to communicate in both interfaces.
+# Ignore this property if the network configuration automatically routes between the public and private networks such as EC2.
+#
+# listen_on_broadcast_address: false
+
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+# To disable the CQL native transport, remove this option and configure native_transport_port_ssl.
+native_transport_port: 9042
+
+# Like native_transport_port, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+native_shard_aware_transport_port: 19042
+
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+#native_transport_port_ssl: 9142
+
+# Like native_transport_port_ssl, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+#native_shard_aware_transport_port_ssl: 19142
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# how long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Scylla enough about your network topology to route
+#   requests efficiently
+# - it allows Scylla to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Scylla will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Scylla provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Scylla will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: GossipingPropertyFileSnitch
+
+# The address or interface to bind the native transport server to.
+#
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+rpc_address: localhost
+# rpc_interface: eth1
+# rpc_interface_prefer_ipv6: false
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# port for REST API server
+api_port: 10000
+
+# IP for the REST API server
+api_address: 127.0.0.1
+
+# Log WARN on any batch size exceeding this value. 128 kiB per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 128
+
+# Fail any multiple-partition batch exceeding this value. 1 MiB (8x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 1024
+
+  # Authentication backend, identifying users
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+  # PasswordAuthenticator}.
+  #
+  # - AllowAllAuthenticator performs no checks - set it to disable authentication.
+  # - PasswordAuthenticator relies on username/password pairs to authenticate
+  #   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+  #   Please increase system_auth keyspace replication factor if you use this authenticator.
+  # - com.scylladb.auth.TransitionalAuthenticator requires username/password pair
+  #   to authenticate in the same manner as PasswordAuthenticator, but improper credentials
+#   result in being logged in as an anonymous user. Use for upgrading clusters' auth.
+authenticator: PasswordAuthenticator
+
+  # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+  # CassandraAuthorizer}.
+  #
+  # - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+  # - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+  #   increase system_auth keyspace replication factor if you use this authorizer.
+  # - com.scylladb.auth.TransitionalAuthorizer wraps around the CassandraAuthorizer, using it for
+  #   authorizing permission management. Otherwise, it allows all. Use for upgrading
+#   clusters' auth.
+authorizer: CassandraAuthorizer
+
+  # initial_token allows you to specify tokens manually.  While you can use # it with
+  # vnodes (num_tokens > 1, above) -- in which case you should provide a
+  # comma-separated list -- it's primarily used when adding nodes # to legacy clusters
+  # that do not have vnodes enabled.
+  # initial_token:
+
+  # RPC address to broadcast to drivers and other Scylla nodes. This cannot
+  # be set to 0.0.0.0. If left blank, this will be set to the value of
+  # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+  # be set.
+  # broadcast_rpc_address: 1.2.3.4
+
+  # Uncomment to enable experimental features
+  # experimental_features:
+  #     - udf
+  #     - alternator-streams
+  #     - broadcast-tables
+  #     - keyspace-storage-options
+
+  # The directory where hints files are stored if hinted handoff is enabled.
+# hints_directory: /var/lib/scylla/hints
+
+# The directory where hints files are stored for materialized-view updates
+# view_hints_directory: /var/lib/scylla/view_hints
+
+# See https://docs.scylladb.com/architecture/anti-entropy/hinted-handoff
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+# hinted_handoff_enabled: true
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+# max_hint_window_in_ms: 10800000 # 3 hours
+
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 10000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+# permissions_validity_in_ms: 10000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this also must have
+# a non-zero value. Defaults to 2000. It's recommended to set this value to
+# be at least 3 times smaller than the permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Murmur3Partitioner is currently the only supported partitioner,
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Total space to use for commitlogs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Scylla will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+#
+# A value of -1 (default) will automatically equate it to the total amount of memory
+# available for Scylla.
+commitlog_total_space_in_mb: -1
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# ssl_storage_port: 7001
+
+# listen_interface: eth0
+# listen_interface_prefer_ipv6: false
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+# start_native_transport: true
+
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# Whether to start the thrift rpc server.
+# start_rpc: true
+
+# enable or disable keepalive on rpc/native connections
+# rpc_keepalive: true
+
+# Set to true to have Scylla create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+# incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Scylla won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+# snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: false
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exhaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+# tombstone_warn_threshold: 1000
+# tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows within the partition by collation column
+#      is faster
+#   2) but, Scylla will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+# column_index_size_in_kb: 64
+
+# Auto-scaling of the promoted index prevents running out of memory
+# when the promoted index grows too large (due to partitions with many rows
+# vs. too small column_index_size_in_kb).  When the serialized representation
+# of the promoted index grows by this threshold, the desired block size
+# for this partition (initialized to column_index_size_in_kb)
+# is doubled, to decrease the sampling resolution by half.
+#
+# To disable promoted index auto-scaling, set the threshold to 0.
+# column_index_auto_scale_threshold_in_kb: 10240
+
+# Log a warning when writing partitions larger than this value
+# compaction_large_partition_warning_threshold_mb: 1000
+
+# Log a warning when writing rows larger than this value
+# compaction_large_row_warning_threshold_mb: 10
+
+# Log a warning when writing cells larger than this value
+# compaction_large_cell_warning_threshold_mb: 1
+
+# Log a warning when row number is larger than this value
+# compaction_rows_count_warning_threshold: 100000
+
+# Log a warning when writing a collection containing more elements than this value
+# compaction_collection_elements_count_warning_threshold: 10000
+
+# How long the coordinator should wait for seq or index scans to complete
+# range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+# counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+# cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+# truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+# request_timeout_in_ms: 10000
+
+# Enable or disable inter-node encryption.
+# You must also generate keys and provide the appropriate key and trust store locations and passwords.
+#
+# The available internode options are : all, none, dc, rack
+# If set to dc scylla  will encrypt the traffic between the DCs
+# If set to rack scylla  will encrypt the traffic between the racks
+#
+# SSL/TLS algorithm and ciphers used can be controlled by
+# the priority_string parameter. Info on priority string
+# syntax and values is available at:
+#   https://gnutls.org/manual/html_node/Priority-Strings.html
+#
+# The require_client_auth parameter allows you to
+# restrict access to service based on certificate
+# validation. Client must provide a certificate
+# accepted by the used trust store to connect.
+#
+# server_encryption_options:
+#    internode_encryption: none
+#    certificate: conf/scylla.crt
+#    keyfile: conf/scylla.key
+#    truststore: <not set, use system trust>
+#    certficate_revocation_list: <not set>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# enable or disable client/server encryption.
+client_encryption_options:
+  enabled: false
+  certificate: /etc/scylla/db.crt
+  keyfile: /etc/scylla/db.key
+#    truststore: <none, use system trust>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+# internode_compression: none
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+# inter_dc_tcp_nodelay: false
+
+# Relaxation of environment checks.
+#
+# Scylla places certain requirements on its environment.  If these requirements are
+# not met, performance and reliability can be degraded.
+#
+# These requirements include:
+#    - A filesystem with good support for asynchronous I/O (AIO). Currently,
+#      this means XFS.
+#
+# false: strict environment checks are in place; do not start if they are not met.
+# true: relaxed environment checks; performance and reliability may degraade.
+#
+# developer_mode: false
+
+
+# Idle-time background processing
+#
+# Scylla can perform certain jobs in the background while the system is otherwise idle,
+# freeing processor resources when there is other work to be done.
+#
+# defragment_memory_on_idle: true
+#
+# prometheus port
+# By default, Scylla opens prometheus API port on port 9180
+# setting the port to 0 will disable the prometheus API.
+# prometheus_port: 9180
+#
+# prometheus address
+# Leaving this blank will set it to the same value as listen_address.
+# This means that by default, Scylla listens to the prometheus API on the same
+# listening address (and therefore network interface) used to listen for
+# internal communication. If the monitoring node is not in this internal
+# network, you can override prometheus_address explicitly - e.g., setting
+# it to 0.0.0.0 to listen on all interfaces.
+# prometheus_address: 1.2.3.4
+
+# Distribution of data among cores (shards) within a node
+#
+# Scylla distributes data within a node among shards, using a round-robin
+# strategy:
+#  [shard0] [shard1] ... [shardN-1] [shard0] [shard1] ... [shardN-1] ...
+#
+# Scylla versions 1.6 and below used just one repetition of the pattern;
+# this interfered with data placement among nodes (vnodes).
+#
+# Scylla versions 1.7 and above use 4096 repetitions of the pattern; this
+# provides for better data distribution.
+#
+# the value below is log (base 2) of the number of repetitions.
+#
+# Set to 0 to avoid rewriting all data when upgrading from Scylla 1.6 and
+# below.
+#
+# Keep at 12 for new clusters.
+murmur3_partitioner_ignore_msb_bits: 12
+
+# Bypass in-memory data cache (the row cache) when performing reversed queries.
+# reversed_reads_auto_bypass_cache: false
+
+# Use a new optimized algorithm for performing reversed reads.
+# Set to `false` to fall-back to the old algorithm.
+# enable_optimized_reversed_reads: true
+
+# Use on a new, parallel algorithm for performing aggregate queries.
+# Set to `false` to fall-back to the old algorithm.
+# enable_parallelized_aggregation: true
+
+# When enabled, the node will start using separate commit log for schema changes
+# right from the boot. Without this, it only happens following a restart after
+# all nodes in the cluster were upgraded.
+#
+# Having this option ensures that new installations don't need a rolling restart
+# to use the feature, but upgrades do.
+#
+# WARNING: It's unsafe to set this to false if the node previously booted
+# with the schema commit log enabled. In such case, some schema changes
+# may be lost if the node was not cleanly stopped.
+force_schema_commit_log: true
+
+# Time for which task manager task is kept in memory after it completes.
+task_ttl_in_seconds: 10
+
+# Use Raft to consistently manage schema information in the cluster.
+# Refer to https://docs.scylladb.com/master/architecture/raft.html for more details.
+# The 'Handling Failures' section is especially important.
+#
+# Once enabled in a cluster, this cannot be turned off.
+# If you want to bootstrap a new cluster without Raft, make sure to set this to `false`
+# before starting your nodes for the first time.
+#
+# A cluster not using Raft can be 'upgraded' to use Raft. Refer to the aforementioned
+# documentation, section 'Enabling Raft in ScyllaDB 5.2 and further', for the procedure.
+consistent_cluster_management: true
+
+# In materialized views, restrictions are allowed only on the view's primary key columns.
+# In old versions Scylla mistakenly allowed IS NOT NULL restrictions on columns which were not part
+# of the view's primary key. These invalid restrictions were ignored.
+# This option controls the behavior when someone tries to create a view with such invalid IS NOT NULL restrictions.
+#
+# Can be true, false, or warn.
+# * `true`: IS NOT NULL is allowed only on the view's primary key columns,
+#           trying to use it on other columns will cause an error, as it should.
+# * `false`: Scylla accepts IS NOT NULL restrictions on regular columns, but they're silently ignored.
+#            It's useful for backwards compatibility.
+# * `warn`: The same as false, but there's a warning about invalid view restrictions.
+#
+# To preserve backwards compatibility on old clusters, Scylla's default setting is `warn`.
+# New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`)
+# to make sure that trying to create an invalid view causes an error.
+strict_is_not_null_in_views: true
+
+# The Unix Domain Socket the node uses for maintenance socket.
+# The possible options are:
+# * ignore: the node will not open the maintenance socket,
+# * workdir: the node will open the maintenance socket on the path <scylla's workdir>/cql.m,
+#            where <scylla's workdir> is a path defined by the workdir configuration option,
+# * <socket path>: the node will open the maintenance socket on the path <socket path>.
+maintenance_socket: ignore
+
+# If set to true, configuration parameters defined with LiveUpdate option can be updated in runtime with CQL
+# by updating system.config virtual table. If we don't want any configuration parameter to be changed in runtime
+# via CQL, this option should be set to false. This parameter doesn't impose any limits on other mechanisms updating
+# configuration parameters in runtime, e.g. sending SIGHUP or using API. This option should be set to false
+# e.g. for cloud users, for whom scylla's configuration should be changed only by support engineers.
+# live_updatable_config_params_changeable_via_cql: true
+
+# ****************
+# *  GUARDRAILS  *
+# ****************
+
+# Guardrails to warn or fail when Replication Factor is smaller/greater than the threshold.
+# Please note that the value of 0 is always allowed,
+# which means that having no replication at all, i.e. RF = 0, is always valid.
+# A guardrail value smaller than 0, e.g. -1, means that the guardrail is disabled.
+# Commenting out a guardrail also means it is disabled.
+# minimum_replication_factor_fail_threshold: -1
+# minimum_replication_factor_warn_threshold:  3
+# maximum_replication_factor_warn_threshold: -1
+# maximum_replication_factor_fail_threshold: -1
+
+# Guardrails to warn about or disallow creating a keyspace with specific replication strategy.
+# Each of these 2 settings is a list storing replication strategies considered harmful.
+# The replication strategies to choose from are:
+# 1) SimpleStrategy,
+# 2) NetworkTopologyStrategy,
+# 3) LocalStrategy,
+# 4) EverywhereStrategy
+#
+# replication_strategy_warn_list:
+#  - SimpleStrategy
+# replication_strategy_fail_list:
+
+api_ui_dir: /usr/lib/scylla/swagger-ui/dist/
+api_doc_dir: /usr/lib/scylla/api/api-doc/
+alternator_port: 8000
+alternator_write_isolation: only_rmw_uses_lwt
+alternator_enforce_authorization: true
+enable_ipv6_dns_lookup: true
+
+uuid_sstable_identifiers_enabled: false
+initial_token: '-9150472522612669563,-9111221205120479077,-9019751773420037553,-8989618184501738691,-8985421987943811872,-8929819017881364616,-8905608265277782216,-8599135383210744400,-8539696938683978900,-8530008900562267713,-8516628679943981513,-8396918178459572267,-8387411421588601075,-8305770047186923597,-8300110857355321492,-8099312471793523241,-8007681245261452244,-7954076580205650908,-7951903234584564605,-7928761812651617155,-7688241757605894193,-7677777294990351344,-7656010926187545636,-7540647644230420434,-7422558024548025552,-7420368851848600639,-7411713535957285305,-7405549945514249854,-7369930096385810359,-7322261369545006044,-7300212215735048843,-7286965808017489526,-7235306043927068906,-7136806720100801313,-7066606512995762838,-7061422146251838104,-7060501001702478772,-7047586981957567954,-7018416121787400316,-7003939417502751434,-6982603648310811274,-6921486934327425891,-6913530189596019610,-6789681656603469856,-6676425892936028342,-6586017841859561568,-6551836579662165820,-6521852536232912519,-6508929464773592306,-6267030001466792112,-6262755788364925062,-6212253947928827454,-6047695452858795641,-6013845781911380329,-5981237452125884361,-5918162653671837295,-5878144032120239038,-5864298594183801736,-5711298079697549861,-5610045046105238650,-5333797487733350497,-5010707313732487558,-4976694327523105243,-4937033874687076944,-4854052391282645746,-4752138936875973027,-4641348250323690119,-4603724542752399633,-4591703913261010381,-4383440747404115872,-4246656764759618007,-4202261120669448972,-4093412687214488231,-4051842807973062323,-4014118550135595084,-4004406152916228712,-3983639400476869021,-3976941166173503819,-3968208907488457948,-3885008610967852868,-3808481946985406616,-3723993115832910258,-3697316272493989048,-3620882464283646869,-3583448297249872229,-3475803597928897896,-3265642651561562397,-3265066831527563630,-3229491989713618109,-3198705023782443579,-3063209869977399053,-3029808017299464637,-2994147045684850645,-2930264078385292477,-2889944340762659113,-2856124743411570807,-2630820465668932554,-2621930425830603867,-2562875312282232932,-2556705047407772751,-2536360414099972905,-2507547814987894704,-2246137023711624937,-2244696130365094668,-2229723407163297305,-2121852734959621982,-2027104875379934467,-1991708389921128761,-1909752385228065447,-1805218469163490466,-1672663355148794556,-1670848835378433635,-1571810439545919011,-1499727493023612358,-1494247671019846625,-1478721375888743575,-1444570715572803077,-1442753870059451557,-1334792554009155557,-1331590360248473807,-1262870266290755546,-1254403997011835061,-1215021392079450420,-1035450717781781469,-925607695261951990,-908241168337547444,-870529250037666337,-727696424341854976,-689271170816467247,-625517373521639770,-528655832325951651,-467955630350460136,-404442101848832464,-351560974793206759,-331568398414687633,-315702203354351490,-269738256863276149,-153894787362308370,-136884713300611835,-18242170234048072,-12965396545630748,23795267101039515,104515136173264751,153619059041897526,202495529400034000,218989125307766323,237527526049436569,281890543165223175,321855157227912129,352716203334730153,357042085297513189,360427991279447730,503986193235822490,551708218890369812,698745592773369709,706351066560661068,715307631668022789,772755424879756861,776136756685726512,814520400242336913,820205564091934859,874402524805210378,985932273638460460,1085321487292494423,1166180976106688260,1405949680873868788,1475483548653314093,1578126614191426721,1578318746761972531,1637595553224624821,1708501072493477510,1755394442148175304,1761908672170209301,1763377094325046577,1780819868253051694,1791143931583961503,2009402765002493061,2053556830324185961,2070067670660539068,2091460808179580670,2352343694451942200,2507014549823141482,2529744678174295854,2533809544342002652,2605852878070936461,2695204831374576477,2741870523031230405,2952274643759878618,3098637440505530831,3208242017460061908,3510645349660921739,3647024240704934790,3748210330265624632,3872297873616108733,3971644809428724485,3974436980927881333,4104640536848881476,4161419263409430262,4223087474836666928,4230434694514464607,4265217815188851747,4490256189425382734,4495994957033788013,4546540825524173027,4550100631797807408,4619872747572526246,4673757201872380752,4771333487053872661,4879449186911734831,4904391051749573787,4981856506292618478,4991570769689861701,4995999121784260085,5218270877629524471,5329147711162496280,5369133336369634192,5416181774884542663,5825274256752259982,6085513734708882282,6085765499072006996,6120481134544641805,6133658358387590468,6201195319183167950,6330819739329469894,6389521692133327267,6462177946114102677,6703908063977647038,6867035408910703843,6870094978576283245,6890691288199689232,6928913257184678722,7035324717862942880,7086698112767955950,7363543299040926279,7587103946003157141,7627779505123365334,7662306697431249393,7715630435067791081,7871755979328430704,7983003677599650607,8044178382685268802,8164089258846962472,8342578640896473263,8438023010035618145,8530148726464531893,8562358520968426056,8619477284898236927,8631273114042206139,8644558679283008652,8645937559258957640,8718171853023189921,8812401769853604278,8974161880705651908,9114909079731397463,9136764902665572886,9193657281392595791'

--- a/testing/scylla/scylla-PoC-restore-dc1-n3.yaml
+++ b/testing/scylla/scylla-PoC-restore-dc1-n3.yaml
@@ -1,0 +1,651 @@
+# Scylla storage config YAML
+
+#######################################
+# This file is split to two sections:
+# 1. Supported parameters
+# 2. Unsupported parameters: reserved for future use or backwards
+#    compatibility.
+# Scylla will only read and use the first segment
+#######################################
+
+### Supported Parameters
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+# It is recommended to change the default value when creating a new cluster.
+# You can NOT modify this value for an existing cluster
+cluster_name: 'Managed Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+num_tokens: 256
+
+# Directory where Scylla should store all its files, which are commitlog,
+# data, hints, view_hints and saved_caches subdirectories. All of these
+# subs can be overridden by the respective options below.
+# If unset, the value defaults to /var/lib/scylla
+# workdir: /var/lib/scylla
+
+# Directory where Scylla should store data on disk.
+data_file_directories:
+  - /var/lib/scylla/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+commitlog_directory: /var/lib/scylla/commitlog
+
+# schema commit log. A special commitlog instance
+# used for schema and system tables.
+# When running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# schema_commitlog_directory: /var/lib/scylla/commitlog/schema
+
+# commitlog_sync may be either "periodic" or "batch."
+#
+# When in batch mode, Scylla won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# The size of the individual schema commitlog file segments.
+#
+# The default size is 128, which is 4 times larger than the default
+# size of the data commitlog. It's because the segment size puts
+# a limit on the mutation size that can be written at once, and some
+# schema mutation writes are much larger than average.
+schema_commitlog_segment_size_in_mb: 128
+
+# seed_provider class_name is saved for future use.
+# A seed address is mandatory.
+seed_provider:
+  # The addresses of hosts that will serve as contact points for the joining node.
+  # It allows the node to discover the cluster ring topology on startup (when
+  # joining the cluster).
+  # Once the node has joined the cluster, the seed list has no function.
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      # In a new cluster, provide the address of the first node.
+      # In an existing cluster, specify the address of at least one existing node.
+      # If you specify addresses of more than one node, use a comma to separate them.
+      # For example: "<IP1>,<IP2>,<IP3>"
+      - seeds: "127.0.0.1"
+
+# Address to bind to and tell other Scylla nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# If you leave broadcast_address (below) empty, then setting listen_address
+# to 0.0.0.0 is wrong as other nodes will not know how to reach this node.
+# If you set broadcast_address, then you can set listen_address to 0.0.0.0.
+listen_address: localhost
+
+# Address to broadcast to other Scylla nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+
+# When using multiple physical network interfaces, set this to true to listen on broadcast_address
+# in addition to the listen_address, allowing nodes to communicate in both interfaces.
+# Ignore this property if the network configuration automatically routes between the public and private networks such as EC2.
+#
+# listen_on_broadcast_address: false
+
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+# To disable the CQL native transport, remove this option and configure native_transport_port_ssl.
+native_transport_port: 9042
+
+# Like native_transport_port, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+native_shard_aware_transport_port: 19042
+
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+#native_transport_port_ssl: 9142
+
+# Like native_transport_port_ssl, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+#native_shard_aware_transport_port_ssl: 19142
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# how long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Scylla enough about your network topology to route
+#   requests efficiently
+# - it allows Scylla to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Scylla will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Scylla provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Scylla will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: GossipingPropertyFileSnitch
+
+# The address or interface to bind the native transport server to.
+#
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+rpc_address: localhost
+# rpc_interface: eth1
+# rpc_interface_prefer_ipv6: false
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# port for REST API server
+api_port: 10000
+
+# IP for the REST API server
+api_address: 127.0.0.1
+
+# Log WARN on any batch size exceeding this value. 128 kiB per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 128
+
+# Fail any multiple-partition batch exceeding this value. 1 MiB (8x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 1024
+
+  # Authentication backend, identifying users
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+  # PasswordAuthenticator}.
+  #
+  # - AllowAllAuthenticator performs no checks - set it to disable authentication.
+  # - PasswordAuthenticator relies on username/password pairs to authenticate
+  #   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+  #   Please increase system_auth keyspace replication factor if you use this authenticator.
+  # - com.scylladb.auth.TransitionalAuthenticator requires username/password pair
+  #   to authenticate in the same manner as PasswordAuthenticator, but improper credentials
+#   result in being logged in as an anonymous user. Use for upgrading clusters' auth.
+authenticator: PasswordAuthenticator
+
+  # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+  # CassandraAuthorizer}.
+  #
+  # - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+  # - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+  #   increase system_auth keyspace replication factor if you use this authorizer.
+  # - com.scylladb.auth.TransitionalAuthorizer wraps around the CassandraAuthorizer, using it for
+  #   authorizing permission management. Otherwise, it allows all. Use for upgrading
+#   clusters' auth.
+authorizer: CassandraAuthorizer
+
+  # initial_token allows you to specify tokens manually.  While you can use # it with
+  # vnodes (num_tokens > 1, above) -- in which case you should provide a
+  # comma-separated list -- it's primarily used when adding nodes # to legacy clusters
+  # that do not have vnodes enabled.
+  # initial_token:
+
+  # RPC address to broadcast to drivers and other Scylla nodes. This cannot
+  # be set to 0.0.0.0. If left blank, this will be set to the value of
+  # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+  # be set.
+  # broadcast_rpc_address: 1.2.3.4
+
+  # Uncomment to enable experimental features
+  # experimental_features:
+  #     - udf
+  #     - alternator-streams
+  #     - broadcast-tables
+  #     - keyspace-storage-options
+
+  # The directory where hints files are stored if hinted handoff is enabled.
+# hints_directory: /var/lib/scylla/hints
+
+# The directory where hints files are stored for materialized-view updates
+# view_hints_directory: /var/lib/scylla/view_hints
+
+# See https://docs.scylladb.com/architecture/anti-entropy/hinted-handoff
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+# hinted_handoff_enabled: true
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+# max_hint_window_in_ms: 10800000 # 3 hours
+
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 10000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+# permissions_validity_in_ms: 10000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this also must have
+# a non-zero value. Defaults to 2000. It's recommended to set this value to
+# be at least 3 times smaller than the permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Murmur3Partitioner is currently the only supported partitioner,
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Total space to use for commitlogs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Scylla will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+#
+# A value of -1 (default) will automatically equate it to the total amount of memory
+# available for Scylla.
+commitlog_total_space_in_mb: -1
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# ssl_storage_port: 7001
+
+# listen_interface: eth0
+# listen_interface_prefer_ipv6: false
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+# start_native_transport: true
+
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# Whether to start the thrift rpc server.
+# start_rpc: true
+
+# enable or disable keepalive on rpc/native connections
+# rpc_keepalive: true
+
+# Set to true to have Scylla create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+# incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Scylla won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+# snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: false
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exhaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+# tombstone_warn_threshold: 1000
+# tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows within the partition by collation column
+#      is faster
+#   2) but, Scylla will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+# column_index_size_in_kb: 64
+
+# Auto-scaling of the promoted index prevents running out of memory
+# when the promoted index grows too large (due to partitions with many rows
+# vs. too small column_index_size_in_kb).  When the serialized representation
+# of the promoted index grows by this threshold, the desired block size
+# for this partition (initialized to column_index_size_in_kb)
+# is doubled, to decrease the sampling resolution by half.
+#
+# To disable promoted index auto-scaling, set the threshold to 0.
+# column_index_auto_scale_threshold_in_kb: 10240
+
+# Log a warning when writing partitions larger than this value
+# compaction_large_partition_warning_threshold_mb: 1000
+
+# Log a warning when writing rows larger than this value
+# compaction_large_row_warning_threshold_mb: 10
+
+# Log a warning when writing cells larger than this value
+# compaction_large_cell_warning_threshold_mb: 1
+
+# Log a warning when row number is larger than this value
+# compaction_rows_count_warning_threshold: 100000
+
+# Log a warning when writing a collection containing more elements than this value
+# compaction_collection_elements_count_warning_threshold: 10000
+
+# How long the coordinator should wait for seq or index scans to complete
+# range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+# counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+# cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+# truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+# request_timeout_in_ms: 10000
+
+# Enable or disable inter-node encryption.
+# You must also generate keys and provide the appropriate key and trust store locations and passwords.
+#
+# The available internode options are : all, none, dc, rack
+# If set to dc scylla  will encrypt the traffic between the DCs
+# If set to rack scylla  will encrypt the traffic between the racks
+#
+# SSL/TLS algorithm and ciphers used can be controlled by
+# the priority_string parameter. Info on priority string
+# syntax and values is available at:
+#   https://gnutls.org/manual/html_node/Priority-Strings.html
+#
+# The require_client_auth parameter allows you to
+# restrict access to service based on certificate
+# validation. Client must provide a certificate
+# accepted by the used trust store to connect.
+#
+# server_encryption_options:
+#    internode_encryption: none
+#    certificate: conf/scylla.crt
+#    keyfile: conf/scylla.key
+#    truststore: <not set, use system trust>
+#    certficate_revocation_list: <not set>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# enable or disable client/server encryption.
+client_encryption_options:
+  enabled: false
+  certificate: /etc/scylla/db.crt
+  keyfile: /etc/scylla/db.key
+#    truststore: <none, use system trust>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+# internode_compression: none
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+# inter_dc_tcp_nodelay: false
+
+# Relaxation of environment checks.
+#
+# Scylla places certain requirements on its environment.  If these requirements are
+# not met, performance and reliability can be degraded.
+#
+# These requirements include:
+#    - A filesystem with good support for asynchronous I/O (AIO). Currently,
+#      this means XFS.
+#
+# false: strict environment checks are in place; do not start if they are not met.
+# true: relaxed environment checks; performance and reliability may degraade.
+#
+# developer_mode: false
+
+
+# Idle-time background processing
+#
+# Scylla can perform certain jobs in the background while the system is otherwise idle,
+# freeing processor resources when there is other work to be done.
+#
+# defragment_memory_on_idle: true
+#
+# prometheus port
+# By default, Scylla opens prometheus API port on port 9180
+# setting the port to 0 will disable the prometheus API.
+# prometheus_port: 9180
+#
+# prometheus address
+# Leaving this blank will set it to the same value as listen_address.
+# This means that by default, Scylla listens to the prometheus API on the same
+# listening address (and therefore network interface) used to listen for
+# internal communication. If the monitoring node is not in this internal
+# network, you can override prometheus_address explicitly - e.g., setting
+# it to 0.0.0.0 to listen on all interfaces.
+# prometheus_address: 1.2.3.4
+
+# Distribution of data among cores (shards) within a node
+#
+# Scylla distributes data within a node among shards, using a round-robin
+# strategy:
+#  [shard0] [shard1] ... [shardN-1] [shard0] [shard1] ... [shardN-1] ...
+#
+# Scylla versions 1.6 and below used just one repetition of the pattern;
+# this interfered with data placement among nodes (vnodes).
+#
+# Scylla versions 1.7 and above use 4096 repetitions of the pattern; this
+# provides for better data distribution.
+#
+# the value below is log (base 2) of the number of repetitions.
+#
+# Set to 0 to avoid rewriting all data when upgrading from Scylla 1.6 and
+# below.
+#
+# Keep at 12 for new clusters.
+murmur3_partitioner_ignore_msb_bits: 12
+
+# Bypass in-memory data cache (the row cache) when performing reversed queries.
+# reversed_reads_auto_bypass_cache: false
+
+# Use a new optimized algorithm for performing reversed reads.
+# Set to `false` to fall-back to the old algorithm.
+# enable_optimized_reversed_reads: true
+
+# Use on a new, parallel algorithm for performing aggregate queries.
+# Set to `false` to fall-back to the old algorithm.
+# enable_parallelized_aggregation: true
+
+# When enabled, the node will start using separate commit log for schema changes
+# right from the boot. Without this, it only happens following a restart after
+# all nodes in the cluster were upgraded.
+#
+# Having this option ensures that new installations don't need a rolling restart
+# to use the feature, but upgrades do.
+#
+# WARNING: It's unsafe to set this to false if the node previously booted
+# with the schema commit log enabled. In such case, some schema changes
+# may be lost if the node was not cleanly stopped.
+force_schema_commit_log: true
+
+# Time for which task manager task is kept in memory after it completes.
+task_ttl_in_seconds: 10
+
+# Use Raft to consistently manage schema information in the cluster.
+# Refer to https://docs.scylladb.com/master/architecture/raft.html for more details.
+# The 'Handling Failures' section is especially important.
+#
+# Once enabled in a cluster, this cannot be turned off.
+# If you want to bootstrap a new cluster without Raft, make sure to set this to `false`
+# before starting your nodes for the first time.
+#
+# A cluster not using Raft can be 'upgraded' to use Raft. Refer to the aforementioned
+# documentation, section 'Enabling Raft in ScyllaDB 5.2 and further', for the procedure.
+consistent_cluster_management: true
+
+# In materialized views, restrictions are allowed only on the view's primary key columns.
+# In old versions Scylla mistakenly allowed IS NOT NULL restrictions on columns which were not part
+# of the view's primary key. These invalid restrictions were ignored.
+# This option controls the behavior when someone tries to create a view with such invalid IS NOT NULL restrictions.
+#
+# Can be true, false, or warn.
+# * `true`: IS NOT NULL is allowed only on the view's primary key columns,
+#           trying to use it on other columns will cause an error, as it should.
+# * `false`: Scylla accepts IS NOT NULL restrictions on regular columns, but they're silently ignored.
+#            It's useful for backwards compatibility.
+# * `warn`: The same as false, but there's a warning about invalid view restrictions.
+#
+# To preserve backwards compatibility on old clusters, Scylla's default setting is `warn`.
+# New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`)
+# to make sure that trying to create an invalid view causes an error.
+strict_is_not_null_in_views: true
+
+# The Unix Domain Socket the node uses for maintenance socket.
+# The possible options are:
+# * ignore: the node will not open the maintenance socket,
+# * workdir: the node will open the maintenance socket on the path <scylla's workdir>/cql.m,
+#            where <scylla's workdir> is a path defined by the workdir configuration option,
+# * <socket path>: the node will open the maintenance socket on the path <socket path>.
+maintenance_socket: ignore
+
+# If set to true, configuration parameters defined with LiveUpdate option can be updated in runtime with CQL
+# by updating system.config virtual table. If we don't want any configuration parameter to be changed in runtime
+# via CQL, this option should be set to false. This parameter doesn't impose any limits on other mechanisms updating
+# configuration parameters in runtime, e.g. sending SIGHUP or using API. This option should be set to false
+# e.g. for cloud users, for whom scylla's configuration should be changed only by support engineers.
+# live_updatable_config_params_changeable_via_cql: true
+
+# ****************
+# *  GUARDRAILS  *
+# ****************
+
+# Guardrails to warn or fail when Replication Factor is smaller/greater than the threshold.
+# Please note that the value of 0 is always allowed,
+# which means that having no replication at all, i.e. RF = 0, is always valid.
+# A guardrail value smaller than 0, e.g. -1, means that the guardrail is disabled.
+# Commenting out a guardrail also means it is disabled.
+# minimum_replication_factor_fail_threshold: -1
+# minimum_replication_factor_warn_threshold:  3
+# maximum_replication_factor_warn_threshold: -1
+# maximum_replication_factor_fail_threshold: -1
+
+# Guardrails to warn about or disallow creating a keyspace with specific replication strategy.
+# Each of these 2 settings is a list storing replication strategies considered harmful.
+# The replication strategies to choose from are:
+# 1) SimpleStrategy,
+# 2) NetworkTopologyStrategy,
+# 3) LocalStrategy,
+# 4) EverywhereStrategy
+#
+# replication_strategy_warn_list:
+#  - SimpleStrategy
+# replication_strategy_fail_list:
+
+api_ui_dir: /usr/lib/scylla/swagger-ui/dist/
+api_doc_dir: /usr/lib/scylla/api/api-doc/
+alternator_port: 8000
+alternator_write_isolation: only_rmw_uses_lwt
+alternator_enforce_authorization: true
+enable_ipv6_dns_lookup: true
+
+uuid_sstable_identifiers_enabled: false
+initial_token: '-9214425796929575304,-9090822078988667550,-8989244603175400746,-8790644111312367041,-8704783602900457863,-8679234040531879002,-8619076651508423644,-8587346048108145060,-8561638704586283383,-8412635122238408104,-8400710170334684555,-8329742811642787278,-8269560739249108332,-8179183431789126706,-8169431406743901125,-8096418644065405926,-7817212532301763844,-7785212462692109661,-7688395915925912798,-7593009351056461317,-7546791286541747968,-7415312613571703697,-7246867707474125739,-7229634351347812629,-7132362261753005429,-7020209684100840410,-6995608447194888114,-6987426543483469336,-6832523678605812487,-6775955417827176772,-6637910955496722427,-6622964571387964303,-6575383475450661912,-6545620046890462560,-6514202755216274864,-6304091746824473427,-6264940148515834802,-6188510686846392689,-6078638434697897427,-6030085721508072039,-5927530918238577711,-5843962097755201501,-5705291471537628710,-5620792828455562595,-5424466464409891289,-5407361846640734623,-5278930019396085729,-5267374976592925495,-5194589659982425238,-5146258963979449608,-4948182539536997823,-4900864224640127230,-4834630934059633770,-4754691640599615845,-4723656979818675036,-4682733435936122603,-4667725386351873390,-4656593383957967338,-4648720370269223527,-4607464580149069298,-4554019796501993812,-4547617769083644965,-4540056699163220287,-4508898930771310800,-4417136013068943678,-4370163750690104023,-4250273645152791769,-4158152129234780895,-4139397728602513391,-3972138689435169687,-3960315170420359493,-3948610981563221150,-3926981271099259356,-3887580040895445846,-3725576695552056012,-3646029286564720145,-3585016037005676655,-3582761760682518594,-3543466934831133522,-3534926366331540143,-3528181900638439563,-3497181973529825576,-3464062444146462064,-3314446660959413745,-3250067318257598286,-3122879980410549640,-3063352487630000042,-3048153834495510749,-2976246570690279926,-2927442636454944433,-2822606427489069295,-2751171927318598222,-2706722892072166701,-2466782166076182708,-2323437898114935808,-2219016579794112523,-2198835562398326294,-2132551032457007448,-2119948194117771754,-2119759720887997856,-2021387801821105394,-1921891206701920072,-1907338775108797051,-1906611852647907492,-1816200322620706858,-1812246084938836355,-1795067719856640022,-1718152098444612345,-1681946106247496512,-1658830658332544903,-1568454903515390796,-1511919027043586321,-1506665001827450820,-1480925651958854437,-1441077965000813621,-1362154709840188998,-1347181104015688646,-1344520443296789871,-1336035540156438705,-1334847884358327102,-1238087874836573176,-1231196981825067985,-1166389071047815516,-1064095156870887505,-812008638614578449,-806722115274104505,-717654117365379673,-709258780026421778,-535390621382027819,-484758298818389125,-273415597984203673,-168881310402033517,-162142469012602538,-144666778197670643,-138275999386677804,-119570755039796276,-77592902252294434,104758490924615517,162950208358308743,248849114078334367,270828068246000257,377333956666683278,457568737599048997,477946335038802393,519848885722919790,608199959932864231,651745253973607532,935459151725920821,967960967636431636,1041738173903731210,1062225263801598070,1281680955057665530,1423184838753061965,1488619772417614080,1510789186252939281,1615172332753227297,1621748146645751975,1819907902695781972,1895866020228263768,2070613644733242041,2170534356159425304,2227479995045183062,2262774029699877497,2323580395507780326,2365998881028247326,2390033963799756614,2455820344503460797,2617353346445084606,2625512147346630010,2626368617772346794,2677302492349612554,2683009461918810262,2684347313898587879,2733254525725725854,2914044763383220276,2929869563224807585,2973850387537456522,2974570517454396436,2999714739112437935,3065079827472239872,3074429758827613027,3094405148760006794,3191165922791938794,3241462483659717326,3297157654506630490,3616821328324495829,3632816062024446287,3775193737884230210,3779202513487605101,3890658770560335811,4111647856597446062,4318551996120079568,4431730243611169594,4490530414495745375,4515578307873450300,4529661869250151666,4644727709509533651,4683580079400052162,4780090830691710025,4867391375597485531,4905396550116743765,4923170773559682614,4985818301028566282,4992531574277587037,5009174354894288817,5124044998099978560,5185426069389128243,5271887708275408858,5297278795848024972,5425957207684705944,5504263868220230689,5519600597043846070,5741221728971832340,5774086908401525726,5780925730969547026,5889851298345795427,5945357229305272972,6093281943933001528,6156906051527955076,6245804993906002036,6282191056163619178,6338601363988919031,6404549889566826526,6539032125390652765,6603511363371040425,6748554879720815759,6763495111240776038,7058756434612142770,7099612063792852272,7206814818258067858,7295564794972191567,7360350528512249099,7411928563030429445,7543219896650939002,7568109094040168133,7587958621118495217,7703108748623156998,7789147611242722344,7805087787693664337,8007777803324589380,8024601197319407078,8094682155871774110,8215737196652388421,8217012579991505527,8342220719143438594,8359271580681238958,8424997955927285415,8611750842410411272,8627778656207356548,8683980334363647451,8822690981399662350,8869400059007968237,8909583222044292160,8974811548985245245,9029220796560817979,9166111512125330397'

--- a/testing/scylla/scylla-PoC-restore-dc2-n1.yaml
+++ b/testing/scylla/scylla-PoC-restore-dc2-n1.yaml
@@ -1,0 +1,651 @@
+# Scylla storage config YAML
+
+#######################################
+# This file is split to two sections:
+# 1. Supported parameters
+# 2. Unsupported parameters: reserved for future use or backwards
+#    compatibility.
+# Scylla will only read and use the first segment
+#######################################
+
+### Supported Parameters
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+# It is recommended to change the default value when creating a new cluster.
+# You can NOT modify this value for an existing cluster
+cluster_name: 'Managed Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+num_tokens: 256
+
+# Directory where Scylla should store all its files, which are commitlog,
+# data, hints, view_hints and saved_caches subdirectories. All of these
+# subs can be overridden by the respective options below.
+# If unset, the value defaults to /var/lib/scylla
+# workdir: /var/lib/scylla
+
+# Directory where Scylla should store data on disk.
+data_file_directories:
+  - /var/lib/scylla/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+commitlog_directory: /var/lib/scylla/commitlog
+
+# schema commit log. A special commitlog instance
+# used for schema and system tables.
+# When running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# schema_commitlog_directory: /var/lib/scylla/commitlog/schema
+
+# commitlog_sync may be either "periodic" or "batch."
+#
+# When in batch mode, Scylla won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# The size of the individual schema commitlog file segments.
+#
+# The default size is 128, which is 4 times larger than the default
+# size of the data commitlog. It's because the segment size puts
+# a limit on the mutation size that can be written at once, and some
+# schema mutation writes are much larger than average.
+schema_commitlog_segment_size_in_mb: 128
+
+# seed_provider class_name is saved for future use.
+# A seed address is mandatory.
+seed_provider:
+  # The addresses of hosts that will serve as contact points for the joining node.
+  # It allows the node to discover the cluster ring topology on startup (when
+  # joining the cluster).
+  # Once the node has joined the cluster, the seed list has no function.
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      # In a new cluster, provide the address of the first node.
+      # In an existing cluster, specify the address of at least one existing node.
+      # If you specify addresses of more than one node, use a comma to separate them.
+      # For example: "<IP1>,<IP2>,<IP3>"
+      - seeds: "127.0.0.1"
+
+# Address to bind to and tell other Scylla nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# If you leave broadcast_address (below) empty, then setting listen_address
+# to 0.0.0.0 is wrong as other nodes will not know how to reach this node.
+# If you set broadcast_address, then you can set listen_address to 0.0.0.0.
+listen_address: localhost
+
+# Address to broadcast to other Scylla nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+
+# When using multiple physical network interfaces, set this to true to listen on broadcast_address
+# in addition to the listen_address, allowing nodes to communicate in both interfaces.
+# Ignore this property if the network configuration automatically routes between the public and private networks such as EC2.
+#
+# listen_on_broadcast_address: false
+
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+# To disable the CQL native transport, remove this option and configure native_transport_port_ssl.
+native_transport_port: 9042
+
+# Like native_transport_port, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+native_shard_aware_transport_port: 19042
+
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+#native_transport_port_ssl: 9142
+
+# Like native_transport_port_ssl, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+#native_shard_aware_transport_port_ssl: 19142
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# how long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Scylla enough about your network topology to route
+#   requests efficiently
+# - it allows Scylla to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Scylla will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Scylla provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Scylla will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: GossipingPropertyFileSnitch
+
+# The address or interface to bind the native transport server to.
+#
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+rpc_address: localhost
+# rpc_interface: eth1
+# rpc_interface_prefer_ipv6: false
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# port for REST API server
+api_port: 10000
+
+# IP for the REST API server
+api_address: 127.0.0.1
+
+# Log WARN on any batch size exceeding this value. 128 kiB per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 128
+
+# Fail any multiple-partition batch exceeding this value. 1 MiB (8x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 1024
+
+  # Authentication backend, identifying users
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+  # PasswordAuthenticator}.
+  #
+  # - AllowAllAuthenticator performs no checks - set it to disable authentication.
+  # - PasswordAuthenticator relies on username/password pairs to authenticate
+  #   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+  #   Please increase system_auth keyspace replication factor if you use this authenticator.
+  # - com.scylladb.auth.TransitionalAuthenticator requires username/password pair
+  #   to authenticate in the same manner as PasswordAuthenticator, but improper credentials
+#   result in being logged in as an anonymous user. Use for upgrading clusters' auth.
+authenticator: PasswordAuthenticator
+
+  # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+  # CassandraAuthorizer}.
+  #
+  # - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+  # - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+  #   increase system_auth keyspace replication factor if you use this authorizer.
+  # - com.scylladb.auth.TransitionalAuthorizer wraps around the CassandraAuthorizer, using it for
+  #   authorizing permission management. Otherwise, it allows all. Use for upgrading
+#   clusters' auth.
+authorizer: CassandraAuthorizer
+
+  # initial_token allows you to specify tokens manually.  While you can use # it with
+  # vnodes (num_tokens > 1, above) -- in which case you should provide a
+  # comma-separated list -- it's primarily used when adding nodes # to legacy clusters
+  # that do not have vnodes enabled.
+  # initial_token:
+
+  # RPC address to broadcast to drivers and other Scylla nodes. This cannot
+  # be set to 0.0.0.0. If left blank, this will be set to the value of
+  # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+  # be set.
+  # broadcast_rpc_address: 1.2.3.4
+
+  # Uncomment to enable experimental features
+  # experimental_features:
+  #     - udf
+  #     - alternator-streams
+  #     - broadcast-tables
+  #     - keyspace-storage-options
+
+  # The directory where hints files are stored if hinted handoff is enabled.
+# hints_directory: /var/lib/scylla/hints
+
+# The directory where hints files are stored for materialized-view updates
+# view_hints_directory: /var/lib/scylla/view_hints
+
+# See https://docs.scylladb.com/architecture/anti-entropy/hinted-handoff
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+# hinted_handoff_enabled: true
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+# max_hint_window_in_ms: 10800000 # 3 hours
+
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 10000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+# permissions_validity_in_ms: 10000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this also must have
+# a non-zero value. Defaults to 2000. It's recommended to set this value to
+# be at least 3 times smaller than the permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Murmur3Partitioner is currently the only supported partitioner,
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Total space to use for commitlogs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Scylla will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+#
+# A value of -1 (default) will automatically equate it to the total amount of memory
+# available for Scylla.
+commitlog_total_space_in_mb: -1
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# ssl_storage_port: 7001
+
+# listen_interface: eth0
+# listen_interface_prefer_ipv6: false
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+# start_native_transport: true
+
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# Whether to start the thrift rpc server.
+# start_rpc: true
+
+# enable or disable keepalive on rpc/native connections
+# rpc_keepalive: true
+
+# Set to true to have Scylla create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+# incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Scylla won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+# snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: false
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exhaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+# tombstone_warn_threshold: 1000
+# tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows within the partition by collation column
+#      is faster
+#   2) but, Scylla will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+# column_index_size_in_kb: 64
+
+# Auto-scaling of the promoted index prevents running out of memory
+# when the promoted index grows too large (due to partitions with many rows
+# vs. too small column_index_size_in_kb).  When the serialized representation
+# of the promoted index grows by this threshold, the desired block size
+# for this partition (initialized to column_index_size_in_kb)
+# is doubled, to decrease the sampling resolution by half.
+#
+# To disable promoted index auto-scaling, set the threshold to 0.
+# column_index_auto_scale_threshold_in_kb: 10240
+
+# Log a warning when writing partitions larger than this value
+# compaction_large_partition_warning_threshold_mb: 1000
+
+# Log a warning when writing rows larger than this value
+# compaction_large_row_warning_threshold_mb: 10
+
+# Log a warning when writing cells larger than this value
+# compaction_large_cell_warning_threshold_mb: 1
+
+# Log a warning when row number is larger than this value
+# compaction_rows_count_warning_threshold: 100000
+
+# Log a warning when writing a collection containing more elements than this value
+# compaction_collection_elements_count_warning_threshold: 10000
+
+# How long the coordinator should wait for seq or index scans to complete
+# range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+# counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+# cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+# truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+# request_timeout_in_ms: 10000
+
+# Enable or disable inter-node encryption.
+# You must also generate keys and provide the appropriate key and trust store locations and passwords.
+#
+# The available internode options are : all, none, dc, rack
+# If set to dc scylla  will encrypt the traffic between the DCs
+# If set to rack scylla  will encrypt the traffic between the racks
+#
+# SSL/TLS algorithm and ciphers used can be controlled by
+# the priority_string parameter. Info on priority string
+# syntax and values is available at:
+#   https://gnutls.org/manual/html_node/Priority-Strings.html
+#
+# The require_client_auth parameter allows you to
+# restrict access to service based on certificate
+# validation. Client must provide a certificate
+# accepted by the used trust store to connect.
+#
+# server_encryption_options:
+#    internode_encryption: none
+#    certificate: conf/scylla.crt
+#    keyfile: conf/scylla.key
+#    truststore: <not set, use system trust>
+#    certficate_revocation_list: <not set>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# enable or disable client/server encryption.
+client_encryption_options:
+  enabled: false
+  certificate: /etc/scylla/db.crt
+  keyfile: /etc/scylla/db.key
+#    truststore: <none, use system trust>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+# internode_compression: none
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+# inter_dc_tcp_nodelay: false
+
+# Relaxation of environment checks.
+#
+# Scylla places certain requirements on its environment.  If these requirements are
+# not met, performance and reliability can be degraded.
+#
+# These requirements include:
+#    - A filesystem with good support for asynchronous I/O (AIO). Currently,
+#      this means XFS.
+#
+# false: strict environment checks are in place; do not start if they are not met.
+# true: relaxed environment checks; performance and reliability may degraade.
+#
+# developer_mode: false
+
+
+# Idle-time background processing
+#
+# Scylla can perform certain jobs in the background while the system is otherwise idle,
+# freeing processor resources when there is other work to be done.
+#
+# defragment_memory_on_idle: true
+#
+# prometheus port
+# By default, Scylla opens prometheus API port on port 9180
+# setting the port to 0 will disable the prometheus API.
+# prometheus_port: 9180
+#
+# prometheus address
+# Leaving this blank will set it to the same value as listen_address.
+# This means that by default, Scylla listens to the prometheus API on the same
+# listening address (and therefore network interface) used to listen for
+# internal communication. If the monitoring node is not in this internal
+# network, you can override prometheus_address explicitly - e.g., setting
+# it to 0.0.0.0 to listen on all interfaces.
+# prometheus_address: 1.2.3.4
+
+# Distribution of data among cores (shards) within a node
+#
+# Scylla distributes data within a node among shards, using a round-robin
+# strategy:
+#  [shard0] [shard1] ... [shardN-1] [shard0] [shard1] ... [shardN-1] ...
+#
+# Scylla versions 1.6 and below used just one repetition of the pattern;
+# this interfered with data placement among nodes (vnodes).
+#
+# Scylla versions 1.7 and above use 4096 repetitions of the pattern; this
+# provides for better data distribution.
+#
+# the value below is log (base 2) of the number of repetitions.
+#
+# Set to 0 to avoid rewriting all data when upgrading from Scylla 1.6 and
+# below.
+#
+# Keep at 12 for new clusters.
+murmur3_partitioner_ignore_msb_bits: 12
+
+# Bypass in-memory data cache (the row cache) when performing reversed queries.
+# reversed_reads_auto_bypass_cache: false
+
+# Use a new optimized algorithm for performing reversed reads.
+# Set to `false` to fall-back to the old algorithm.
+# enable_optimized_reversed_reads: true
+
+# Use on a new, parallel algorithm for performing aggregate queries.
+# Set to `false` to fall-back to the old algorithm.
+# enable_parallelized_aggregation: true
+
+# When enabled, the node will start using separate commit log for schema changes
+# right from the boot. Without this, it only happens following a restart after
+# all nodes in the cluster were upgraded.
+#
+# Having this option ensures that new installations don't need a rolling restart
+# to use the feature, but upgrades do.
+#
+# WARNING: It's unsafe to set this to false if the node previously booted
+# with the schema commit log enabled. In such case, some schema changes
+# may be lost if the node was not cleanly stopped.
+force_schema_commit_log: true
+
+# Time for which task manager task is kept in memory after it completes.
+task_ttl_in_seconds: 10
+
+# Use Raft to consistently manage schema information in the cluster.
+# Refer to https://docs.scylladb.com/master/architecture/raft.html for more details.
+# The 'Handling Failures' section is especially important.
+#
+# Once enabled in a cluster, this cannot be turned off.
+# If you want to bootstrap a new cluster without Raft, make sure to set this to `false`
+# before starting your nodes for the first time.
+#
+# A cluster not using Raft can be 'upgraded' to use Raft. Refer to the aforementioned
+# documentation, section 'Enabling Raft in ScyllaDB 5.2 and further', for the procedure.
+consistent_cluster_management: true
+
+# In materialized views, restrictions are allowed only on the view's primary key columns.
+# In old versions Scylla mistakenly allowed IS NOT NULL restrictions on columns which were not part
+# of the view's primary key. These invalid restrictions were ignored.
+# This option controls the behavior when someone tries to create a view with such invalid IS NOT NULL restrictions.
+#
+# Can be true, false, or warn.
+# * `true`: IS NOT NULL is allowed only on the view's primary key columns,
+#           trying to use it on other columns will cause an error, as it should.
+# * `false`: Scylla accepts IS NOT NULL restrictions on regular columns, but they're silently ignored.
+#            It's useful for backwards compatibility.
+# * `warn`: The same as false, but there's a warning about invalid view restrictions.
+#
+# To preserve backwards compatibility on old clusters, Scylla's default setting is `warn`.
+# New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`)
+# to make sure that trying to create an invalid view causes an error.
+strict_is_not_null_in_views: true
+
+# The Unix Domain Socket the node uses for maintenance socket.
+# The possible options are:
+# * ignore: the node will not open the maintenance socket,
+# * workdir: the node will open the maintenance socket on the path <scylla's workdir>/cql.m,
+#            where <scylla's workdir> is a path defined by the workdir configuration option,
+# * <socket path>: the node will open the maintenance socket on the path <socket path>.
+maintenance_socket: ignore
+
+# If set to true, configuration parameters defined with LiveUpdate option can be updated in runtime with CQL
+# by updating system.config virtual table. If we don't want any configuration parameter to be changed in runtime
+# via CQL, this option should be set to false. This parameter doesn't impose any limits on other mechanisms updating
+# configuration parameters in runtime, e.g. sending SIGHUP or using API. This option should be set to false
+# e.g. for cloud users, for whom scylla's configuration should be changed only by support engineers.
+# live_updatable_config_params_changeable_via_cql: true
+
+# ****************
+# *  GUARDRAILS  *
+# ****************
+
+# Guardrails to warn or fail when Replication Factor is smaller/greater than the threshold.
+# Please note that the value of 0 is always allowed,
+# which means that having no replication at all, i.e. RF = 0, is always valid.
+# A guardrail value smaller than 0, e.g. -1, means that the guardrail is disabled.
+# Commenting out a guardrail also means it is disabled.
+# minimum_replication_factor_fail_threshold: -1
+# minimum_replication_factor_warn_threshold:  3
+# maximum_replication_factor_warn_threshold: -1
+# maximum_replication_factor_fail_threshold: -1
+
+# Guardrails to warn about or disallow creating a keyspace with specific replication strategy.
+# Each of these 2 settings is a list storing replication strategies considered harmful.
+# The replication strategies to choose from are:
+# 1) SimpleStrategy,
+# 2) NetworkTopologyStrategy,
+# 3) LocalStrategy,
+# 4) EverywhereStrategy
+#
+# replication_strategy_warn_list:
+#  - SimpleStrategy
+# replication_strategy_fail_list:
+
+api_ui_dir: /usr/lib/scylla/swagger-ui/dist/
+api_doc_dir: /usr/lib/scylla/api/api-doc/
+alternator_port: 8000
+alternator_write_isolation: only_rmw_uses_lwt
+alternator_enforce_authorization: true
+enable_ipv6_dns_lookup: true
+
+uuid_sstable_identifiers_enabled: false
+initial_token: '-9196974718617318436,-9182972412215274037,-9133532502163250341,-9111918788430162944,-8838627949484658664,-8818613275326478168,-8793240158037652758,-8771002930433005917,-8670815482270539624,-8656607670812628584,-8654467557761052456,-8621210605528700568,-8608813441897850496,-8590462736990773356,-8577658703629063386,-8424950326514469431,-8351152362507791159,-8346874941040230521,-8313568332154903914,-8289804556000641640,-8201849571069283037,-8069118368459942486,-7909656443872815408,-7884621291615298132,-7873554255405096236,-7851215549814043333,-7823478545631421483,-7819754827090694165,-7749678075491714560,-7630562762347889688,-7450607401999057135,-7437951810311176690,-7387951922335979202,-7375506770660006392,-7348974181369014551,-7340402113332776568,-7304186921243720083,-7303837718342541400,-7284599393515676711,-7199167238429125631,-7177779381613697956,-7164829311778682627,-7152730944918378422,-6968299577292594962,-6928487513072085316,-6702147038443301450,-6640684344956917337,-6282597442706591448,-6163711053111073182,-6054068162600960132,-6006462318868437369,-5960386635781275179,-5895918238383174263,-5880525543550253249,-5800248381696430769,-5783921257876348165,-5776464215025367260,-5721495275144197789,-5692689376233532948,-5682317122992441013,-5638775666535024029,-5597632210016082584,-5575244839917247442,-5526389683501106993,-5519335307722599465,-5482047325339678247,-5436501924539408959,-5260930274045574632,-5154467266913937115,-5152618221778776507,-5123200285238973054,-5087387176102249924,-5056114447716073635,-4839035279246468067,-4777845769292726890,-4721318476380233056,-4570142218431396003,-4567273847173665356,-4533011753059218688,-4483990027917924941,-4465683688222706328,-4453426829386469364,-4319115493796210124,-4278527636447001998,-4272360137553142087,-4117720169680958304,-3967792318170564578,-3895981526528183874,-3851176500131641737,-3832839315887416685,-3795562111809269074,-3756067508285742318,-3625143130952656395,-3418022435336825110,-3413247474521795267,-3391387002249139099,-3350592454423831082,-3301456785055984802,-3257566009732347867,-3145838540532390075,-2635153541758233140,-2617008365529527624,-2592186110024436215,-2553660308380321767,-2516702209984504044,-2471578507405722619,-2417251594997517905,-2317925255861746876,-2273447888641838926,-2167944457727667629,-2134876683105238223,-2069119014482590650,-1983435000542911730,-1950655849981382330,-1858092683415157964,-1829496833671318312,-1791889513676018282,-1788922084664875298,-1540737323474366331,-1305370678953521302,-1287865006884748268,-1202120768442365416,-1113868878688343233,-1092318093161030095,-1060492291065653215,-937793982938302468,-922974707233873767,-882911290970326383,-856369911959980413,-832954750291789506,-443170277493153079,-427379429633710894,-277322667966107678,-208909885618231429,-193955560052798111,-86461926651206869,-81575976570247821,-52985918635129910,-3076734636582589,32890343840136089,149760144610151593,281812316166221744,322570996438963755,331724057837791782,401311342543505009,457801146540590822,536197413680034251,598698402160489752,638079383582548731,714937664584964049,795543501383134985,936702900235847978,976758649922778152,1270193921446351353,1297389514994732855,1443596345224985037,1514765858872042275,1598813861869015446,1721598336304559171,1795948719032799869,1867813307709028676,1875778305284675836,1946411547266076755,1955857328009168659,1957327517556895560,2041436820954299616,2064317023079627793,2238325761398692844,2362697066869051359,2377781713499474982,2428122862919175959,2619467270728636399,2670586511102503760,2703475901452304268,2717512207081520563,2762893425029656642,2856543104417623605,2992397921598553377,3007215245225070301,3008675962148282213,3068971811263461552,3249692493528783757,3433540067451386461,3441565246579728493,3573922064697561677,3603926552331144344,3620198345802055403,3673732757528037297,3703063939344540456,3831218543608194321,3876752798881112539,3880761381209446660,3952498861481346044,4074795928476541012,4076938017228533900,4117208143295685252,4259076724108045571,4268992680747868166,4315393448158621396,4496869773555874776,4507671202615015114,4528954577090902980,4605917857980467280,4661535871283621414,4676360880814259625,4890373422931797233,4891448886863725951,4936876490821646830,4947365370517340289,5031833699483011856,5165717072592961832,5232975446744756630,5246841474915537296,5437954781611248594,5525913694320935734,5568025319206672658,5591741541110886894,5614587170626422224,5718155108774680592,5763452093165031393,5806552568994409833,5994149625020674496,6016437078365916101,6114000096289626182,6206764069180709219,6327242628497185239,6442002245929438076,6443494067249211240,6507597434667794863,6508237754877899485,6580940126430903070,6707435692104493667,6761196016583147061,6810601553742920039,6837308646773239013,6858205773965117140,6889335491706109541,7009371655191748490,7343410645502858869,7451538188825719334,7585811475002952320,7663147546938671055,7756013500331282962,7838801047264804636,8155049057186941407,8179089800769644803,8448685253147898194,8508368454743810269,8660108435856577533,8698072157174574702,8761518894117096362,8808474193389857770,8819026568231461886,8997386378693623663,9032900506374745162,9176889346596993624'

--- a/testing/scylla/scylla-PoC-restore-dc2-n2.yaml
+++ b/testing/scylla/scylla-PoC-restore-dc2-n2.yaml
@@ -1,0 +1,651 @@
+# Scylla storage config YAML
+
+#######################################
+# This file is split to two sections:
+# 1. Supported parameters
+# 2. Unsupported parameters: reserved for future use or backwards
+#    compatibility.
+# Scylla will only read and use the first segment
+#######################################
+
+### Supported Parameters
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+# It is recommended to change the default value when creating a new cluster.
+# You can NOT modify this value for an existing cluster
+cluster_name: 'Managed Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+num_tokens: 256
+
+# Directory where Scylla should store all its files, which are commitlog,
+# data, hints, view_hints and saved_caches subdirectories. All of these
+# subs can be overridden by the respective options below.
+# If unset, the value defaults to /var/lib/scylla
+# workdir: /var/lib/scylla
+
+# Directory where Scylla should store data on disk.
+data_file_directories:
+  - /var/lib/scylla/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+commitlog_directory: /var/lib/scylla/commitlog
+
+# schema commit log. A special commitlog instance
+# used for schema and system tables.
+# When running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# schema_commitlog_directory: /var/lib/scylla/commitlog/schema
+
+# commitlog_sync may be either "periodic" or "batch."
+#
+# When in batch mode, Scylla won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# The size of the individual schema commitlog file segments.
+#
+# The default size is 128, which is 4 times larger than the default
+# size of the data commitlog. It's because the segment size puts
+# a limit on the mutation size that can be written at once, and some
+# schema mutation writes are much larger than average.
+schema_commitlog_segment_size_in_mb: 128
+
+# seed_provider class_name is saved for future use.
+# A seed address is mandatory.
+seed_provider:
+  # The addresses of hosts that will serve as contact points for the joining node.
+  # It allows the node to discover the cluster ring topology on startup (when
+  # joining the cluster).
+  # Once the node has joined the cluster, the seed list has no function.
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      # In a new cluster, provide the address of the first node.
+      # In an existing cluster, specify the address of at least one existing node.
+      # If you specify addresses of more than one node, use a comma to separate them.
+      # For example: "<IP1>,<IP2>,<IP3>"
+      - seeds: "127.0.0.1"
+
+# Address to bind to and tell other Scylla nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# If you leave broadcast_address (below) empty, then setting listen_address
+# to 0.0.0.0 is wrong as other nodes will not know how to reach this node.
+# If you set broadcast_address, then you can set listen_address to 0.0.0.0.
+listen_address: localhost
+
+# Address to broadcast to other Scylla nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+
+# When using multiple physical network interfaces, set this to true to listen on broadcast_address
+# in addition to the listen_address, allowing nodes to communicate in both interfaces.
+# Ignore this property if the network configuration automatically routes between the public and private networks such as EC2.
+#
+# listen_on_broadcast_address: false
+
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+# To disable the CQL native transport, remove this option and configure native_transport_port_ssl.
+native_transport_port: 9042
+
+# Like native_transport_port, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+native_shard_aware_transport_port: 19042
+
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+#native_transport_port_ssl: 9142
+
+# Like native_transport_port_ssl, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+#native_shard_aware_transport_port_ssl: 19142
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# how long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Scylla enough about your network topology to route
+#   requests efficiently
+# - it allows Scylla to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Scylla will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Scylla provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Scylla will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: GossipingPropertyFileSnitch
+
+# The address or interface to bind the native transport server to.
+#
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+rpc_address: localhost
+# rpc_interface: eth1
+# rpc_interface_prefer_ipv6: false
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# port for REST API server
+api_port: 10000
+
+# IP for the REST API server
+api_address: 127.0.0.1
+
+# Log WARN on any batch size exceeding this value. 128 kiB per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 128
+
+# Fail any multiple-partition batch exceeding this value. 1 MiB (8x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 1024
+
+  # Authentication backend, identifying users
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+  # PasswordAuthenticator}.
+  #
+  # - AllowAllAuthenticator performs no checks - set it to disable authentication.
+  # - PasswordAuthenticator relies on username/password pairs to authenticate
+  #   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+  #   Please increase system_auth keyspace replication factor if you use this authenticator.
+  # - com.scylladb.auth.TransitionalAuthenticator requires username/password pair
+  #   to authenticate in the same manner as PasswordAuthenticator, but improper credentials
+#   result in being logged in as an anonymous user. Use for upgrading clusters' auth.
+authenticator: PasswordAuthenticator
+
+  # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+  # CassandraAuthorizer}.
+  #
+  # - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+  # - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+  #   increase system_auth keyspace replication factor if you use this authorizer.
+  # - com.scylladb.auth.TransitionalAuthorizer wraps around the CassandraAuthorizer, using it for
+  #   authorizing permission management. Otherwise, it allows all. Use for upgrading
+#   clusters' auth.
+authorizer: CassandraAuthorizer
+
+  # initial_token allows you to specify tokens manually.  While you can use # it with
+  # vnodes (num_tokens > 1, above) -- in which case you should provide a
+  # comma-separated list -- it's primarily used when adding nodes # to legacy clusters
+  # that do not have vnodes enabled.
+  # initial_token:
+
+  # RPC address to broadcast to drivers and other Scylla nodes. This cannot
+  # be set to 0.0.0.0. If left blank, this will be set to the value of
+  # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+  # be set.
+  # broadcast_rpc_address: 1.2.3.4
+
+  # Uncomment to enable experimental features
+  # experimental_features:
+  #     - udf
+  #     - alternator-streams
+  #     - broadcast-tables
+  #     - keyspace-storage-options
+
+  # The directory where hints files are stored if hinted handoff is enabled.
+# hints_directory: /var/lib/scylla/hints
+
+# The directory where hints files are stored for materialized-view updates
+# view_hints_directory: /var/lib/scylla/view_hints
+
+# See https://docs.scylladb.com/architecture/anti-entropy/hinted-handoff
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+# hinted_handoff_enabled: true
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+# max_hint_window_in_ms: 10800000 # 3 hours
+
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 10000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+# permissions_validity_in_ms: 10000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this also must have
+# a non-zero value. Defaults to 2000. It's recommended to set this value to
+# be at least 3 times smaller than the permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Murmur3Partitioner is currently the only supported partitioner,
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Total space to use for commitlogs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Scylla will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+#
+# A value of -1 (default) will automatically equate it to the total amount of memory
+# available for Scylla.
+commitlog_total_space_in_mb: -1
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# ssl_storage_port: 7001
+
+# listen_interface: eth0
+# listen_interface_prefer_ipv6: false
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+# start_native_transport: true
+
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# Whether to start the thrift rpc server.
+# start_rpc: true
+
+# enable or disable keepalive on rpc/native connections
+# rpc_keepalive: true
+
+# Set to true to have Scylla create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+# incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Scylla won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+# snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: false
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exhaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+# tombstone_warn_threshold: 1000
+# tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows within the partition by collation column
+#      is faster
+#   2) but, Scylla will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+# column_index_size_in_kb: 64
+
+# Auto-scaling of the promoted index prevents running out of memory
+# when the promoted index grows too large (due to partitions with many rows
+# vs. too small column_index_size_in_kb).  When the serialized representation
+# of the promoted index grows by this threshold, the desired block size
+# for this partition (initialized to column_index_size_in_kb)
+# is doubled, to decrease the sampling resolution by half.
+#
+# To disable promoted index auto-scaling, set the threshold to 0.
+# column_index_auto_scale_threshold_in_kb: 10240
+
+# Log a warning when writing partitions larger than this value
+# compaction_large_partition_warning_threshold_mb: 1000
+
+# Log a warning when writing rows larger than this value
+# compaction_large_row_warning_threshold_mb: 10
+
+# Log a warning when writing cells larger than this value
+# compaction_large_cell_warning_threshold_mb: 1
+
+# Log a warning when row number is larger than this value
+# compaction_rows_count_warning_threshold: 100000
+
+# Log a warning when writing a collection containing more elements than this value
+# compaction_collection_elements_count_warning_threshold: 10000
+
+# How long the coordinator should wait for seq or index scans to complete
+# range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+# counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+# cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+# truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+# request_timeout_in_ms: 10000
+
+# Enable or disable inter-node encryption.
+# You must also generate keys and provide the appropriate key and trust store locations and passwords.
+#
+# The available internode options are : all, none, dc, rack
+# If set to dc scylla  will encrypt the traffic between the DCs
+# If set to rack scylla  will encrypt the traffic between the racks
+#
+# SSL/TLS algorithm and ciphers used can be controlled by
+# the priority_string parameter. Info on priority string
+# syntax and values is available at:
+#   https://gnutls.org/manual/html_node/Priority-Strings.html
+#
+# The require_client_auth parameter allows you to
+# restrict access to service based on certificate
+# validation. Client must provide a certificate
+# accepted by the used trust store to connect.
+#
+# server_encryption_options:
+#    internode_encryption: none
+#    certificate: conf/scylla.crt
+#    keyfile: conf/scylla.key
+#    truststore: <not set, use system trust>
+#    certficate_revocation_list: <not set>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# enable or disable client/server encryption.
+client_encryption_options:
+  enabled: false
+  certificate: /etc/scylla/db.crt
+  keyfile: /etc/scylla/db.key
+#    truststore: <none, use system trust>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+# internode_compression: none
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+# inter_dc_tcp_nodelay: false
+
+# Relaxation of environment checks.
+#
+# Scylla places certain requirements on its environment.  If these requirements are
+# not met, performance and reliability can be degraded.
+#
+# These requirements include:
+#    - A filesystem with good support for asynchronous I/O (AIO). Currently,
+#      this means XFS.
+#
+# false: strict environment checks are in place; do not start if they are not met.
+# true: relaxed environment checks; performance and reliability may degraade.
+#
+# developer_mode: false
+
+
+# Idle-time background processing
+#
+# Scylla can perform certain jobs in the background while the system is otherwise idle,
+# freeing processor resources when there is other work to be done.
+#
+# defragment_memory_on_idle: true
+#
+# prometheus port
+# By default, Scylla opens prometheus API port on port 9180
+# setting the port to 0 will disable the prometheus API.
+# prometheus_port: 9180
+#
+# prometheus address
+# Leaving this blank will set it to the same value as listen_address.
+# This means that by default, Scylla listens to the prometheus API on the same
+# listening address (and therefore network interface) used to listen for
+# internal communication. If the monitoring node is not in this internal
+# network, you can override prometheus_address explicitly - e.g., setting
+# it to 0.0.0.0 to listen on all interfaces.
+# prometheus_address: 1.2.3.4
+
+# Distribution of data among cores (shards) within a node
+#
+# Scylla distributes data within a node among shards, using a round-robin
+# strategy:
+#  [shard0] [shard1] ... [shardN-1] [shard0] [shard1] ... [shardN-1] ...
+#
+# Scylla versions 1.6 and below used just one repetition of the pattern;
+# this interfered with data placement among nodes (vnodes).
+#
+# Scylla versions 1.7 and above use 4096 repetitions of the pattern; this
+# provides for better data distribution.
+#
+# the value below is log (base 2) of the number of repetitions.
+#
+# Set to 0 to avoid rewriting all data when upgrading from Scylla 1.6 and
+# below.
+#
+# Keep at 12 for new clusters.
+murmur3_partitioner_ignore_msb_bits: 12
+
+# Bypass in-memory data cache (the row cache) when performing reversed queries.
+# reversed_reads_auto_bypass_cache: false
+
+# Use a new optimized algorithm for performing reversed reads.
+# Set to `false` to fall-back to the old algorithm.
+# enable_optimized_reversed_reads: true
+
+# Use on a new, parallel algorithm for performing aggregate queries.
+# Set to `false` to fall-back to the old algorithm.
+# enable_parallelized_aggregation: true
+
+# When enabled, the node will start using separate commit log for schema changes
+# right from the boot. Without this, it only happens following a restart after
+# all nodes in the cluster were upgraded.
+#
+# Having this option ensures that new installations don't need a rolling restart
+# to use the feature, but upgrades do.
+#
+# WARNING: It's unsafe to set this to false if the node previously booted
+# with the schema commit log enabled. In such case, some schema changes
+# may be lost if the node was not cleanly stopped.
+force_schema_commit_log: true
+
+# Time for which task manager task is kept in memory after it completes.
+task_ttl_in_seconds: 10
+
+# Use Raft to consistently manage schema information in the cluster.
+# Refer to https://docs.scylladb.com/master/architecture/raft.html for more details.
+# The 'Handling Failures' section is especially important.
+#
+# Once enabled in a cluster, this cannot be turned off.
+# If you want to bootstrap a new cluster without Raft, make sure to set this to `false`
+# before starting your nodes for the first time.
+#
+# A cluster not using Raft can be 'upgraded' to use Raft. Refer to the aforementioned
+# documentation, section 'Enabling Raft in ScyllaDB 5.2 and further', for the procedure.
+consistent_cluster_management: true
+
+# In materialized views, restrictions are allowed only on the view's primary key columns.
+# In old versions Scylla mistakenly allowed IS NOT NULL restrictions on columns which were not part
+# of the view's primary key. These invalid restrictions were ignored.
+# This option controls the behavior when someone tries to create a view with such invalid IS NOT NULL restrictions.
+#
+# Can be true, false, or warn.
+# * `true`: IS NOT NULL is allowed only on the view's primary key columns,
+#           trying to use it on other columns will cause an error, as it should.
+# * `false`: Scylla accepts IS NOT NULL restrictions on regular columns, but they're silently ignored.
+#            It's useful for backwards compatibility.
+# * `warn`: The same as false, but there's a warning about invalid view restrictions.
+#
+# To preserve backwards compatibility on old clusters, Scylla's default setting is `warn`.
+# New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`)
+# to make sure that trying to create an invalid view causes an error.
+strict_is_not_null_in_views: true
+
+# The Unix Domain Socket the node uses for maintenance socket.
+# The possible options are:
+# * ignore: the node will not open the maintenance socket,
+# * workdir: the node will open the maintenance socket on the path <scylla's workdir>/cql.m,
+#            where <scylla's workdir> is a path defined by the workdir configuration option,
+# * <socket path>: the node will open the maintenance socket on the path <socket path>.
+maintenance_socket: ignore
+
+# If set to true, configuration parameters defined with LiveUpdate option can be updated in runtime with CQL
+# by updating system.config virtual table. If we don't want any configuration parameter to be changed in runtime
+# via CQL, this option should be set to false. This parameter doesn't impose any limits on other mechanisms updating
+# configuration parameters in runtime, e.g. sending SIGHUP or using API. This option should be set to false
+# e.g. for cloud users, for whom scylla's configuration should be changed only by support engineers.
+# live_updatable_config_params_changeable_via_cql: true
+
+# ****************
+# *  GUARDRAILS  *
+# ****************
+
+# Guardrails to warn or fail when Replication Factor is smaller/greater than the threshold.
+# Please note that the value of 0 is always allowed,
+# which means that having no replication at all, i.e. RF = 0, is always valid.
+# A guardrail value smaller than 0, e.g. -1, means that the guardrail is disabled.
+# Commenting out a guardrail also means it is disabled.
+# minimum_replication_factor_fail_threshold: -1
+# minimum_replication_factor_warn_threshold:  3
+# maximum_replication_factor_warn_threshold: -1
+# maximum_replication_factor_fail_threshold: -1
+
+# Guardrails to warn about or disallow creating a keyspace with specific replication strategy.
+# Each of these 2 settings is a list storing replication strategies considered harmful.
+# The replication strategies to choose from are:
+# 1) SimpleStrategy,
+# 2) NetworkTopologyStrategy,
+# 3) LocalStrategy,
+# 4) EverywhereStrategy
+#
+# replication_strategy_warn_list:
+#  - SimpleStrategy
+# replication_strategy_fail_list:
+
+api_ui_dir: /usr/lib/scylla/swagger-ui/dist/
+api_doc_dir: /usr/lib/scylla/api/api-doc/
+alternator_port: 8000
+alternator_write_isolation: only_rmw_uses_lwt
+alternator_enforce_authorization: true
+enable_ipv6_dns_lookup: true
+
+uuid_sstable_identifiers_enabled: false
+initial_token: '-9121346027654360452,-9107000043869786133,-9078583858308862173,-9064118705429149978,-9024325947237712802,-8925076961068258833,-8880489830805197147,-8779021613372477624,-8746770589007386314,-8710850652460628699,-8517016469133299700,-8435393032802922937,-8390123950885957965,-8376509732175794720,-8369239889086835890,-8324187676798118029,-8316891022166003494,-8225145482037318854,-8141583063252793037,-8117247631067910363,-8036031384445944189,-8002100525096402759,-7937610203866177166,-7883213856325808797,-7866463943354008206,-7820547396492931481,-7820228396038123790,-7790268913571551450,-7783383455883692802,-7756230762951860881,-7643337948335997703,-7624450065518073078,-7505695845985451956,-7502287114221185672,-7356399153448213548,-7260826840527063026,-7236733597000785139,-7208134075031170857,-7196503934137169213,-7112873774598353964,-7018028135028023647,-6943128288538843851,-6927753510302202216,-6916145591742888216,-6895979834485321005,-6846910069758910454,-6816013972149698564,-6774025577282472945,-6734093536506638289,-6691156051666658449,-6619467038332482822,-6544640855403841832,-6487833360927224658,-6391251316915511295,-6359989334621601818,-6317364186542524010,-6215302146579508221,-6157114449266663011,-5996200782160700302,-5980240926015607017,-5757871237707184472,-5707277870801763198,-5685867491001584459,-5493645921599542580,-5470610332783936682,-5452417159920089810,-5440295932917463420,-5405053180573603431,-5261430100481026282,-5208757010384284499,-5075551843687447777,-4989895438013592625,-4944314124563247818,-4818090670819574110,-4772973758637208265,-4754223214915771155,-4724060540251320055,-4702602947653682111,-4699446265870100790,-4593609530000604368,-4425294309307882627,-4362639207604901228,-4258049327678504261,-4197095241756940921,-4181818063120887230,-4098614762247148403,-4004485105770400063,-3805476331121208386,-3783899861488494174,-3758511823366504514,-3534996928901441623,-3418113981133652853,-3299292570606841461,-3240671855597620625,-3056680315392132448,-2914166047766035460,-2910127406873860698,-2588760221879050914,-2558357546858956634,-2330502115888019435,-2186307454927337741,-2165668281194889874,-2161175555626912362,-2151704311970932431,-2063090639258077891,-1968858967919810239,-1925881215298819390,-1752749924189896027,-1739895759577611225,-1719476595119089561,-1705542572788949203,-1704951024461632664,-1675268739206049917,-1556093351884552823,-1534283073139984624,-1463100025945072580,-1455783625046275904,-1434605722907653486,-1264545013846632509,-1256820622221756275,-1234837924960817612,-1198014161308353657,-1157107713676924363,-923532436724056462,-782395865801158859,-763529028487673634,-683349590789482178,-455804338341491746,-433331648049658914,-314674632977525578,-110187915387481349,-102983856679899268,-74670652355698470,127650562284947425,269431149266229263,308197531091109201,410120668577307691,435517601646173677,510785158195436110,825150727202884476,960615549711514024,1039871411889833352,1061271642602871213,1175114820659257241,1415439113858685629,1434710851645098545,1489517665979568781,1549504650842078589,1728239578093385400,1816828610386042218,1821613937185758692,1879537339470335933,1959488575180389797,1988332549274086328,2009427673860247408,2106799145481035348,2185008953746129793,2322918222333049170,2327329355768815400,2578741442917824382,2817122913932293752,2842343833569014146,2859142887793680736,2983491455529259693,3090904912001438180,3191129445349227330,3390395494847706119,3481459276597528243,3494799171452308009,3495915347697824701,3562969668504075892,3699118794179604761,3780728091366998972,3849243378206514623,3913133150935025154,3980564740325858479,4063229216155919176,4125887433882057878,4143577496782243657,4239684457858708030,4250845492311221383,4293730999050253617,4551362861696649889,4708842166620456566,4821817112391127923,4968343991056408860,4968585413057351926,4989305154564311800,5253079879979371167,5306365843082927779,5411918713752528042,5652264612954014063,5693538452815458950,5810255753135805565,5843921202904343919,5883578726549754326,5978972217108166732,6059656177825334161,6126628721814318306,6134124582883470833,6235341173393094634,6278593857612080355,6357916947292097654,6486840970903088689,6596856308859283694,6611061532579148869,6634797550142555665,6670844105463522613,6711311979814904370,6806663183941913559,6818561427382486341,6944956786389939052,7079675466308641497,7085940676473129714,7177133823650257364,7239945718656330005,7257703859468376337,7314313730215789380,7381804569144137781,7411172902718477840,7497240035034006478,7607105954203665843,7612685364393438998,7631752619334217707,7680967675351293232,7724052878157449936,7792410785426250676,7838020746532655309,7882132735877955774,7908506560460457325,7971458981453672927,8041318489759326599,8165991128198265974,8178985412920108120,8244737397109056602,8341065744007237551,8385244887839220585,8405884759509315677,8428135091161726724,8449483719586379448,8452195039840981299,8477441624255615496,8558730518670406207,8578158688979834261,8635407305819536683,8643664556731849419,8699660637489754202,8731068636929464961,8749673668167707244,8804642464166346364,8826251253680895032,8920679745583197393,8968474240788048459,8970785069388135822,8976544414345881747,9153435379595617007'

--- a/testing/scylla/scylla-PoC-restore-dc2-n3.yaml
+++ b/testing/scylla/scylla-PoC-restore-dc2-n3.yaml
@@ -1,0 +1,651 @@
+# Scylla storage config YAML
+
+#######################################
+# This file is split to two sections:
+# 1. Supported parameters
+# 2. Unsupported parameters: reserved for future use or backwards
+#    compatibility.
+# Scylla will only read and use the first segment
+#######################################
+
+### Supported Parameters
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+# It is recommended to change the default value when creating a new cluster.
+# You can NOT modify this value for an existing cluster
+cluster_name: 'Managed Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+num_tokens: 256
+
+# Directory where Scylla should store all its files, which are commitlog,
+# data, hints, view_hints and saved_caches subdirectories. All of these
+# subs can be overridden by the respective options below.
+# If unset, the value defaults to /var/lib/scylla
+# workdir: /var/lib/scylla
+
+# Directory where Scylla should store data on disk.
+data_file_directories:
+  - /var/lib/scylla/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+commitlog_directory: /var/lib/scylla/commitlog
+
+# schema commit log. A special commitlog instance
+# used for schema and system tables.
+# When running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# schema_commitlog_directory: /var/lib/scylla/commitlog/schema
+
+# commitlog_sync may be either "periodic" or "batch."
+#
+# When in batch mode, Scylla won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# The size of the individual schema commitlog file segments.
+#
+# The default size is 128, which is 4 times larger than the default
+# size of the data commitlog. It's because the segment size puts
+# a limit on the mutation size that can be written at once, and some
+# schema mutation writes are much larger than average.
+schema_commitlog_segment_size_in_mb: 128
+
+# seed_provider class_name is saved for future use.
+# A seed address is mandatory.
+seed_provider:
+  # The addresses of hosts that will serve as contact points for the joining node.
+  # It allows the node to discover the cluster ring topology on startup (when
+  # joining the cluster).
+  # Once the node has joined the cluster, the seed list has no function.
+  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+    parameters:
+      # In a new cluster, provide the address of the first node.
+      # In an existing cluster, specify the address of at least one existing node.
+      # If you specify addresses of more than one node, use a comma to separate them.
+      # For example: "<IP1>,<IP2>,<IP3>"
+      - seeds: "127.0.0.1"
+
+# Address to bind to and tell other Scylla nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# If you leave broadcast_address (below) empty, then setting listen_address
+# to 0.0.0.0 is wrong as other nodes will not know how to reach this node.
+# If you set broadcast_address, then you can set listen_address to 0.0.0.0.
+listen_address: localhost
+
+# Address to broadcast to other Scylla nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+
+# When using multiple physical network interfaces, set this to true to listen on broadcast_address
+# in addition to the listen_address, allowing nodes to communicate in both interfaces.
+# Ignore this property if the network configuration automatically routes between the public and private networks such as EC2.
+#
+# listen_on_broadcast_address: false
+
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+# To disable the CQL native transport, remove this option and configure native_transport_port_ssl.
+native_transport_port: 9042
+
+# Like native_transport_port, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+native_shard_aware_transport_port: 19042
+
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+#native_transport_port_ssl: 9142
+
+# Like native_transport_port_ssl, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+#native_shard_aware_transport_port_ssl: 19142
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# how long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Scylla enough about your network topology to route
+#   requests efficiently
+# - it allows Scylla to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Scylla will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Scylla provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Scylla will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: GossipingPropertyFileSnitch
+
+# The address or interface to bind the native transport server to.
+#
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+rpc_address: localhost
+# rpc_interface: eth1
+# rpc_interface_prefer_ipv6: false
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# port for REST API server
+api_port: 10000
+
+# IP for the REST API server
+api_address: 127.0.0.1
+
+# Log WARN on any batch size exceeding this value. 128 kiB per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 128
+
+# Fail any multiple-partition batch exceeding this value. 1 MiB (8x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 1024
+
+  # Authentication backend, identifying users
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+  # PasswordAuthenticator}.
+  #
+  # - AllowAllAuthenticator performs no checks - set it to disable authentication.
+  # - PasswordAuthenticator relies on username/password pairs to authenticate
+  #   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+  #   Please increase system_auth keyspace replication factor if you use this authenticator.
+  # - com.scylladb.auth.TransitionalAuthenticator requires username/password pair
+  #   to authenticate in the same manner as PasswordAuthenticator, but improper credentials
+#   result in being logged in as an anonymous user. Use for upgrading clusters' auth.
+authenticator: PasswordAuthenticator
+
+  # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+  # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+  # CassandraAuthorizer}.
+  #
+  # - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+  # - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+  #   increase system_auth keyspace replication factor if you use this authorizer.
+  # - com.scylladb.auth.TransitionalAuthorizer wraps around the CassandraAuthorizer, using it for
+  #   authorizing permission management. Otherwise, it allows all. Use for upgrading
+#   clusters' auth.
+authorizer: CassandraAuthorizer
+
+  # initial_token allows you to specify tokens manually.  While you can use # it with
+  # vnodes (num_tokens > 1, above) -- in which case you should provide a
+  # comma-separated list -- it's primarily used when adding nodes # to legacy clusters
+  # that do not have vnodes enabled.
+  # initial_token:
+
+  # RPC address to broadcast to drivers and other Scylla nodes. This cannot
+  # be set to 0.0.0.0. If left blank, this will be set to the value of
+  # rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+  # be set.
+  # broadcast_rpc_address: 1.2.3.4
+
+  # Uncomment to enable experimental features
+  # experimental_features:
+  #     - udf
+  #     - alternator-streams
+  #     - broadcast-tables
+  #     - keyspace-storage-options
+
+  # The directory where hints files are stored if hinted handoff is enabled.
+# hints_directory: /var/lib/scylla/hints
+
+# The directory where hints files are stored for materialized-view updates
+# view_hints_directory: /var/lib/scylla/view_hints
+
+# See https://docs.scylladb.com/architecture/anti-entropy/hinted-handoff
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+# hinted_handoff_enabled: true
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+# max_hint_window_in_ms: 10800000 # 3 hours
+
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 10000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+# permissions_validity_in_ms: 10000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this also must have
+# a non-zero value. Defaults to 2000. It's recommended to set this value to
+# be at least 3 times smaller than the permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Murmur3Partitioner is currently the only supported partitioner,
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Total space to use for commitlogs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Scylla will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+#
+# A value of -1 (default) will automatically equate it to the total amount of memory
+# available for Scylla.
+commitlog_total_space_in_mb: -1
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# ssl_storage_port: 7001
+
+# listen_interface: eth0
+# listen_interface_prefer_ipv6: false
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+# start_native_transport: true
+
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# Whether to start the thrift rpc server.
+# start_rpc: true
+
+# enable or disable keepalive on rpc/native connections
+# rpc_keepalive: true
+
+# Set to true to have Scylla create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+# incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Scylla won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+# snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: false
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exhaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+# tombstone_warn_threshold: 1000
+# tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows within the partition by collation column
+#      is faster
+#   2) but, Scylla will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+# column_index_size_in_kb: 64
+
+# Auto-scaling of the promoted index prevents running out of memory
+# when the promoted index grows too large (due to partitions with many rows
+# vs. too small column_index_size_in_kb).  When the serialized representation
+# of the promoted index grows by this threshold, the desired block size
+# for this partition (initialized to column_index_size_in_kb)
+# is doubled, to decrease the sampling resolution by half.
+#
+# To disable promoted index auto-scaling, set the threshold to 0.
+# column_index_auto_scale_threshold_in_kb: 10240
+
+# Log a warning when writing partitions larger than this value
+# compaction_large_partition_warning_threshold_mb: 1000
+
+# Log a warning when writing rows larger than this value
+# compaction_large_row_warning_threshold_mb: 10
+
+# Log a warning when writing cells larger than this value
+# compaction_large_cell_warning_threshold_mb: 1
+
+# Log a warning when row number is larger than this value
+# compaction_rows_count_warning_threshold: 100000
+
+# Log a warning when writing a collection containing more elements than this value
+# compaction_collection_elements_count_warning_threshold: 10000
+
+# How long the coordinator should wait for seq or index scans to complete
+# range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+# counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+# cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+# truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+# request_timeout_in_ms: 10000
+
+# Enable or disable inter-node encryption.
+# You must also generate keys and provide the appropriate key and trust store locations and passwords.
+#
+# The available internode options are : all, none, dc, rack
+# If set to dc scylla  will encrypt the traffic between the DCs
+# If set to rack scylla  will encrypt the traffic between the racks
+#
+# SSL/TLS algorithm and ciphers used can be controlled by
+# the priority_string parameter. Info on priority string
+# syntax and values is available at:
+#   https://gnutls.org/manual/html_node/Priority-Strings.html
+#
+# The require_client_auth parameter allows you to
+# restrict access to service based on certificate
+# validation. Client must provide a certificate
+# accepted by the used trust store to connect.
+#
+# server_encryption_options:
+#    internode_encryption: none
+#    certificate: conf/scylla.crt
+#    keyfile: conf/scylla.key
+#    truststore: <not set, use system trust>
+#    certficate_revocation_list: <not set>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# enable or disable client/server encryption.
+client_encryption_options:
+  enabled: false
+  certificate: /etc/scylla/db.crt
+  keyfile: /etc/scylla/db.key
+#    truststore: <none, use system trust>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+# internode_compression: none
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+# inter_dc_tcp_nodelay: false
+
+# Relaxation of environment checks.
+#
+# Scylla places certain requirements on its environment.  If these requirements are
+# not met, performance and reliability can be degraded.
+#
+# These requirements include:
+#    - A filesystem with good support for asynchronous I/O (AIO). Currently,
+#      this means XFS.
+#
+# false: strict environment checks are in place; do not start if they are not met.
+# true: relaxed environment checks; performance and reliability may degraade.
+#
+# developer_mode: false
+
+
+# Idle-time background processing
+#
+# Scylla can perform certain jobs in the background while the system is otherwise idle,
+# freeing processor resources when there is other work to be done.
+#
+# defragment_memory_on_idle: true
+#
+# prometheus port
+# By default, Scylla opens prometheus API port on port 9180
+# setting the port to 0 will disable the prometheus API.
+# prometheus_port: 9180
+#
+# prometheus address
+# Leaving this blank will set it to the same value as listen_address.
+# This means that by default, Scylla listens to the prometheus API on the same
+# listening address (and therefore network interface) used to listen for
+# internal communication. If the monitoring node is not in this internal
+# network, you can override prometheus_address explicitly - e.g., setting
+# it to 0.0.0.0 to listen on all interfaces.
+# prometheus_address: 1.2.3.4
+
+# Distribution of data among cores (shards) within a node
+#
+# Scylla distributes data within a node among shards, using a round-robin
+# strategy:
+#  [shard0] [shard1] ... [shardN-1] [shard0] [shard1] ... [shardN-1] ...
+#
+# Scylla versions 1.6 and below used just one repetition of the pattern;
+# this interfered with data placement among nodes (vnodes).
+#
+# Scylla versions 1.7 and above use 4096 repetitions of the pattern; this
+# provides for better data distribution.
+#
+# the value below is log (base 2) of the number of repetitions.
+#
+# Set to 0 to avoid rewriting all data when upgrading from Scylla 1.6 and
+# below.
+#
+# Keep at 12 for new clusters.
+murmur3_partitioner_ignore_msb_bits: 12
+
+# Bypass in-memory data cache (the row cache) when performing reversed queries.
+# reversed_reads_auto_bypass_cache: false
+
+# Use a new optimized algorithm for performing reversed reads.
+# Set to `false` to fall-back to the old algorithm.
+# enable_optimized_reversed_reads: true
+
+# Use on a new, parallel algorithm for performing aggregate queries.
+# Set to `false` to fall-back to the old algorithm.
+# enable_parallelized_aggregation: true
+
+# When enabled, the node will start using separate commit log for schema changes
+# right from the boot. Without this, it only happens following a restart after
+# all nodes in the cluster were upgraded.
+#
+# Having this option ensures that new installations don't need a rolling restart
+# to use the feature, but upgrades do.
+#
+# WARNING: It's unsafe to set this to false if the node previously booted
+# with the schema commit log enabled. In such case, some schema changes
+# may be lost if the node was not cleanly stopped.
+force_schema_commit_log: true
+
+# Time for which task manager task is kept in memory after it completes.
+task_ttl_in_seconds: 10
+
+# Use Raft to consistently manage schema information in the cluster.
+# Refer to https://docs.scylladb.com/master/architecture/raft.html for more details.
+# The 'Handling Failures' section is especially important.
+#
+# Once enabled in a cluster, this cannot be turned off.
+# If you want to bootstrap a new cluster without Raft, make sure to set this to `false`
+# before starting your nodes for the first time.
+#
+# A cluster not using Raft can be 'upgraded' to use Raft. Refer to the aforementioned
+# documentation, section 'Enabling Raft in ScyllaDB 5.2 and further', for the procedure.
+consistent_cluster_management: true
+
+# In materialized views, restrictions are allowed only on the view's primary key columns.
+# In old versions Scylla mistakenly allowed IS NOT NULL restrictions on columns which were not part
+# of the view's primary key. These invalid restrictions were ignored.
+# This option controls the behavior when someone tries to create a view with such invalid IS NOT NULL restrictions.
+#
+# Can be true, false, or warn.
+# * `true`: IS NOT NULL is allowed only on the view's primary key columns,
+#           trying to use it on other columns will cause an error, as it should.
+# * `false`: Scylla accepts IS NOT NULL restrictions on regular columns, but they're silently ignored.
+#            It's useful for backwards compatibility.
+# * `warn`: The same as false, but there's a warning about invalid view restrictions.
+#
+# To preserve backwards compatibility on old clusters, Scylla's default setting is `warn`.
+# New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`)
+# to make sure that trying to create an invalid view causes an error.
+strict_is_not_null_in_views: true
+
+# The Unix Domain Socket the node uses for maintenance socket.
+# The possible options are:
+# * ignore: the node will not open the maintenance socket,
+# * workdir: the node will open the maintenance socket on the path <scylla's workdir>/cql.m,
+#            where <scylla's workdir> is a path defined by the workdir configuration option,
+# * <socket path>: the node will open the maintenance socket on the path <socket path>.
+maintenance_socket: ignore
+
+# If set to true, configuration parameters defined with LiveUpdate option can be updated in runtime with CQL
+# by updating system.config virtual table. If we don't want any configuration parameter to be changed in runtime
+# via CQL, this option should be set to false. This parameter doesn't impose any limits on other mechanisms updating
+# configuration parameters in runtime, e.g. sending SIGHUP or using API. This option should be set to false
+# e.g. for cloud users, for whom scylla's configuration should be changed only by support engineers.
+# live_updatable_config_params_changeable_via_cql: true
+
+# ****************
+# *  GUARDRAILS  *
+# ****************
+
+# Guardrails to warn or fail when Replication Factor is smaller/greater than the threshold.
+# Please note that the value of 0 is always allowed,
+# which means that having no replication at all, i.e. RF = 0, is always valid.
+# A guardrail value smaller than 0, e.g. -1, means that the guardrail is disabled.
+# Commenting out a guardrail also means it is disabled.
+# minimum_replication_factor_fail_threshold: -1
+# minimum_replication_factor_warn_threshold:  3
+# maximum_replication_factor_warn_threshold: -1
+# maximum_replication_factor_fail_threshold: -1
+
+# Guardrails to warn about or disallow creating a keyspace with specific replication strategy.
+# Each of these 2 settings is a list storing replication strategies considered harmful.
+# The replication strategies to choose from are:
+# 1) SimpleStrategy,
+# 2) NetworkTopologyStrategy,
+# 3) LocalStrategy,
+# 4) EverywhereStrategy
+#
+# replication_strategy_warn_list:
+#  - SimpleStrategy
+# replication_strategy_fail_list:
+
+api_ui_dir: /usr/lib/scylla/swagger-ui/dist/
+api_doc_dir: /usr/lib/scylla/api/api-doc/
+alternator_port: 8000
+alternator_write_isolation: only_rmw_uses_lwt
+alternator_enforce_authorization: true
+enable_ipv6_dns_lookup: true
+
+uuid_sstable_identifiers_enabled: false
+initial_token: '-9126533192591375445,-9115947761275298300,-9042984182799678160,-8891924845513038305,-8864655508946584430,-8806247815244815735,-8723934509426365475,-8713309909849542869,-8701438106434530617,-8678373287990258936,-8570334067066046261,-8532508644777222292,-8514023126234190365,-8478823742661978711,-8476578859505802072,-8344892158166858885,-8344352300175446056,-8339523744191593886,-8237325922069935813,-8208660650078935224,-8101466554335546134,-7815362314631355898,-7812521676194475293,-7739106190608494939,-7689034045685572166,-7674743426610193446,-7671342468797567022,-7605914531689507587,-7596617542662802241,-7593403754547174744,-7452595577246066254,-7317303527591381915,-7294688752227077244,-7230683553496701610,-7172461764614165025,-7154825034887746307,-7029359912946587736,-6981469630631531058,-6957736172888681044,-6934316750579574579,-6919484209764847697,-6856254310238083159,-6850739174736868294,-6837574818716634007,-6805635403109774356,-6743464012998862101,-6551688112218347665,-6526660377427395051,-6524116145593039318,-6494883622094864238,-6471390242017656906,-6469442068261585818,-6449320910293443317,-6310108514809037721,-6180336475481596557,-6143483318990432391,-6098022589838023987,-6087487674175119567,-5881889537053062041,-5839624999397569252,-5794851760302715615,-5742980596267684869,-5705796252256642237,-5700696789090627311,-5665899342440735014,-5596178197589268132,-5393147708646489045,-5374327491420354803,-5114216337353318324,-5113494371323474289,-5089705246073881609,-5084887612277333397,-5079578074174504652,-5002911229952471566,-4936712335886733807,-4935461683162833449,-4927803153229367078,-4885412510052256417,-4844624202863248012,-4822669227685657126,-4802863941264162295,-4509820979418360845,-4502745833015471901,-4480236244370855623,-4443867647734439536,-4352257758766869547,-4308223770933022948,-4272933133624045159,-4096640309528017148,-4082619352084538444,-4075761004442398468,-3986104853404590096,-3963487973489824679,-3944541382304515940,-3817760291413179016,-3685051635411094512,-3677689801992730974,-3589901911924119848,-3550703575415605325,-3457401179063412063,-3378786895530462815,-3324588070786794092,-3190639132340513573,-3062476262347616111,-2950804235166853420,-2906073147210908073,-2903872818246613019,-2727531121335292440,-2644335961635770936,-2606414032824072794,-2592487419370512092,-2446435333727902184,-2248195493090978911,-2182298065138850098,-2130841856173867989,-2041321949007299296,-2018756862508476139,-1978218550142219176,-1962996175717742851,-1701002874943563222,-1694688057518610705,-1682628358551463218,-1642172336255064762,-1606108109152870077,-1490347097226812945,-1410586080664401268,-1402910690704861588,-1363768367450679470,-1358648670535396378,-1313406486061605231,-1074366320823138565,-1047067836233036121,-1018270956824290686,-1018130937647237827,-961751779316008739,-903685490941273884,-867556117265320185,-824355709649861843,-819807642995193715,-675690332853345434,-362246357222867883,-216571031207266360,-137495002864398511,-82239043105150619,-46138336412760823,-24666295432058289,24800814860719912,36013531059151969,118914045106503255,154755445414177401,161216696600035888,218461572493949184,256273194944845369,284373880476716834,295998661209587790,298896945001145080,333311178785184533,343130472134599886,388169627620546701,393565581141620972,416705197026670643,557643057585151703,670259319240144382,683891795999159033,794300128685770297,821309110887287458,884508795082678286,1048673668352144758,1062203732962056292,1062960441254212155,1142572279550155734,1582204528571885947,1636653109765755829,1647003976049836337,1668177396355013344,1680014206250127155,1737839435551495501,1754323764994756323,1776906742319853423,1842587605588799451,1889696466176453530,2183162657411549025,2268703458841018281,2427356450072456183,2460017054313979077,2476065192055194739,2799039725304164081,2907193934140166253,3037265719433353510,3085334665196097976,3120328490024931664,3132183257318850267,3455359829557938302,3587638764276842535,3637062327555434801,3658577477460214051,3702651962857620130,3842951051553806375,3924325553926655478,4034775301159519653,4092647680980834067,4223117726675548339,4231188041968428331,4427749437053694575,4495366768053742388,4549408722184320367,4745712565392757869,4842398773913943997,4956509773194341820,5082917961369500753,5142502603432105587,5173287033165245124,5414721762341479335,5461941687357578474,5465536538691105362,5481574469362684721,5714291968062043155,5882869819470164984,5907317370506198335,5925881109605730334,5985238387205357440,5993693143734349392,6194554706611974450,6364682052612052017,6611726916267057260,7183678960498810937,7282819128525293684,7415494371567829961,7431266750923359540,7432473706308042254,7543412173104015163,7557794058801145930,7669956585822909698,7792995672207178815,7798473836340594832,7804069554648808069,7831951459277012447,7867720005631818568,7944255944668721327,7954078491481322975,8102176365513078280,8173040891145800458,8259635702977656156,8311708418520219570,8518853531216201465,8646472604701855296,8697324345976778812,8871191879698557754,8979962455524594980,9062892950825787405,9108975535979405537,9116305640078576000,9118889611408814498,9196729454738333850,9212461388070348433,9214814170239285604'


### PR DESCRIPTION
This PR is just to explore the 1-1 restore.

`.1-1-restore-poc/256000_rows_backuptest_data_big_table.tar` is the archived snapshot.
To execute the PoC that restores simple backuptest_data.big_table table:

0. Clean the scylla data folders on containers.
```
make clean_restore
```
2. Extract information about the token ring from the backup manifest
```
make extract_tokens_and_schema
```
3. Set initial_token to the `scylla.yaml` per every node.
```
make set_initial_tokens
```
4. Start the cluster
```
make start-dev-env
```
5. Recreate schema
```
make recreate_schema
```
6. Extract SSTables from archive
```
make extract_sstables
```
7. Copy nodes SSTables to the /var/lib/scylla/data 
```
make copy_sstables
```
8. Refresh the restored table.
```
make refresh_nodes
```
9. Query the amount of rows
```
make query_data
```


256000 rows are restored.
Calling `make query_data` before refreshing the table results with `0 rows available`.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
