### PR TITLE
Configcache: return on error in ForceUpdateCluster

### DIFF
--- a/pkg/service/configcache/service.go
+++ b/pkg/service/configcache/service.go
@@ -141,6 +141,7 @@ func (svc *Service) ForceUpdateCluster(ctx context.Context, clusterID uuid.UUID)
 	c, err := svc.clusterSvc.GetCluster(ctx, clusterID.String())
 	if err != nil {
 		logger.Error(ctx, "Update failed", "error", err)
+		return false
 	}
 
 	return svc.updateSingle(ctx, c)


### PR DESCRIPTION
Otherwise, we panic inside updateSingle method.
This commit also contains a small test for
testing this behavior.
