### PR TITLE
Restore test: keep single cluster ID for many restores

### DIFF
--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -1312,7 +1312,7 @@ func restoreViewSSTableSchema(t *testing.T, schemaTarget, tablesTarget Target, k
 	dstH.validateRestoreSuccess(dstSession, srcSession, schemaTarget, toValidate)
 
 	tablesTarget.SnapshotTag = schemaTarget.SnapshotTag
-	dstH.ClusterID = uuid.MustRandom()
+	dstH.TaskID = uuid.MustRandom()
 	dstH.RunID = uuid.MustRandom()
 
 	Print("When: Grant minimal user permissions for restore tables")
@@ -1420,7 +1420,7 @@ func restoreAllTables(t *testing.T, schemaTarget, tablesTarget Target, keyspace 
 	dstH.validateRestoreSuccess(dstSession, srcSession, schemaTarget, toValidate)
 
 	tablesTarget.SnapshotTag = schemaTarget.SnapshotTag
-	dstH.ClusterID = uuid.MustRandom()
+	dstH.TaskID = uuid.MustRandom()
 	dstH.RunID = uuid.MustRandom()
 	grantRestoreTablesPermissions(t, dstSession, tablesTarget.Keyspace, user)
 
@@ -1506,7 +1506,7 @@ func restoreAlternator(t *testing.T, schemaTarget, tablesTarget Target, testKeys
 	dstH.validateRestoreSuccess(dstSession, srcSession, schemaTarget, toValidate)
 
 	tablesTarget.SnapshotTag = schemaTarget.SnapshotTag
-	dstH.ClusterID = uuid.MustRandom()
+	dstH.TaskID = uuid.MustRandom()
 	dstH.RunID = uuid.MustRandom()
 	grantRestoreTablesPermissions(t, dstSession, tablesTarget.Keyspace, user)
 


### PR DESCRIPTION
When new restore task is executed, it should have its own task ID and run ID, but the cluster ID should remain the same. This commit fixes an autofill typo from the past. It was discovered because it affected the config cache service.
