### PR TITLE
Don't query raft read barrier API on Scylla 2024.2

### DIFF
--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -239,7 +239,7 @@ func (ni *NodeInfo) SupportsSafeDescribeSchemaWithInternals() (SafeDescribeMetho
 
 	for _, fv := range []featureByVersion{
 		{Constraint: ">= 6.1, < 2000", Method: SafeDescribeMethodReadBarrierAPI},
-		{Constraint: ">= 2024.2, > 1000", Method: SafeDescribeMethodReadBarrierAPI},
+		{Constraint: ">= 2024.2, > 1000", Method: SafeDescribeMethodReadBarrierCQL},
 		{Constraint: ">= 6.0, < 2000", Method: SafeDescribeMethodReadBarrierCQL},
 	} {
 		supports, err := scyllaversion.CheckConstraint(ni.ScyllaVersion, fv.Constraint)

--- a/pkg/scyllaclient/client_agent_test.go
+++ b/pkg/scyllaclient/client_agent_test.go
@@ -372,9 +372,9 @@ func TestSupportsSafeDescribeSchemaWithInternals(t *testing.T) {
 			expectedError:  nil,
 		},
 		{
-			name:           "when scylla >= 2024.2, then it is expected to support read barrier api",
+			name:           "when scylla >= 2024.2, then it is expected to support read barrier cql",
 			scyllaVersion:  "2024.2",
-			expectedMethod: scyllaclient.SafeDescribeMethodReadBarrierAPI,
+			expectedMethod: scyllaclient.SafeDescribeMethodReadBarrierCQL,
 			expectedError:  nil,
 		},
 		{


### PR DESCRIPTION
It turns out that Scylla 2024.2 does not expose this API. For now, it's not know which enterprise release will contain it.
Luckily for us, this was present only on SM master, so no need for backporting it to any release.

Fixes #4183
