### PR TITLE
Unify workflows between master and branch

### DIFF
--- a/.github/cfg/integration-test-core.yaml
+++ b/.github/cfg/integration-test-core.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - 'branch-**'
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/integration-tests-2023.1.11-IPV4-raftschema.yaml
+++ b/.github/workflows/integration-tests-2023.1.11-IPV4-raftschema.yaml
@@ -116,3 +116,4 @@ name: integration-tests-2023.1.11-IPV4-raftschema
     push:
         branches:
             - master
+            - branch-**

--- a/.github/workflows/integration-tests-2023.1.11-IPV4.yaml
+++ b/.github/workflows/integration-tests-2023.1.11-IPV4.yaml
@@ -116,3 +116,4 @@ name: integration-tests-2023.1.11-IPV4
     push:
         branches:
             - master
+            - branch-**

--- a/.github/workflows/integration-tests-2023.1.11-IPV6-raftschema.yaml
+++ b/.github/workflows/integration-tests-2023.1.11-IPV6-raftschema.yaml
@@ -116,3 +116,4 @@ name: integration-tests-2023.1.11-IPV6-raftschema
     push:
         branches:
             - master
+            - branch-**

--- a/.github/workflows/integration-tests-2024.1.12-IPV4.yaml
+++ b/.github/workflows/integration-tests-2024.1.12-IPV4.yaml
@@ -116,3 +116,4 @@ name: integration-tests-2024.1.12-IPV4
     push:
         branches:
             - master
+            - branch-**

--- a/.github/workflows/integration-tests-2024.1.12-IPV6.yaml
+++ b/.github/workflows/integration-tests-2024.1.12-IPV6.yaml
@@ -116,3 +116,4 @@ name: integration-tests-2024.1.12-IPV6
     push:
         branches:
             - master
+            - branch-**

--- a/.github/workflows/integration-tests-6.2.0-IPV4-tablets.yaml
+++ b/.github/workflows/integration-tests-6.2.0-IPV4-tablets.yaml
@@ -116,3 +116,4 @@ name: integration-tests-6.2.0-IPV4-tablets
     push:
         branches:
             - master
+            - branch-**

--- a/.github/workflows/integration-tests-6.2.0-IPV4.yaml
+++ b/.github/workflows/integration-tests-6.2.0-IPV4.yaml
@@ -116,3 +116,4 @@ name: integration-tests-6.2.0-IPV4
     push:
         branches:
             - master
+            - branch-**

--- a/.github/workflows/integration-tests-6.2.0-IPV6-tablets-nossl.yaml
+++ b/.github/workflows/integration-tests-6.2.0-IPV6-tablets-nossl.yaml
@@ -116,3 +116,4 @@ name: integration-tests-6.2.0-IPV6-tablets-nossl
     push:
         branches:
             - master
+            - branch-**

--- a/.github/workflows/integration-tests-latest-enterprise-IPV4-tablets-nossl.yaml
+++ b/.github/workflows/integration-tests-latest-enterprise-IPV4-tablets-nossl.yaml
@@ -116,3 +116,4 @@ name: integration-tests-latest-enterprise-IPV4-tablets-nossl
     push:
         branches:
             - master
+            - branch-**

--- a/.github/workflows/integration-tests-latest-enterprise-IPV4.yaml
+++ b/.github/workflows/integration-tests-latest-enterprise-IPV4.yaml
@@ -116,3 +116,4 @@ name: integration-tests-latest-enterprise-IPV4
     push:
         branches:
             - master
+            - branch-**

--- a/.github/workflows/sanity-checks.yml
+++ b/.github/workflows/sanity-checks.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 'branch-**'
   pull_request:
     types: [ opened, synchronize, reopened ]
 


### PR DESCRIPTION
`master` and `branch-**` have different gh actions specification due to ac49dff8.
We should avoid that because:
- it's problematic to keep track of it
- it causes conflicts on patch releases
