### PR TITLE
feat(managerclient): adds new task type - 1_1_restore

### DIFF
--- a/v3/pkg/managerclient/tasks.go
+++ b/v3/pkg/managerclient/tasks.go
@@ -8,7 +8,7 @@ import "github.com/scylladb/go-set/strset"
 const (
 	BackupTask         string = "backup"
 	RestoreTask        string = "restore"
-	FastRestoreTask    string = "fastrestore"
+	One2OneRestoreTask string = "1_1_restore"
 	HealthCheckTask    string = "healthcheck"
 	RepairTask         string = "repair"
 	SuspendTask        string = "suspend"
@@ -19,7 +19,7 @@ const (
 var TasksTypes = strset.New(
 	BackupTask,
 	RestoreTask,
-	FastRestoreTask,
+	One2OneRestoreTask,
 	HealthCheckTask,
 	RepairTask,
 	SuspendTask,

--- a/v3/pkg/managerclient/tasks.go
+++ b/v3/pkg/managerclient/tasks.go
@@ -8,6 +8,7 @@ import "github.com/scylladb/go-set/strset"
 const (
 	BackupTask         string = "backup"
 	RestoreTask        string = "restore"
+	FastRestoreTask    string = "fastrestore"
 	HealthCheckTask    string = "healthcheck"
 	RepairTask         string = "repair"
 	SuspendTask        string = "suspend"
@@ -18,6 +19,7 @@ const (
 var TasksTypes = strset.New(
 	BackupTask,
 	RestoreTask,
+	FastRestoreTask,
 	HealthCheckTask,
 	RepairTask,
 	SuspendTask,


### PR DESCRIPTION
This adds a new task type for 1-1 vnode restore.
As managerclient is a separate go module, changes into it should be merged first. 
~~Fixes 4200~~

Part1 of #4200 

see Part2 - #4221 


---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
