### PR TITLE
Rclone: stream files as they are being listed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -127,6 +127,6 @@ require (
 
 replace (
 	github.com/gocql/gocql => github.com/scylladb/gocql v1.12.0
-	github.com/rclone/rclone => github.com/scylladb/rclone v1.54.1-0.20240312172628-afe1fd2aa65e
+	github.com/rclone/rclone => github.com/scylladb/rclone v1.54.1-0.20241203155938-9f3550e7e668
 	google.golang.org/api v0.114.0 => github.com/scylladb/google-api-go-client v0.34.1-patched
 )

--- a/go.sum
+++ b/go.sum
@@ -1051,8 +1051,8 @@ github.com/scylladb/gocqlx/v2 v2.8.0 h1:f/oIgoEPjKDKd+RIoeHqexsIQVIbalVmT+axwvUq
 github.com/scylladb/gocqlx/v2 v2.8.0/go.mod h1:4/+cga34PVqjhgSoo5Nr2fX1MQIqZB5eCE5DK4xeDig=
 github.com/scylladb/google-api-go-client v0.34.1-patched h1:DW+T0HA+74o6FDr3TFzVwgESabOB1eTwb4woE6oUziY=
 github.com/scylladb/google-api-go-client v0.34.1-patched/go.mod h1:RriRmS2wJXH+2yd9PRTEcR380U9AXmurWwznqVhzsSc=
-github.com/scylladb/rclone v1.54.1-0.20240312172628-afe1fd2aa65e h1:lJRphCtu+nKd+mfo8whOTeFkgjMWvk8iCSlqgibKSa8=
-github.com/scylladb/rclone v1.54.1-0.20240312172628-afe1fd2aa65e/go.mod h1:JGZp4EvCUK+6AM1Fe1dye5xvihTc/Bk0WnHHSCJOePM=
+github.com/scylladb/rclone v1.54.1-0.20241203155938-9f3550e7e668 h1:3beIciiaygPjiUPLN0+wVlnfe4JnB1Wb/uV1MChzRbM=
+github.com/scylladb/rclone v1.54.1-0.20241203155938-9f3550e7e668/go.mod h1:JGZp4EvCUK+6AM1Fe1dye5xvihTc/Bk0WnHHSCJOePM=
 github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20241104134613-aba35605c28b h1:JRDV1d1FIiH0TIyHVmTAILAjQ2f8O4t7ZtZ/S+fT2sY=
 github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20241104134613-aba35605c28b/go.mod h1:Tss7a99vrgds+B70w8ZFG3Skxfr9Br3kAzrKP2b3CmQ=
 github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20241104134613-aba35605c28b h1:7CHNmPrQqSdApaEh5nkRL+D52KFHaOHVBBVDvytHEOY=

--- a/pkg/config/agent/testdata/auth_token_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/auth_token_overwrite.golden.yaml
@@ -66,6 +66,7 @@ rclone:
   suffix: ""
   suffix_keep_extension: false
   use_list_r: false
+  use_list_cb: false
   buffer_size: 16777216
   bw_limit: []
   bw_limit_file: []

--- a/pkg/config/agent/testdata/basic.golden.yaml
+++ b/pkg/config/agent/testdata/basic.golden.yaml
@@ -66,6 +66,7 @@ rclone:
   suffix: ""
   suffix_keep_extension: false
   use_list_r: false
+  use_list_cb: false
   buffer_size: 16777216
   bw_limit: []
   bw_limit_file: []

--- a/pkg/config/agent/testdata/debug_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/debug_overwrite.golden.yaml
@@ -66,6 +66,7 @@ rclone:
   suffix: ""
   suffix_keep_extension: false
   use_list_r: false
+  use_list_cb: false
   buffer_size: 16777216
   bw_limit: []
   bw_limit_file: []

--- a/pkg/config/agent/testdata/https_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/https_overwrite.golden.yaml
@@ -66,6 +66,7 @@ rclone:
   suffix: ""
   suffix_keep_extension: false
   use_list_r: false
+  use_list_cb: false
   buffer_size: 16777216
   bw_limit: []
   bw_limit_file: []

--- a/pkg/config/agent/testdata/multiple_cpus.golden.yaml
+++ b/pkg/config/agent/testdata/multiple_cpus.golden.yaml
@@ -69,6 +69,7 @@ rclone:
   suffix: ""
   suffix_keep_extension: false
   use_list_r: false
+  use_list_cb: false
   buffer_size: 16777216
   bw_limit: []
   bw_limit_file: []

--- a/pkg/config/agent/testdata/prometheus_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/prometheus_overwrite.golden.yaml
@@ -66,6 +66,7 @@ rclone:
   suffix: ""
   suffix_keep_extension: false
   use_list_r: false
+  use_list_cb: false
   buffer_size: 16777216
   bw_limit: []
   bw_limit_file: []

--- a/pkg/config/agent/testdata/scylla_overwrite.golden.yaml
+++ b/pkg/config/agent/testdata/scylla_overwrite.golden.yaml
@@ -66,6 +66,7 @@ rclone:
   suffix: ""
   suffix_keep_extension: false
   use_list_r: false
+  use_list_cb: false
   buffer_size: 16777216
   bw_limit: []
   bw_limit_file: []

--- a/pkg/config/agent/testdata/structs_empty.golden.yaml
+++ b/pkg/config/agent/testdata/structs_empty.golden.yaml
@@ -66,6 +66,7 @@ rclone:
   suffix: ""
   suffix_keep_extension: false
   use_list_r: false
+  use_list_cb: false
   buffer_size: 16777216
   bw_limit: []
   bw_limit_file: []

--- a/pkg/rclone/rcserver/rc.go
+++ b/pkg/rclone/rcserver/rc.go
@@ -486,6 +486,11 @@ func rcChunkedList(ctx context.Context, in rc.Params) (out rc.Params, err error)
 		}
 	}
 
+	ctx, ci := fs.AddConfig(ctx)
+	// Allow for calling callback as the dir is listed (#4132)
+	// Note that ListCB is implemented only for a non-recursive listings.
+	ci.UseListCB = true
+
 	w, err := in.GetHTTPResponseWriter()
 	if err != nil {
 		return nil, err

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -68,7 +68,6 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 		remoteSSTableBundles := newSSTableBundlesByID()
 		listOpts := &scyllaclient.RcloneListDirOpts{
 			FilesOnly: true,
-			Recurse:   true,
 		}
 		if err := w.Client.RcloneListDirIter(ctx, h.IP, dataDst, listOpts, func(f *scyllaclient.RcloneListDirItem) {
 			if err := remoteSSTableBundles.add(f.Name, f.Size); err != nil {

--- a/pkg/testutils/s3.go
+++ b/pkg/testutils/s3.go
@@ -45,3 +45,11 @@ func S3Credentials() (provider, endpoint, accessKeyID, secretAccessKey string) {
 	}
 	return *flagS3Provider, *flagS3Endpoint, *flagS3AccessKeyID, *flagS3SecretAccessKey
 }
+
+// S3BucketPath returns the os path to the bucket.
+func S3BucketPath(bucket string) string {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	return filepath.Join(*flagS3DataDir, bucket)
+}

--- a/vendor/github.com/rclone/rclone/fs/config.go
+++ b/vendor/github.com/rclone/rclone/fs/config.go
@@ -82,6 +82,7 @@ type ConfigInfo struct {
 	Suffix                 string        `yaml:"suffix"`
 	SuffixKeepExtension    bool          `yaml:"suffix_keep_extension"`
 	UseListR               bool          `yaml:"use_list_r"`
+	UseListCB              bool          `yaml:"use_list_cb"`
 	BufferSize             SizeSuffix    `yaml:"buffer_size"`
 	BwLimit                BwTimetable   `yaml:"bw_limit"`
 	BwLimitFile            BwTimetable   `yaml:"bw_limit_file"`

--- a/vendor/github.com/rclone/rclone/fs/fs.go
+++ b/vendor/github.com/rclone/rclone/fs/fs.go
@@ -1045,6 +1045,23 @@ type ListRer interface {
 	ListR(ctx context.Context, dir string, callback ListRCallback) error
 }
 
+// ListCBer extends Fs with ListCB.
+type ListCBer interface {
+	Fs
+	// ListCB calls callback on directory entries as they are being listed.
+	//
+	// dir should be "" to start from the root, and should not
+	// have trailing slashes.
+	//
+	// This should return ErrDirNotFound if the directory isn't found.
+	//
+	// It should call callback for each tranche of entries read.
+	// These need not be returned in any particular order. If
+	// callback returns an error then the listing will stop
+	// immediately.
+	ListCB(ctx context.Context, dir string, callback ListRCallback) error
+}
+
 // RangeSeeker is the interface that wraps the RangeSeek method.
 //
 // Some of the returns from Object.Open() may optionally implement
@@ -1187,7 +1204,7 @@ func Find(name string) (*RegInfo, error) {
 
 // MustFind looks for an Info object for the type name passed in
 //
-// Services are looked up in the config file
+// # Services are looked up in the config file
 //
 // Exits with a fatal error if not found
 func MustFind(name string) *RegInfo {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -313,7 +313,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/rclone/rclone v1.51.0 => github.com/scylladb/rclone v1.54.1-0.20240312172628-afe1fd2aa65e
+# github.com/rclone/rclone v1.51.0 => github.com/scylladb/rclone v1.54.1-0.20241203155938-9f3550e7e668
 ## explicit; go 1.21
 github.com/rclone/rclone/backend/azureblob
 github.com/rclone/rclone/backend/crypt
@@ -758,4 +758,4 @@ gopkg.in/yaml.v2
 ## explicit
 gopkg.in/yaml.v3
 # github.com/gocql/gocql => github.com/scylladb/gocql v1.12.0
-# github.com/rclone/rclone => github.com/scylladb/rclone v1.54.1-0.20240312172628-afe1fd2aa65e
+# github.com/rclone/rclone => github.com/scylladb/rclone v1.54.1-0.20241203155938-9f3550e7e668


### PR DESCRIPTION
This PR changes the rclone version used by SM-agent server.
The goal is improve huge dir listing by streaming the files to the SM as the dir is being listed. Rclone lists files in chunks (1000 is the default value for s3), so we can start streaming those files after each chunk has been listed, not only after the whole dir has been listed.
This allows for more reliable timeout handling on SM side, and also decreases memory pressure on agent.

Since this is timeout/performance change, I didn't prepare a dedicated test for it, but I created a benchmark for that (see last [commit](https://github.com/scylladb/scylla-manager/pull/4146/commits/e3fe0c9464f8c151920761b73eb8b23716f444bb) for details). It measures some interesting averages when listing a flat dir with 5555 files 1000 times. Note that this has been tested on my local docker setup without any rate limiting, but I still think that the results show what needs to be seen.

The results without the fix:
```
Avg total time: 157.916848ms           (average time of listing the whole dir)
Avg first latency: 146.564896ms        (average time after the first item has been listed)
Avg max cross chunk latency: 19.196µs  (average time between listing the last item from given chunk and the first from the next chunk)
Avg max within chunk latency: 112.92µs (average time between listing files from the same chunk)
```
The results after the fix:
```
Avg total time: 143.211603ms
Avg first latency: 26.344503ms
Avg max cross chunk latency: 26.144269ms
Avg max within chunk latency: 320.72µs
```

What is important, is that this fix reduces the time needed for listing the first item from `~146ms` to `~26ms`. Let's have in mind that 5555 files is not a huge amount for backed up sstables, and that the local setup has faster connections than the real one. It also slightly reduces the total time needed for listing, but the values are too similar to tell it for sure.

Fixes  #4132 