### PR TITLE
feat(swagger): extends sm agent `/node_info' with `data_directory`.

### DIFF
--- a/v3/swagger/agent.json
+++ b/v3/swagger/agent.json
@@ -1683,6 +1683,10 @@
         "enable_tablets": {
           "description": "Whether tablets are enabled.",
           "type": "boolean"
+        },
+        "data_directory": {
+          "description": "First entry from `data_file_directories` list from scylla config file.",
+          "type": "string"
         }
       }
     }

--- a/v3/swagger/gen/agent/models/node_info.go
+++ b/v3/swagger/gen/agent/models/node_info.go
@@ -59,6 +59,9 @@ type NodeInfo struct {
 	// Whether CQL requires password authentication.
 	CqlPasswordProtected bool `json:"cql_password_protected,omitempty"`
 
+	// First entry from `data_file_directories` list from scylla config file.
+	DataDirectory string `json:"data_directory,omitempty"`
+
 	// Whether tablets are enabled.
 	EnableTablets bool `json:"enable_tablets,omitempty"`
 


### PR DESCRIPTION
This extends `/node_info` response of scylla manager agent with `data_directory` field which should contain first entry from the `data_file_directories` list of scylladb configuration.

Refs: #4130

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
