### PR TITLE
Reduce info to debug on closest DC

### DIFF
--- a/pkg/scyllaclient/client_ping.go
+++ b/pkg/scyllaclient/client_ping.go
@@ -119,7 +119,7 @@ func (c *Client) CheckHostsConnectivity(ctx context.Context, hosts []string) []e
 // the lowest latency over 3 Ping() invocations across random selection of
 // hosts for each DC.
 func (c *Client) ClosestDC(ctx context.Context, dcs map[string][]string) ([]string, error) {
-	c.logger.Info(ctx, "Measuring datacenter latencies", "dcs", extractKeys(dcs))
+	c.logger.Debug(ctx, "Measuring datacenter latencies", "dcs", extractKeys(dcs))
 
 	if len(dcs) == 0 {
 		return nil, errors.Errorf("no dcs to choose from")


### PR DESCRIPTION
That's how the majority of the SM logs look like:

<details>
<Summary> example </Summary>

```
Jan 04 13:51:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T13:51:10.004+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"kCNEUDYBTsChj6NUUh3fYQ"}
Jan 04 13:51:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T13:51:10.017+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"kCNEUDYBTsChj6NUUh3fYQ"}
Jan 04 13:51:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T13:51:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 13:51:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T13:51:10.884+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 13:56:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T13:56:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 13:56:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T13:56:10.886+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:01:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:01:10.865+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:01:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:01:10.884+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:06:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:06:10.865+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:06:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:06:10.898+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:07:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:07:10.005+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"sednUK62R-uAYy5lLoitCw"}
Jan 04 14:07:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:07:10.016+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"sednUK62R-uAYy5lLoitCw"}
Jan 04 14:11:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:11:10.865+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:11:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:11:10.892+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:16:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:16:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:16:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:16:10.890+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:21:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:21:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:21:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:21:10.880+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:23:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:23:10.004+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"egRE--1ITxGwa1G_GRutAQ"}
Jan 04 14:23:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:23:10.047+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"egRE--1ITxGwa1G_GRutAQ"}
Jan 04 14:26:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:26:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:26:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:26:10.886+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:31:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:31:10.865+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:31:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:31:10.887+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:36:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:36:10.865+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:36:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:36:10.892+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:39:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:39:10.004+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"w0iYz4ccS_GntbfihbTVGg"}
Jan 04 14:39:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:39:10.016+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"w0iYz4ccS_GntbfihbTVGg"}
Jan 04 14:41:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:41:10.865+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:41:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:41:10.885+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:46:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:46:10.867+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:46:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:46:10.944+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:51:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:51:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:51:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:51:10.882+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:55:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:55:10.004+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"OROmMRWBSUKtIV3uM6H6XA"}
Jan 04 14:55:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:55:10.018+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"OROmMRWBSUKtIV3uM6H6XA"}
Jan 04 14:56:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:56:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 14:56:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T14:56:10.883+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:01:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:01:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:01:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:01:10.888+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:06:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:06:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:06:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:06:10.887+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:11:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:11:10.005+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"5_rNbEi5QhaQzcYo_MnCZg"}
Jan 04 15:11:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:11:10.017+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"5_rNbEi5QhaQzcYo_MnCZg"}
Jan 04 15:11:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:11:10.865+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:11:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:11:10.881+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:16:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:16:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:16:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:16:10.888+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:21:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:21:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:21:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:21:10.885+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:26:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:26:10.865+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:26:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:26:10.894+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:27:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:27:10.002+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"ekg5jOCMT9ecWrEcIZY4Aw"}
Jan 04 15:27:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:27:10.016+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"ekg5jOCMT9ecWrEcIZY4Aw"}
Jan 04 15:31:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:31:10.865+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:31:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:31:10.882+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:36:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:36:10.866+0600","N":"cluster","M":"Creating new Scylla HTTP client","cluster_id":"0ced091a-cc6a-4d2d-8f4f-14e19ae4a10c","_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
Jan 04 15:36:10 scylla-admin-01-p scylla-manager[1424033]: {"L":"INFO","T":"2025-01-04T15:36:10.881+0600","N":"cluster.client","M":"Measuring datacenter latencies","dcs":["ST"],"_trace_id":"2-gk21DpRt2dBQ8MjZERHQ"}
```

</details>

The log `Measuring datacenter latencies` does not contain any useful information, but it clogs the log files since checking for closest DC is done during every fresh scyllaclient creation, which is done by the config cache service every minute.

I was also thinking on removing `Creating new Scylla HTTP client` logs, but having a single line of log for indicating scyllaclient creation performed by config cache svc might be fine. 
