### PR TITLE
feat: adds gcp metadata provider support to cloudmeta package

### DIFF
--- a/pkg/cloudmeta/gcp.go
+++ b/pkg/cloudmeta/gcp.go
@@ -58,7 +58,7 @@ func parseMachineTypeResponse(resp string) (string, error) {
 		return "", errUnexpectedFormat
 	}
 
-	if parts[2] != "machineType" {
+	if parts[2] != "machineTypes" {
 		return "", errUnexpectedFormat
 	}
 

--- a/pkg/cloudmeta/gcp.go
+++ b/pkg/cloudmeta/gcp.go
@@ -10,20 +10,20 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GCPMetadata is a wrapper around gcp metadata client.
-type GCPMetadata struct {
+// gcpMetadata is a wrapper around gcp metadata client.
+type gcpMetadata struct {
 	meta *metadata.Client
 }
 
-// NewGCPMetadata returns gcp metadata provider.
-func NewGCPMetadata() *GCPMetadata {
-	return &GCPMetadata{
+// newGCPMetadata returns gcp metadata provider.
+func newGCPMetadata() *gcpMetadata {
+	return &gcpMetadata{
 		meta: metadata.NewClient(nil),
 	}
 }
 
 // Metadata returns InstanceMetadata from gcp if available.
-func (gcp *GCPMetadata) Metadata(ctx context.Context) (InstanceMetadata, error) {
+func (gcp *gcpMetadata) Metadata(ctx context.Context) (InstanceMetadata, error) {
 	machineType, err := gcp.getMachineType(ctx)
 	if err != nil {
 		return InstanceMetadata{}, errors.Wrap(err, "gcp.meta.GetWithContext")
@@ -34,7 +34,7 @@ func (gcp *GCPMetadata) Metadata(ctx context.Context) (InstanceMetadata, error) 
 	}, nil
 }
 
-func (gcp *GCPMetadata) getMachineType(ctx context.Context) (string, error) {
+func (gcp *gcpMetadata) getMachineType(ctx context.Context) (string, error) {
 	// The machine type for this VM. This value has the following format: projects/PROJECT_NUM/machineTypes/MACHINE_TYPE.
 	machineType, err := gcp.meta.GetWithContext(ctx, "instance/machine-type")
 	if err != nil {

--- a/pkg/cloudmeta/gcp.go
+++ b/pkg/cloudmeta/gcp.go
@@ -53,7 +53,7 @@ func (gcp *gcpMetadata) getMachineType(ctx context.Context) (string, error) {
 func parseMachineTypeResponse(resp string) (string, error) {
 	errUnexpectedFormat := errors.Errorf("unexpected machineType response format: %s", resp)
 
-	parts := strings.SplitN(resp, "/", 4)
+	parts := strings.Split(resp, "/")
 	if len(parts) != 4 {
 		return "", errUnexpectedFormat
 	}

--- a/pkg/cloudmeta/gcp.go
+++ b/pkg/cloudmeta/gcp.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2024 ScyllaDB
+
+package cloudmeta
+
+import (
+	"context"
+	"strings"
+
+	"cloud.google.com/go/compute/metadata"
+	"github.com/pkg/errors"
+)
+
+// GCPMetadata is a wrapper around gcp metadata client.
+type GCPMetadata struct {
+	meta *metadata.Client
+}
+
+// NewGCPMetadata returns gcp metadata provider.
+func NewGCPMetadata() *GCPMetadata {
+	return &GCPMetadata{
+		meta: metadata.NewClient(nil),
+	}
+}
+
+// Metadata returns InstanceMetadata from gcp if available.
+func (gcp *GCPMetadata) Metadata(ctx context.Context) (InstanceMetadata, error) {
+	machineType, err := gcp.getMachineType(ctx)
+	if err != nil {
+		return InstanceMetadata{}, errors.Wrap(err, "gcp.meta.GetWithContext")
+	}
+	return InstanceMetadata{
+		CloudProvider: CloudProviderGCP,
+		InstanceType:  machineType,
+	}, nil
+}
+
+func (gcp *GCPMetadata) getMachineType(ctx context.Context) (string, error) {
+	// The machine type for this VM. This value has the following format: projects/PROJECT_NUM/machineTypes/MACHINE_TYPE.
+	machineType, err := gcp.meta.GetWithContext(ctx, "instance/machine-type")
+	if err != nil {
+		return "", errors.Wrap(err, "gcp.meta.GetWithContext")
+	}
+
+	parts := strings.Split(machineType, "/")
+	if len(parts) < 2 {
+		return "", errors.Errorf("unexpected machine-type format: %s", machineType)
+	}
+
+	return parts[len(parts)-1], nil
+}

--- a/pkg/cloudmeta/gcp_test.go
+++ b/pkg/cloudmeta/gcp_test.go
@@ -27,6 +27,13 @@ func TestParseMachineTypeResponse(t *testing.T) {
 			expected:    "",
 		},
 		{
+			name:                "new response part is added after machineTypes part",
+			machineTypeResponse: "projects/project1/machineTypes/machineType1/zones/zone1",
+
+			expectedErr: true,
+			expected:    "",
+		},
+		{
 			name:                "parts are mixed up",
 			machineTypeResponse: "machineTypes/machineType1/projects/project1",
 

--- a/pkg/cloudmeta/gcp_test.go
+++ b/pkg/cloudmeta/gcp_test.go
@@ -14,21 +14,21 @@ func TestParseMachineTypeResponse(t *testing.T) {
 	}{
 		{
 			name:                "everything is fine",
-			machineTypeResponse: "projects/project1/machineType/machineType1",
+			machineTypeResponse: "projects/project1/machineTypes/machineType1",
 
 			expectedErr: false,
 			expected:    "machineType1",
 		},
 		{
 			name:                "new response part is added",
-			machineTypeResponse: "projects/project1/zone/zone1/machineType/machineType1",
+			machineTypeResponse: "projects/project1/zone/zone1/machineTypes/machineType1",
 
 			expectedErr: true,
 			expected:    "",
 		},
 		{
 			name:                "parts are mixed up",
-			machineTypeResponse: "machineType/machineType1/projects/project1",
+			machineTypeResponse: "machineTypes/machineType1/projects/project1",
 
 			expectedErr: true,
 			expected:    "",

--- a/pkg/cloudmeta/gcp_test.go
+++ b/pkg/cloudmeta/gcp_test.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2024 ScyllaDB
+
+package cloudmeta
+
+import "testing"
+
+func TestParseMachineTypeResponse(t *testing.T) {
+	testCases := []struct {
+		name                string
+		machineTypeResponse string
+
+		expectedErr bool
+		expected    string
+	}{
+		{
+			name:                "everything is fine",
+			machineTypeResponse: "projects/project1/machineType/machineType1",
+
+			expectedErr: false,
+			expected:    "machineType1",
+		},
+		{
+			name:                "new response part is added",
+			machineTypeResponse: "projects/project1/zone/zone1/machineType/machineType1",
+
+			expectedErr: true,
+			expected:    "",
+		},
+		{
+			name:                "parts are mixed up",
+			machineTypeResponse: "machineType/machineType1/projects/project1",
+
+			expectedErr: true,
+			expected:    "",
+		},
+		{
+			name:                "empty response",
+			machineTypeResponse: "",
+
+			expectedErr: true,
+			expected:    "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			machineType, err := parseMachineTypeResponse(tc.machineTypeResponse)
+			if tc.expectedErr && err == nil {
+				t.Fatalf("expected err, but got %v", err)
+			}
+			if !tc.expectedErr && err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+
+			if tc.expected != machineType {
+				t.Fatalf("machineType(%s) != expected(%s)", machineType, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/cloudmeta/metadata.go
+++ b/pkg/cloudmeta/metadata.go
@@ -47,7 +47,7 @@ func NewCloudMeta() (*CloudMeta, error) {
 		return nil, err
 	}
 
-	gcpMeta := NewGCPMetadata()
+	gcpMeta := newGCPMetadata()
 
 	return &CloudMeta{
 		providers: []CloudMetadataProvider{

--- a/pkg/cloudmeta/metadata.go
+++ b/pkg/cloudmeta/metadata.go
@@ -19,7 +19,7 @@ type InstanceMetadata struct {
 // CloudProvider is enum of supported cloud providers.
 type CloudProvider string
 
-var (
+const (
 	// CloudProviderAWS represents aws provider.
 	CloudProviderAWS CloudProvider = "aws"
 	// CloudProviderGCP represents gcp provider.

--- a/pkg/cloudmeta/metadata.go
+++ b/pkg/cloudmeta/metadata.go
@@ -19,8 +19,12 @@ type InstanceMetadata struct {
 // CloudProvider is enum of supported cloud providers.
 type CloudProvider string
 
-// CloudProviderAWS represents aws provider.
-var CloudProviderAWS CloudProvider = "aws"
+var (
+	// CloudProviderAWS represents aws provider.
+	CloudProviderAWS CloudProvider = "aws"
+	// CloudProviderGCP represents gcp provider.
+	CloudProviderGCP CloudProvider = "gcp"
+)
 
 // CloudMetadataProvider interface that each metadata provider should implement.
 type CloudMetadataProvider interface {
@@ -43,9 +47,12 @@ func NewCloudMeta() (*CloudMeta, error) {
 		return nil, err
 	}
 
+	gcpMeta := NewGCPMetadata()
+
 	return &CloudMeta{
 		providers: []CloudMetadataProvider{
 			awsMeta,
+			gcpMeta,
 		},
 		providerTimeout: defaultTimeout,
 	}, nil


### PR DESCRIPTION
This adds gcp metadata provider support to cloudmeta package.

This changes has been manually tested on gcp node in lab env.

Fixes: #4128

P.S. retries are handled by gcp sdk, here is the note from documentation of `GetWithContext(...)`method.

```
Without an extra deadline in the context this call can take in the worst case, with internal backoff retries, up to 15 seconds (e.g. when server is responding slowly). Pass context with additional timeouts when needed.
```

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
