### PR TITLE
Swagger: scylla, update tablet repair API

### DIFF
--- a/v3/swagger/gen/scylla/v1/client/operations/storage_service_tablets_repair_post_parameters.go
+++ b/v3/swagger/gen/scylla/v1/client/operations/storage_service_tablets_repair_post_parameters.go
@@ -61,6 +61,11 @@ for the storage service tablets repair post operation typically these are writte
 */
 type StorageServiceTabletsRepairPostParams struct {
 
+	/*AwaitCompletion
+	  Set true to wait for the repair to complete. Set false to skip waiting for the repair to complete. When the option is not provided, it defaults to false.
+
+	*/
+	AwaitCompletion *string
 	/*Ks
 	  Keyspace name to repair
 
@@ -115,6 +120,17 @@ func (o *StorageServiceTabletsRepairPostParams) SetHTTPClient(client *http.Clien
 	o.HTTPClient = client
 }
 
+// WithAwaitCompletion adds the awaitCompletion to the storage service tablets repair post params
+func (o *StorageServiceTabletsRepairPostParams) WithAwaitCompletion(awaitCompletion *string) *StorageServiceTabletsRepairPostParams {
+	o.SetAwaitCompletion(awaitCompletion)
+	return o
+}
+
+// SetAwaitCompletion adds the awaitCompletion to the storage service tablets repair post params
+func (o *StorageServiceTabletsRepairPostParams) SetAwaitCompletion(awaitCompletion *string) {
+	o.AwaitCompletion = awaitCompletion
+}
+
 // WithKs adds the ks to the storage service tablets repair post params
 func (o *StorageServiceTabletsRepairPostParams) WithKs(ks string) *StorageServiceTabletsRepairPostParams {
 	o.SetKs(ks)
@@ -155,6 +171,22 @@ func (o *StorageServiceTabletsRepairPostParams) WriteToRequest(r runtime.ClientR
 		return err
 	}
 	var res []error
+
+	if o.AwaitCompletion != nil {
+
+		// query param await_completion
+		var qrAwaitCompletion string
+		if o.AwaitCompletion != nil {
+			qrAwaitCompletion = *o.AwaitCompletion
+		}
+		qAwaitCompletion := qrAwaitCompletion
+		if qAwaitCompletion != "" {
+			if err := r.SetQueryParam("await_completion", qAwaitCompletion); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// query param ks
 	qrKs := o.Ks

--- a/v3/swagger/gen/scylla/v1/client/operations/storage_service_tablets_repair_post_responses.go
+++ b/v3/swagger/gen/scylla/v1/client/operations/storage_service_tablets_repair_post_responses.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/models"
 )
@@ -50,12 +51,24 @@ func NewStorageServiceTabletsRepairPostOK() *StorageServiceTabletsRepairPostOK {
 /*
 StorageServiceTabletsRepairPostOK handles this case with default header values.
 
-Success
+Tablet task ID
 */
 type StorageServiceTabletsRepairPostOK struct {
+	Payload *StorageServiceTabletsRepairPostOKBody
+}
+
+func (o *StorageServiceTabletsRepairPostOK) GetPayload() *StorageServiceTabletsRepairPostOKBody {
+	return o.Payload
 }
 
 func (o *StorageServiceTabletsRepairPostOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(StorageServiceTabletsRepairPostOKBody)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }
@@ -101,4 +114,37 @@ func (o *StorageServiceTabletsRepairPostDefault) readResponse(response runtime.C
 
 func (o *StorageServiceTabletsRepairPostDefault) Error() string {
 	return fmt.Sprintf("agent [HTTP %d] %s", o._statusCode, strings.TrimRight(o.Payload.Message, "."))
+}
+
+/*
+StorageServiceTabletsRepairPostOKBody storage service tablets repair post o k body
+swagger:model StorageServiceTabletsRepairPostOKBody
+*/
+type StorageServiceTabletsRepairPostOKBody struct {
+
+	// Tablet task ID
+	TabletTaskID string `json:"tablet_task_id,omitempty"`
+}
+
+// Validate validates this storage service tablets repair post o k body
+func (o *StorageServiceTabletsRepairPostOKBody) Validate(formats strfmt.Registry) error {
+	return nil
+}
+
+// MarshalBinary interface implementation
+func (o *StorageServiceTabletsRepairPostOKBody) MarshalBinary() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(o)
+}
+
+// UnmarshalBinary interface implementation
+func (o *StorageServiceTabletsRepairPostOKBody) UnmarshalBinary(b []byte) error {
+	var res StorageServiceTabletsRepairPostOKBody
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*o = res
+	return nil
 }

--- a/v3/swagger/scylla_v1.json
+++ b/v3/swagger/scylla_v1.json
@@ -12694,12 +12694,27 @@
             "required": true,
             "type": "string",
             "description": "Tokens owned by the tablets to repair. Multiple tokens can be provided using a comma-separated list. When set to the special word 'all', all tablets will be repaired"
+          },
+          {
+            "name": "await_completion",
+            "in": "query",
+            "required": false,
+            "type": "string",
+            "description": "Set true to wait for the repair to complete. Set false to skip waiting for the repair to complete. When the option is not provided, it defaults to false."
           }
         ],
         "responses": {
           "200": {
-            "description": "Success",
-            "headers": {}
+            "description": "Tablet task ID",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "tablet_task_id": {
+                  "description": "Tablet task ID",
+                  "type": "string"
+                }
+              }
+            }
           },
           "default": {
             "description": "internal server error",


### PR DESCRIPTION
This PR adds new 'await_completion' query param
introduced in https://github.com/scylladb/scylladb/pull/22436
and updates response to task manager task ID
as per https://github.com/scylladb/scylladb/pull/22436#issuecomment-2614704691.
