### PR TITLE
feat: adds cloudmeta package with AWS provider

### DIFF
--- a/pkg/cloudmeta/aws.go
+++ b/pkg/cloudmeta/aws.go
@@ -5,46 +5,29 @@ package cloudmeta
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/pkg/errors"
 )
 
-// AWSMetadata is a wrapper around ec2 metadata client.
-type AWSMetadata struct {
+// awsMetadata is a wrapper around ec2 metadata client.
+type awsMetadata struct {
 	ec2meta *ec2metadata.EC2Metadata
 }
 
-// NewAWSMetadata is a constructor for  AWSMetadata service.
-func NewAWSMetadata() (*AWSMetadata, error) {
+// newAWSMetadata is a constructor for  AWSMetadata service.
+func newAWSMetadata() (*awsMetadata, error) {
 	session, err := session.NewSession()
 	if err != nil {
 		return nil, errors.Wrap(err, "session.NewSession")
 	}
-	return &AWSMetadata{
+	return &awsMetadata{
 		ec2meta: ec2metadata.New(session),
 	}, nil
 }
 
-// NewAWSMetadataWithEndpoint is a constructor for  AWSMetadata service that allows your to overwrite default metadata endpoint.
-// Might be useful for tests.
-func NewAWSMetadataWithEndpoint(endpoint string) (*AWSMetadata, error) {
-	session, err := session.NewSession()
-	if err != nil {
-		return nil, errors.Wrap(err, "session.NewSession")
-	}
-	cfg := aws.NewConfig()
-	if endpoint != "" {
-		cfg = cfg.WithEndpoint(endpoint)
-	}
-	return &AWSMetadata{
-		ec2meta: ec2metadata.New(session, cfg),
-	}, nil
-}
-
 // Metadata return InstanceMetadata from aws if available.
-func (aws *AWSMetadata) Metadata(ctx context.Context) (InstanceMetadata, error) {
+func (aws *awsMetadata) Metadata(ctx context.Context) (InstanceMetadata, error) {
 	if !aws.ec2meta.AvailableWithContext(ctx) {
 		return InstanceMetadata{}, errors.New("metadata is not available")
 	}

--- a/pkg/cloudmeta/aws.go
+++ b/pkg/cloudmeta/aws.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2024 ScyllaDB
+
+package cloudmeta
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/pkg/errors"
+)
+
+// AWSMetadata is a wrapper around ec2 metadata client.
+type AWSMetadata struct {
+	ec2meta *ec2metadata.EC2Metadata
+}
+
+// NewAWSMetadata is a constructor for  AWSMetadata service.
+// testEndpoint can be provided if you want to overwrite the default metadata endpoint, otherwise leave it empty.
+func NewAWSMetadata(testEndpoint string) (*AWSMetadata, error) {
+	session, err := session.NewSession()
+	if err != nil {
+		return nil, errors.Wrap(err, "session.NewSession")
+	}
+	cfg := aws.NewConfig()
+	if testEndpoint != "" {
+		cfg = cfg.WithEndpoint(testEndpoint)
+	}
+	return &AWSMetadata{
+		ec2meta: ec2metadata.New(session, cfg),
+	}, nil
+}
+
+// Metadata return InstanceMetadata from aws if available.
+func (aws *AWSMetadata) Metadata(ctx context.Context) (InstanceMetadata, error) {
+	if !aws.ec2meta.AvailableWithContext(ctx) {
+		return InstanceMetadata{}, errors.New("metadata is not available")
+	}
+
+	instanceData, err := aws.ec2meta.GetInstanceIdentityDocumentWithContext(ctx)
+	if err != nil {
+		return InstanceMetadata{}, errors.Wrap(err, "aws.metadataClient.GetInstanceIdentityDocument")
+	}
+
+	return InstanceMetadata{
+		CloudProvider: CloudProviderAWS,
+		InstanceType:  instanceData.InstanceType,
+	}, nil
+}

--- a/pkg/cloudmeta/aws.go
+++ b/pkg/cloudmeta/aws.go
@@ -17,15 +17,26 @@ type AWSMetadata struct {
 }
 
 // NewAWSMetadata is a constructor for  AWSMetadata service.
-// testEndpoint can be provided if you want to overwrite the default metadata endpoint, otherwise leave it empty.
-func NewAWSMetadata(testEndpoint string) (*AWSMetadata, error) {
+func NewAWSMetadata() (*AWSMetadata, error) {
+	session, err := session.NewSession()
+	if err != nil {
+		return nil, errors.Wrap(err, "session.NewSession")
+	}
+	return &AWSMetadata{
+		ec2meta: ec2metadata.New(session),
+	}, nil
+}
+
+// NewAWSMetadataWithEndpoint is a constructor for  AWSMetadata service that allows your to overwrite default metadata endpoint.
+// Might be useful for tests.
+func NewAWSMetadataWithEndpoint(endpoint string) (*AWSMetadata, error) {
 	session, err := session.NewSession()
 	if err != nil {
 		return nil, errors.Wrap(err, "session.NewSession")
 	}
 	cfg := aws.NewConfig()
-	if testEndpoint != "" {
-		cfg = cfg.WithEndpoint(testEndpoint)
+	if endpoint != "" {
+		cfg = cfg.WithEndpoint(endpoint)
 	}
 	return &AWSMetadata{
 		ec2meta: ec2metadata.New(session, cfg),

--- a/pkg/cloudmeta/metadata.go
+++ b/pkg/cloudmeta/metadata.go
@@ -36,7 +36,7 @@ type CloudMeta struct {
 func NewCloudMeta() (*CloudMeta, error) {
 	const defaultTimeout = 5 * time.Second
 
-	awsMeta, err := NewAWSMetadata("")
+	awsMeta, err := NewAWSMetadata()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudmeta/metadata.go
+++ b/pkg/cloudmeta/metadata.go
@@ -78,7 +78,6 @@ func (cloud *CloudMeta) GetInstanceMetadata(ctx context.Context) (InstanceMetada
 				return
 			case results <- msg{meta: meta, err: err}:
 			}
-
 		}(provider)
 	}
 

--- a/pkg/cloudmeta/metadata.go
+++ b/pkg/cloudmeta/metadata.go
@@ -49,8 +49,14 @@ func NewCloudMeta() (*CloudMeta, error) {
 	}, nil
 }
 
+// ErrNoProviders will be returned by CloudMeta service, when it hasn't been initialized with any metadata provider.
+var ErrNoProviders = errors.New("no metadata providers found")
+
 // GetInstanceMetadata tries to fetch instance metadata from AWS, GCP, Azure providers in order.
 func (cloud *CloudMeta) GetInstanceMetadata(ctx context.Context) (InstanceMetadata, error) {
+	if len(cloud.providers) == 0 {
+		return InstanceMetadata{}, ErrNoProviders
+	}
 	var mErr error
 	for _, provider := range cloud.providers {
 		meta, err := cloud.runWithTimeout(ctx, provider)

--- a/pkg/cloudmeta/metadata.go
+++ b/pkg/cloudmeta/metadata.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2024 ScyllaDB
+
+package cloudmeta
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// InstanceMetadata represents metadata returned by cloud provider.
+type InstanceMetadata struct {
+	InstanceType  string
+	CloudProvider CloudProvider
+}
+
+// CloudProvider is enum of supported cloud providers.
+type CloudProvider string
+
+// CloudProviderAWS represents aws provider.
+var CloudProviderAWS CloudProvider = "aws"
+
+// CloudMetadataProvider interface that each metadata provider should implement.
+type CloudMetadataProvider interface {
+	Metadata(ctx context.Context) (InstanceMetadata, error)
+}
+
+// CloudMeta is a wrapper around various cloud metadata providers.
+type CloudMeta struct {
+	providers []CloudMetadataProvider
+
+	providerTimeout time.Duration
+}
+
+// NewCloudMeta creates new CloudMeta provider.
+func NewCloudMeta() (*CloudMeta, error) {
+	// providers will initialized here and added to CloudMeta.providers.
+
+	const defaultTimeout = 5 * time.Second
+
+	return &CloudMeta{
+		providers:       []CloudMetadataProvider{},
+		providerTimeout: defaultTimeout,
+	}, nil
+}
+
+// GetInstanceMetadata tries to fetch instance metadata from AWS, GCP, Azure providers in order.
+func (cloud *CloudMeta) GetInstanceMetadata(ctx context.Context) (InstanceMetadata, error) {
+	var mErr error
+	for _, provider := range cloud.providers {
+		meta, err := cloud.runWithTimeout(ctx, provider)
+		if err != nil {
+			mErr = errors.Join(mErr, err)
+			continue
+		}
+		return meta, nil
+	}
+
+	return InstanceMetadata{}, mErr
+}
+
+func (cloud *CloudMeta) runWithTimeout(ctx context.Context, provider CloudMetadataProvider) (InstanceMetadata, error) {
+	ctx, cancel := context.WithTimeout(ctx, cloud.providerTimeout)
+	defer cancel()
+
+	return provider.Metadata(ctx)
+}
+
+// WithProviderTimeout sets per provider timeout.
+func (cloud *CloudMeta) WithProviderTimeout(providerTimeout time.Duration) {
+	cloud.providerTimeout = providerTimeout
+}

--- a/pkg/cloudmeta/metadata.go
+++ b/pkg/cloudmeta/metadata.go
@@ -34,12 +34,17 @@ type CloudMeta struct {
 
 // NewCloudMeta creates new CloudMeta provider.
 func NewCloudMeta() (*CloudMeta, error) {
-	// providers will initialized here and added to CloudMeta.providers.
-
 	const defaultTimeout = 5 * time.Second
 
+	awsMeta, err := NewAWSMetadata("")
+	if err != nil {
+		return nil, err
+	}
+
 	return &CloudMeta{
-		providers:       []CloudMetadataProvider{},
+		providers: []CloudMetadataProvider{
+			awsMeta,
+		},
 		providerTimeout: defaultTimeout,
 	}, nil
 }

--- a/pkg/cloudmeta/metadata.go
+++ b/pkg/cloudmeta/metadata.go
@@ -76,10 +76,9 @@ func (cloud *CloudMeta) GetInstanceMetadata(ctx context.Context) (InstanceMetada
 			select {
 			case <-ctx.Done():
 				return
-			default:
+			case results <- msg{meta: meta, err: err}:
 			}
 
-			results <- msg{meta: meta, err: err}
 		}(provider)
 	}
 

--- a/pkg/cloudmeta/metadata_test.go
+++ b/pkg/cloudmeta/metadata_test.go
@@ -17,6 +17,7 @@ func TestGetInstanceMetadata(t *testing.T) {
 		if !errors.Is(err, ErrNoProviders) {
 			t.Fatalf("expected err, got: %v", err)
 		}
+
 		if meta.InstanceType != "" {
 			t.Fatalf("meta.InstanceType should be empty, got %v", meta.InstanceType)
 		}

--- a/pkg/cloudmeta/metadata_test.go
+++ b/pkg/cloudmeta/metadata_test.go
@@ -4,6 +4,7 @@ package cloudmeta
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -13,8 +14,8 @@ func TestGetInstanceMetadata(t *testing.T) {
 		cloudmeta := &CloudMeta{}
 
 		meta, err := cloudmeta.GetInstanceMetadata(context.Background())
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
+		if !errors.Is(err, ErrNoProviders) {
+			t.Fatalf("expected err, got: %v", err)
 		}
 		if meta.InstanceType != "" {
 			t.Fatalf("meta.InstanceType should be empty, got %v", meta.InstanceType)

--- a/pkg/cloudmeta/metadata_test.go
+++ b/pkg/cloudmeta/metadata_test.go
@@ -1,0 +1,140 @@
+// Copyright (C) 2017 ScyllaDB
+
+package cloudmeta
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestGetInstanceMetadata(t *testing.T) {
+	t.Run("when there is no active providers", func(t *testing.T) {
+		cloudmeta := &CloudMeta{}
+
+		meta, err := cloudmeta.GetInstanceMetadata(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if meta.InstanceType != "" {
+			t.Fatalf("meta.InstanceType should be empty, got %v", meta.InstanceType)
+		}
+
+		if meta.CloudProvider != "" {
+			t.Fatalf("meta.CloudProvider should be empty, got %v", meta.CloudProvider)
+		}
+	})
+
+	t.Run("when there is only one active provider", func(t *testing.T) {
+		cloudmeta := &CloudMeta{
+			providers: []CloudMetadataProvider{newTestProvider(t, "test_provider_1", "x-test-1", nil)},
+		}
+
+		meta, err := cloudmeta.GetInstanceMetadata(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+
+		if meta.InstanceType != "x-test-1" {
+			t.Fatalf("meta.InstanceType should be 'x-test-1', got %v", meta.InstanceType)
+		}
+
+		if meta.CloudProvider != "test_provider_1" {
+			t.Fatalf("meta.CloudProvider should be 'test_provider_1', got %v", meta.CloudProvider)
+		}
+	})
+
+	t.Run("when there is more than one active provider", func(t *testing.T) {
+		cloudmeta := &CloudMeta{
+			providers: []CloudMetadataProvider{
+				newTestProvider(t, "test_provider_1", "x-test-1", nil),
+				newTestProvider(t, "test_provider_2", "x-test-2", nil),
+			},
+		}
+
+		// Only first one should be returned.
+		meta, err := cloudmeta.GetInstanceMetadata(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+
+		if meta.InstanceType != "x-test-1" {
+			t.Fatalf("meta.InstanceType should be 'x-test-1', got %v", meta.InstanceType)
+		}
+
+		if meta.CloudProvider != "test_provider_1" {
+			t.Fatalf("meta.CloudProvider should be 'test_provider_1', got %v", meta.CloudProvider)
+		}
+	})
+	t.Run("when there is more than one active provider, but first returns err", func(t *testing.T) {
+		cloudmeta := &CloudMeta{
+			providers: []CloudMetadataProvider{
+				newTestProvider(t, "test_provider_1", "x-test-1", fmt.Errorf("'test_provider_1' err")),
+				newTestProvider(t, "test_provider_2", "x-test-2", nil),
+			},
+		}
+
+		// Only first succesfull one should be returned.
+		meta, err := cloudmeta.GetInstanceMetadata(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+
+		if meta.InstanceType != "x-test-2" {
+			t.Fatalf("meta.InstanceType should be 'x-test-2', got %v", meta.InstanceType)
+		}
+
+		if meta.CloudProvider != "test_provider_2" {
+			t.Fatalf("meta.CloudProvider should be 'test_provider_2', got %v", meta.CloudProvider)
+		}
+	})
+
+	t.Run("when there is more than one active provider, but all returns err", func(t *testing.T) {
+		cloudmeta := &CloudMeta{
+			providers: []CloudMetadataProvider{
+				newTestProvider(t, "test_provider_1", "x-test-1", fmt.Errorf("'test_provider_1' err")),
+				newTestProvider(t, "test_provider_2", "x-test-2", fmt.Errorf("'test_provider_2' err")),
+			},
+		}
+
+		// Only first succesfull one should be returned.
+		meta, err := cloudmeta.GetInstanceMetadata(context.Background())
+		if err == nil {
+			t.Fatalf("expected err, but got: %v", err)
+		}
+
+		if meta.InstanceType != "" {
+			t.Fatalf("meta.InstanceType should be empty, got %v", meta.InstanceType)
+		}
+
+		if meta.CloudProvider != "" {
+			t.Fatalf("meta.CloudProvider should be empty, got %v", meta.CloudProvider)
+		}
+	})
+}
+
+func newTestProvider(t *testing.T, providerName, instanceType string, err error) *testProvider {
+	t.Helper()
+
+	return &testProvider{
+		name:         CloudProvider(providerName),
+		instanceType: instanceType,
+		err:          err,
+	}
+}
+
+type testProvider struct {
+	name         CloudProvider
+	instanceType string
+	err          error
+}
+
+func (tp testProvider) Metadata(ctx context.Context) (InstanceMetadata, error) {
+	if tp.err != nil {
+		return InstanceMetadata{}, tp.err
+	}
+	return InstanceMetadata{
+		CloudProvider: tp.name,
+		InstanceType:  tp.instanceType,
+	}, nil
+}

--- a/pkg/cloudmeta/metadata_test.go
+++ b/pkg/cloudmeta/metadata_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2024 ScyllaDB
 
 package cloudmeta
 


### PR DESCRIPTION
This adds basic interface and models to work with different cloud metadata providers and also adds implementation for aws metadata provider. 
This package will be used in order to extend backup manifest with additional information. 

This changes has been manually tested with the help of https://github.com/aws/amazon-ec2-metadata-mock container. 

Fixes: #4127 

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
