### PR TITLE
feat(swagger): extends sm agent `/node_info` with `storage_size`.

### DIFF
--- a/v3/swagger/agent.json
+++ b/v3/swagger/agent.json
@@ -1687,6 +1687,10 @@
         "data_directory": {
           "description": "First entry from `data_file_directories` list from scylla config file.",
           "type": "string"
+        },
+        "storage_size": {
+          "description": "Disk size of the first entry from `data_file_directories` list from scylla config file. In bytes.",
+          "type": "integer"
         }
       }
     }

--- a/v3/swagger/agent.json
+++ b/v3/swagger/agent.json
@@ -1689,8 +1689,9 @@
           "type": "string"
         },
         "storage_size": {
-          "description": "Disk size of the first entry from `data_file_directories` list from scylla config file. In bytes.",
-          "type": "integer"
+          "description": "Total disk size of the first entry from `data_file_directories` list from scylla config file. In bytes.",
+          "type": "integer",
+          "format": "uint64"
         }
       }
     }

--- a/v3/swagger/gen/agent/models/node_info.go
+++ b/v3/swagger/gen/agent/models/node_info.go
@@ -95,6 +95,9 @@ type NodeInfo struct {
 	// Whether Scylla supports uuid-like sstable naming.
 	SstableUUIDFormat bool `json:"sstable_uuid_format,omitempty"`
 
+	// Disk size of the first entry from `data_file_directories` list from scylla config file. In bytes.
+	StorageSize int64 `json:"storage_size,omitempty"`
+
 	// Uptime in seconds.
 	Uptime int64 `json:"uptime,omitempty"`
 }

--- a/v3/swagger/gen/agent/models/node_info.go
+++ b/v3/swagger/gen/agent/models/node_info.go
@@ -95,8 +95,8 @@ type NodeInfo struct {
 	// Whether Scylla supports uuid-like sstable naming.
 	SstableUUIDFormat bool `json:"sstable_uuid_format,omitempty"`
 
-	// Disk size of the first entry from `data_file_directories` list from scylla config file. In bytes.
-	StorageSize int64 `json:"storage_size,omitempty"`
+	// Total disk size of the first entry from `data_file_directories` list from scylla config file. In bytes.
+	StorageSize uint64 `json:"storage_size,omitempty"`
 
 	// Uptime in seconds.
 	Uptime int64 `json:"uptime,omitempty"`


### PR DESCRIPTION
This extends `/node_info` agent response with `storage_size` - total disk size in bytes. It's needed for the backup manifest and should be calculated on the agent side.

Refs: #4130 

p.s. I've realized that exposing `DataDirectory` is not enough, because `storage_size` can be calculated only on agent side, but backup manifest is created on the SM side.


---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
