### PR TITLE
Swagger: scylla-manager, move towards just restored bytes

### DIFF
--- a/v3/swagger/gen/scylla-manager/models/restore_host_progress.go
+++ b/v3/swagger/gen/scylla-manager/models/restore_host_progress.go
@@ -15,22 +15,28 @@ import (
 // swagger:model RestoreHostProgress
 type RestoreHostProgress struct {
 
-	// Total time spent by host on download in milliseconds
+	// Total time spent by host on download in milliseconds (included in restore_duration)
 	DownloadDuration int64 `json:"download_duration,omitempty"`
 
-	// Total bytes downloaded by host
+	// Total bytes downloaded by host (included in restored_bytes)
 	DownloadedBytes int64 `json:"downloaded_bytes,omitempty"`
 
 	// host
 	Host string `json:"host,omitempty"`
 
+	// Total time spent by host on restore in milliseconds
+	RestoreDuration int64 `json:"restore_duration,omitempty"`
+
+	// Total bytes restored by host
+	RestoredBytes int64 `json:"restored_bytes,omitempty"`
+
 	// Host shard count
 	ShardCnt int64 `json:"shard_cnt,omitempty"`
 
-	// Total time spent by host on load&stream in milliseconds
+	// Total time spent by host on load&stream in milliseconds (included in restore_duration)
 	StreamDuration int64 `json:"stream_duration,omitempty"`
 
-	// Total bytes load&streamed by host
+	// Total bytes load&streamed by host (included in restored_bytes)
 	StreamedBytes int64 `json:"streamed_bytes,omitempty"`
 }
 

--- a/v3/swagger/gen/scylla-manager/models/restore_keyspace_progress.go
+++ b/v3/swagger/gen/scylla-manager/models/restore_keyspace_progress.go
@@ -23,7 +23,7 @@ type RestoreKeyspaceProgress struct {
 	// Format: date-time
 	CompletedAt *strfmt.DateTime `json:"completed_at,omitempty"`
 
-	// downloaded
+	// This field is DEPRECATED. Total bytes downloaded from table (included in restored)
 	Downloaded int64 `json:"downloaded,omitempty"`
 
 	// failed

--- a/v3/swagger/gen/scylla-manager/models/restore_progress.go
+++ b/v3/swagger/gen/scylla-manager/models/restore_progress.go
@@ -23,7 +23,7 @@ type RestoreProgress struct {
 	// Format: date-time
 	CompletedAt *strfmt.DateTime `json:"completed_at,omitempty"`
 
-	// downloaded
+	// This field is DEPRECATED. Total bytes downloaded from table (included in restored)
 	Downloaded int64 `json:"downloaded,omitempty"`
 
 	// failed

--- a/v3/swagger/gen/scylla-manager/models/restore_table_progress.go
+++ b/v3/swagger/gen/scylla-manager/models/restore_table_progress.go
@@ -21,7 +21,7 @@ type RestoreTableProgress struct {
 	// Format: date-time
 	CompletedAt *strfmt.DateTime `json:"completed_at,omitempty"`
 
-	// downloaded
+	// This field is DEPRECATED. Total bytes downloaded from table (included in restored)
 	Downloaded int64 `json:"downloaded,omitempty"`
 
 	// error

--- a/v3/swagger/scylla-manager.json
+++ b/v3/swagger/scylla-manager.json
@@ -888,6 +888,7 @@
           "type": "integer"
         },
         "downloaded": {
+          "description": "This field is DEPRECATED. Total bytes downloaded from table (included in restored)",
           "type": "integer"
         },
         "failed": {
@@ -1055,6 +1056,7 @@
           "type": "integer"
         },
         "downloaded": {
+          "description": "This field is DEPRECATED. Total bytes downloaded from table (included in restored)",
           "type": "integer"
         },
         "failed": {
@@ -1091,6 +1093,7 @@
           "type": "integer"
         },
         "downloaded": {
+          "description": "This field is DEPRECATED. Total bytes downloaded from table (included in restored)",
           "type": "integer"
         },
         "failed": {
@@ -1118,20 +1121,28 @@
           "description": "Host shard count",
           "type": "integer"
         },
+        "restored_bytes": {
+          "description": "Total bytes restored by host",
+          "type": "integer"
+        },
+        "restore_duration": {
+          "description": "Total time spent by host on restore in milliseconds",
+          "type": "integer"
+        },
         "downloaded_bytes": {
-          "description": "Total bytes downloaded by host",
+          "description": "Total bytes downloaded by host (included in restored_bytes)",
           "type": "integer"
         },
         "download_duration": {
-          "description": "Total time spent by host on download in milliseconds",
+          "description": "Total time spent by host on download in milliseconds (included in restore_duration)",
           "type": "integer"
         },
         "streamed_bytes": {
-          "description": "Total bytes load&streamed by host",
+          "description": "Total bytes load&streamed by host (included in restored_bytes)",
           "type": "integer"
         },
         "stream_duration": {
-          "description": "Total time spent by host on load&stream in milliseconds",
+          "description": "Total time spent by host on load&stream in milliseconds (included in restore_duration)",
           "type": "integer"
         }
       }


### PR DESCRIPTION
In overall/keyspace/table progress we were reporting both downloaded and restored bytes. There are two problems with it:

1. Users does not really care for the distinction between downloaded and restored bytes - they just want to know the amount of bytes that have been successfully restored.

2. With new native Scylla API restore, we no longer separate restoration into download/load&stream stages.

That's why we should move towards reporting just the amount of successfully restored bytes, and not keep on adding another fields to our API for each new type of restore.

This commit:
- Adds restored_bytes/duration to host progress, since it was lacking there. It does not deprecate the downloaded/streamed fields because they were just added in the previous minor release, so that would be confusing. Instead, for now we allow for host progress to contain detailed operation bandwidth information.
- Deprecates downloaded bytes in overall/keyspace/table progress, as we want to move towards observing just the restored bytes.

A general note is that we should use metrics for monitoring performance, not the sctool progress cmd, but since we already started going in this direction, we need to support it.
