### PR TITLE
feat(1-1-restore): adds copy data stage + loadSStables call

### DIFF
--- a/.github/cfg/integration-test-core.yaml
+++ b/.github/cfg/integration-test-core.yaml
@@ -136,4 +136,4 @@ jobs:
         run: make pkg-integration-test PKG=./pkg/schema/migrate
 
       - name: Run 1-1-restore tests
-        run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+        run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore

--- a/.github/workflows/integration-tests-2023.1.11-IPV4-raftschema.yaml
+++ b/.github/workflows/integration-tests-2023.1.11-IPV4-raftschema.yaml
@@ -107,7 +107,7 @@ jobs:
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
             - name: Run 1-1-restore tests
-              run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+              run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore
 name: integration-tests-2023.1.11-IPV4-raftschema
 "on":
     pull_request:

--- a/.github/workflows/integration-tests-2023.1.11-IPV4.yaml
+++ b/.github/workflows/integration-tests-2023.1.11-IPV4.yaml
@@ -107,7 +107,7 @@ jobs:
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
             - name: Run 1-1-restore tests
-              run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+              run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore
 name: integration-tests-2023.1.11-IPV4
 "on":
     pull_request:

--- a/.github/workflows/integration-tests-2023.1.11-IPV6-raftschema.yaml
+++ b/.github/workflows/integration-tests-2023.1.11-IPV6-raftschema.yaml
@@ -107,7 +107,7 @@ jobs:
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
             - name: Run 1-1-restore tests
-              run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+              run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore
 name: integration-tests-2023.1.11-IPV6-raftschema
 "on":
     pull_request:

--- a/.github/workflows/integration-tests-2024.1.12-IPV4.yaml
+++ b/.github/workflows/integration-tests-2024.1.12-IPV4.yaml
@@ -107,7 +107,7 @@ jobs:
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
             - name: Run 1-1-restore tests
-              run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+              run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore
 name: integration-tests-2024.1.12-IPV4
 "on":
     pull_request:

--- a/.github/workflows/integration-tests-2024.1.12-IPV6.yaml
+++ b/.github/workflows/integration-tests-2024.1.12-IPV6.yaml
@@ -107,7 +107,7 @@ jobs:
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
             - name: Run 1-1-restore tests
-              run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+              run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore
 name: integration-tests-2024.1.12-IPV6
 "on":
     pull_request:

--- a/.github/workflows/integration-tests-6.2.0-IPV4-tablets.yaml
+++ b/.github/workflows/integration-tests-6.2.0-IPV4-tablets.yaml
@@ -107,7 +107,7 @@ jobs:
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
             - name: Run 1-1-restore tests
-              run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+              run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore
 name: integration-tests-6.2.0-IPV4-tablets
 "on":
     pull_request:

--- a/.github/workflows/integration-tests-6.2.0-IPV4.yaml
+++ b/.github/workflows/integration-tests-6.2.0-IPV4.yaml
@@ -107,7 +107,7 @@ jobs:
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
             - name: Run 1-1-restore tests
-              run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+              run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore
 name: integration-tests-6.2.0-IPV4
 "on":
     pull_request:

--- a/.github/workflows/integration-tests-6.2.0-IPV6-tablets-nossl.yaml
+++ b/.github/workflows/integration-tests-6.2.0-IPV6-tablets-nossl.yaml
@@ -107,7 +107,7 @@ jobs:
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
             - name: Run 1-1-restore tests
-              run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+              run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore
 name: integration-tests-6.2.0-IPV6-tablets-nossl
 "on":
     pull_request:

--- a/.github/workflows/integration-tests-latest-enterprise-IPV4-tablets-nossl.yaml
+++ b/.github/workflows/integration-tests-latest-enterprise-IPV4-tablets-nossl.yaml
@@ -107,7 +107,7 @@ jobs:
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
             - name: Run 1-1-restore tests
-              run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+              run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore
 name: integration-tests-latest-enterprise-IPV4-tablets-nossl
 "on":
     pull_request:

--- a/.github/workflows/integration-tests-latest-enterprise-IPV4.yaml
+++ b/.github/workflows/integration-tests-latest-enterprise-IPV4.yaml
@@ -107,7 +107,7 @@ jobs:
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
             - name: Run 1-1-restore tests
-              run: make pkg-integration-test PKG=./pkg/service/one2onerestore
+              run: make pkg-integration-test TABLETS=${{ env.tablets }} PKG=./pkg/service/one2onerestore
 name: integration-tests-latest-enterprise-IPV4
 "on":
     pull_request:

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ pkg-integration-test:
 		-v "$(PWD)/$(PKG)/testdata:/integration-test/testdata" \
 		-w "/integration-test" \
 		-e "SSL_ENABLED=$(SSL_ENABLED)" \
+		-e "TABLETS=$(TABLETS)" \
 		-u $(CURRENT_UID):$(CURRENT_GID) \
 		-i --read-only --rm ubuntu integration-test -test.v -test.run $(RUN) $(INTEGRATION_TEST_ARGS) $(SSL_FLAGS) $(ARGS)
 

--- a/pkg/service/one2onerestore/helpers_integration_test.go
+++ b/pkg/service/one2onerestore/helpers_integration_test.go
@@ -1,0 +1,188 @@
+// Copyright (C) 2025 ScyllaDB
+
+//go:build all || integration
+// +build all integration
+
+package one2onerestore
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/go-log"
+	"github.com/scylladb/gocqlx/v2"
+	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testhelper"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+	"go.uber.org/zap/zapcore"
+)
+
+type testHelper struct {
+	client     *scyllaclient.Client
+	clusterID  uuid.UUID
+	backupSvc  *backup.Service
+	restoreSvc Servicer
+}
+
+func newTestHelper(t *testing.T, hosts []string) *testHelper {
+	clientCfg := scyllaclient.TestConfig(hosts, AgentAuthToken())
+	sc, err := scyllaclient.NewClient(clientCfg, log.NopLogger)
+	requireNoError(t, err)
+	session := CreateScyllaManagerDBSession(t)
+
+	clusterID := uuid.NewTime()
+
+	backupSvc := newBackupSvc(t, session, sc, clusterID)
+	restoreSvc := newRestoreSvc(t, session, sc, clusterID, "", "")
+
+	return &testHelper{
+		client:     sc,
+		clusterID:  clusterID,
+		backupSvc:  backupSvc,
+		restoreSvc: restoreSvc,
+	}
+}
+
+func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {
+	t.Helper()
+	Printf("Run backup with properties: %v", props)
+	ctx := context.Background()
+	taskID := uuid.NewTime()
+	runID := uuid.NewTime()
+
+	rawProps, err := json.Marshal(props)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "marshal properties"))
+	}
+
+	target, err := h.backupSvc.GetTarget(ctx, h.clusterID, rawProps)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "generate target"))
+	}
+
+	err = h.backupSvc.Backup(ctx, h.clusterID, taskID, runID, target)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "run backup"))
+	}
+
+	pr, err := h.backupSvc.GetProgress(ctx, h.clusterID, taskID, runID)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "get progress"))
+	}
+
+	return pr.SnapshotTag
+}
+
+func (h *testHelper) runRestore(t *testing.T, props map[string]any) {
+	t.Helper()
+	Printf("Run 1-1-restore with properties: %v", props)
+	ctx := context.Background()
+	taskID := uuid.NewTime()
+	runID := uuid.NewTime()
+
+	rawProps, err := json.Marshal(props)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "marshal properties"))
+	}
+
+	err = h.restoreSvc.One2OneRestore(ctx, h.clusterID, taskID, runID, rawProps)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "run 1-1-restore"))
+	}
+}
+
+func testLocation(bucket, dc string) backupspec.Location {
+	return backupspec.Location{
+		DC:       dc,
+		Provider: backupspec.S3,
+		Path:     "restoretest-" + bucket,
+	}
+}
+
+func newBackupSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient.Client, clusterID uuid.UUID) *backup.Service {
+	svc, err := backup.NewService(
+		mgrSession,
+		defaultBackupTestConfig(),
+		metrics.NewBackupMetrics(),
+		func(_ context.Context, id uuid.UUID) (string, error) {
+			return "test_cluster", nil
+		},
+		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
+			return client, nil
+		},
+		func(ctx context.Context, clusterID uuid.UUID, _ ...cluster.SessionConfigOption) (gocqlx.Session, error) {
+			return CreateSession(t, client), nil
+		},
+		NewTestConfigCacheSvc(t, clusterID, client.Config().Hosts),
+		log.NewDevelopmentWithLevel(zapcore.InfoLevel).Named("backup"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func newRestoreSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient.Client, clusterID uuid.UUID, user, pass string) Servicer {
+	configCacheSvc := NewTestConfigCacheSvc(t, clusterID, client.Config().Hosts)
+
+	svc, err := NewService(
+		mgrSession,
+		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
+			return client, nil
+		},
+		func(ctx context.Context, clusterID uuid.UUID, _ ...cluster.SessionConfigOption) (gocqlx.Session, error) {
+			return CreateManagedClusterSession(t, false, client, user, pass), nil
+		},
+		configCacheSvc,
+		log.NewDevelopmentWithLevel(zapcore.InfoLevel).Named("1-1-restore"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return svc
+}
+
+func defaultBackupTestConfig() backup.Config {
+	return backup.Config{
+		DiskSpaceFreeMinPercent:   5,
+		LongPollingTimeoutSeconds: 1,
+		AgeMax:                    24 * time.Hour,
+	}
+}
+
+// getNodeMappings creates []nodeMapping from the cluster that can be reached by client.
+// Nodes are mapped to themselves.
+func getNodeMappings(t *testing.T, client *scyllaclient.Client) []nodeMapping {
+	t.Helper()
+	ctx := context.Background()
+
+	var result []nodeMapping
+
+	nodesStatus, err := client.Status(ctx)
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+
+	for _, n := range nodesStatus {
+		rack, err := client.HostRack(ctx, n.Addr)
+		if err != nil {
+			t.Fatalf("get host rack: %v", err)
+		}
+		result = append(result, nodeMapping{
+			Source: node{DC: n.Datacenter, Rack: rack, HostID: n.HostID},
+			Target: node{DC: n.Datacenter, Rack: rack, HostID: n.HostID},
+		})
+	}
+
+	return result
+}

--- a/pkg/service/one2onerestore/model.go
+++ b/pkg/service/one2onerestore/model.go
@@ -18,7 +18,9 @@ type Target struct {
 }
 
 func defaultTarget() Target {
-	return Target{}
+	return Target{
+		Keyspace: []string{"*"},
+	}
 }
 
 type nodeMapping struct {

--- a/pkg/service/one2onerestore/service.go
+++ b/pkg/service/one2onerestore/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/configcache"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 )
 
@@ -69,6 +70,7 @@ func (s *Service) One2OneRestore(ctx context.Context, clusterID, taskID, runID u
 	if err != nil {
 		return errors.Wrap(err, "parse target")
 	}
+	s.logger.Info(ctx, "Service input params", "target", target)
 
 	w, err := s.newWorker(ctx, clusterID)
 	if err != nil {
@@ -85,7 +87,11 @@ func (s *Service) One2OneRestore(ctx context.Context, clusterID, taskID, runID u
 	}
 	s.logger.Info(ctx, "Can proceed with 1-1-restore")
 
-	s.logger.Info(ctx, "Not yet implemented", "target", target)
+	start := timeutc.Now()
+	if err := w.restoreTables(ctx, manifests, hosts, target.NodesMapping); err != nil {
+		return errors.Wrap(err, "restore data")
+	}
+	s.logger.Info(ctx, "Data restore is completed", "took", timeutc.Since(start))
 	return nil
 }
 

--- a/pkg/service/one2onerestore/service.go
+++ b/pkg/service/one2onerestore/service.go
@@ -88,7 +88,7 @@ func (s *Service) One2OneRestore(ctx context.Context, clusterID, taskID, runID u
 	s.logger.Info(ctx, "Can proceed with 1-1-restore")
 
 	start := timeutc.Now()
-	if err := w.restoreTables(ctx, manifests, hosts, target.NodesMapping); err != nil {
+	if err := w.restoreTables(ctx, manifests, hosts, target.NodesMapping, target.Keyspace); err != nil {
 		return errors.Wrap(err, "restore data")
 	}
 	s.logger.Info(ctx, "Data restore is completed", "took", timeutc.Since(start))

--- a/pkg/service/one2onerestore/service_integration_test.go
+++ b/pkg/service/one2onerestore/service_integration_test.go
@@ -1,0 +1,257 @@
+// Copyright (C) 2025 ScyllaDB
+
+//go:build all || integration
+// +build all integration
+
+package one2onerestore
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/go-log"
+	"github.com/scylladb/gocqlx/v2"
+	"github.com/scylladb/gocqlx/v2/qb"
+	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
+	. "github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testhelper"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestOne2OneRestoreService(t *testing.T) {
+	h := newTestHelper(t, ManagedClusterHosts())
+
+	clusterSession := CreateSessionAndDropAllKeyspaces(t, h.client)
+
+	ksName := "testrestore"
+	WriteData(t, clusterSession, ksName, 10)
+
+	srcCnt := rowCount(t, clusterSession, ksName, BigTableName)
+	if srcCnt == 0 {
+		t.Fatalf("Unexpected row count: 0")
+	}
+
+	Print("Run backup")
+	loc := []Location{testLocation("basic", "")}
+	S3InitBucket(t, loc[0].Path)
+	tag := h.runBackup(t, map[string]any{
+		"location": loc,
+	})
+
+	Print("Truncate tables")
+	truncateAllTablesInKeyspace(t, clusterSession, ksName)
+	if cnt := rowCount(t, clusterSession, ksName, BigTableName); cnt != 0 {
+		t.Fatalf("Unexpected row count: %d", cnt)
+	}
+
+	Print("Run 1-1-restore")
+	h.runRestore(t, map[string]any{
+		"location":          loc,
+		"snapshot_tag":      tag,
+		"source_cluster_id": h.clusterID,
+		"nodes_mapping":     h.getNodeMappings(t),
+	})
+
+	Print("Validate data")
+	dstCnt := rowCount(t, clusterSession, ksName, BigTableName)
+	if srcCnt != dstCnt {
+		t.Fatalf("Expected row count %d, but got %d", srcCnt, dstCnt)
+	}
+}
+
+func testLocation(bucket, dc string) Location {
+	return Location{
+		DC:       dc,
+		Provider: S3,
+		Path:     "restoretest-" + bucket,
+	}
+}
+
+func newBackupSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient.Client, clusterID uuid.UUID) *backup.Service {
+	svc, err := backup.NewService(
+		mgrSession,
+		defaultBackupTestConfig(),
+		metrics.NewBackupMetrics(),
+		func(_ context.Context, id uuid.UUID) (string, error) {
+			return "test_cluster", nil
+		},
+		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
+			return client, nil
+		},
+		func(ctx context.Context, clusterID uuid.UUID, _ ...cluster.SessionConfigOption) (gocqlx.Session, error) {
+			return CreateSession(t, client), nil
+		},
+		NewTestConfigCacheSvc(t, clusterID, client.Config().Hosts),
+		log.NewDevelopmentWithLevel(zapcore.ErrorLevel).Named("backup"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func defaultBackupTestConfig() backup.Config {
+	return backup.Config{
+		DiskSpaceFreeMinPercent:   5,
+		LongPollingTimeoutSeconds: 1,
+		AgeMax:                    24 * time.Hour,
+	}
+}
+
+func newRestoreSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient.Client, clusterID uuid.UUID, user, pass string) *Service {
+	configCacheSvc := NewTestConfigCacheSvc(t, clusterID, client.Config().Hosts)
+
+	svc, err := NewService(
+		mgrSession,
+		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
+			return client, nil
+		},
+		func(ctx context.Context, clusterID uuid.UUID, _ ...cluster.SessionConfigOption) (gocqlx.Session, error) {
+			return CreateManagedClusterSession(t, false, client, user, pass), nil
+		},
+		configCacheSvc,
+		log.NewDevelopmentWithLevel(zapcore.InfoLevel).Named("1-1-restore"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return svc
+}
+
+func newTestHelper(t *testing.T, hosts []string) *testHelper {
+	clientCfg := scyllaclient.TestConfig(hosts, AgentAuthToken())
+	sc, err := scyllaclient.NewClient(clientCfg, log.NewDevelopment())
+	requireNoError(t, err)
+	session := CreateScyllaManagerDBSession(t)
+
+	clusterID := uuid.NewTime()
+
+	backupSvc := newBackupSvc(t, session, sc, clusterID)
+	restoreSvc := newRestoreSvc(t, session, sc, clusterID, "", "")
+
+	return &testHelper{
+		client:     sc,
+		clusterID:  clusterID,
+		backupSvc:  backupSvc,
+		restoreSvc: restoreSvc,
+	}
+}
+
+type testHelper struct {
+	client     *scyllaclient.Client
+	clusterID  uuid.UUID
+	backupSvc  *backup.Service
+	restoreSvc *Service
+}
+
+func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {
+	t.Helper()
+	Printf("Run backup with properties: %v", props)
+	ctx := context.Background()
+	taskID := uuid.NewTime()
+	runID := uuid.NewTime()
+
+	rawProps, err := json.Marshal(props)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "marshal properties"))
+	}
+
+	target, err := h.backupSvc.GetTarget(ctx, h.clusterID, rawProps)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "generate target"))
+	}
+
+	err = h.backupSvc.Backup(ctx, h.clusterID, taskID, runID, target)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "run backup"))
+	}
+
+	pr, err := h.backupSvc.GetProgress(ctx, h.clusterID, taskID, runID)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "get progress"))
+	}
+
+	return pr.SnapshotTag
+}
+
+func (h *testHelper) runRestore(t *testing.T, props map[string]any) {
+	t.Helper()
+	Printf("Run 1-1-restore with properties: %v", props)
+	ctx := context.Background()
+	taskID := uuid.NewTime()
+	runID := uuid.NewTime()
+
+	rawProps, err := json.Marshal(props)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "marshal properties"))
+	}
+
+	err = h.restoreSvc.One2OneRestore(ctx, h.clusterID, taskID, runID, rawProps)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "run 1-1-restore"))
+	}
+}
+
+func (h *testHelper) getNodeMappings(t *testing.T) []nodeMapping {
+	t.Helper()
+	ctx := context.Background()
+
+	var result []nodeMapping
+
+	nodesStatus, err := h.client.Status(ctx)
+	requireNoError(t, err)
+
+	for _, n := range nodesStatus {
+		rack, err := h.client.HostRack(ctx, n.Addr)
+		requireNoError(t, err)
+		result = append(result, nodeMapping{
+			Source: node{DC: n.Datacenter, Rack: rack, HostID: n.HostID},
+			Target: node{DC: n.Datacenter, Rack: rack, HostID: n.HostID},
+		})
+	}
+
+	return result
+}
+
+func truncateAllTablesInKeyspace(tb testing.TB, session gocqlx.Session, ks string) {
+	tb.Helper()
+
+	q := qb.Select("system_schema.tables").Columns("table_name").Where(qb.Eq("keyspace_name")).Query(session).Bind(ks)
+	defer q.Release()
+
+	var all []string
+	if err := q.Select(&all); err != nil {
+		tb.Fatal(err)
+	}
+
+	for _, t := range all {
+		truncateTable(tb, session, ks, t)
+	}
+}
+
+func truncateTable(tb testing.TB, session gocqlx.Session, keyspace, table string) {
+	tb.Helper()
+
+	ExecStmt(tb, session, fmt.Sprintf("TRUNCATE TABLE %q.%q", keyspace, table))
+}
+
+func rowCount(t *testing.T, s gocqlx.Session, ks, tab string) int {
+	var cnt int
+	if err := s.Session.Query(fmt.Sprintf("SELECT COUNT(*) FROM %q.%q USING TIMEOUT 300s", ks, tab)).Scan(&cnt); err != nil {
+		t.Fatal(errors.Wrapf(err, "get table %s.%s row count", ks, tab))
+	}
+	Printf("%s.%s row count: %v", ks, tab, cnt)
+	return cnt
+}

--- a/pkg/service/one2onerestore/service_integration_test.go
+++ b/pkg/service/one2onerestore/service_integration_test.go
@@ -43,7 +43,7 @@ func TestOne2OneRestoreService(t *testing.T) {
 	}
 
 	Print("Run backup")
-	loc := []Location{testLocation("basic", "")}
+	loc := []Location{testLocation("1-1-restore", "")}
 	S3InitBucket(t, loc[0].Path)
 	tag := h.runBackup(t, map[string]any{
 		"location": loc,
@@ -93,7 +93,7 @@ func newBackupSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient.
 			return CreateSession(t, client), nil
 		},
 		NewTestConfigCacheSvc(t, clusterID, client.Config().Hosts),
-		log.NewDevelopmentWithLevel(zapcore.ErrorLevel).Named("backup"),
+		log.NewDevelopmentWithLevel(zapcore.InfoLevel).Named("backup"),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -132,7 +132,7 @@ func newRestoreSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient
 
 func newTestHelper(t *testing.T, hosts []string) *testHelper {
 	clientCfg := scyllaclient.TestConfig(hosts, AgentAuthToken())
-	sc, err := scyllaclient.NewClient(clientCfg, log.NewDevelopment())
+	sc, err := scyllaclient.NewClient(clientCfg, log.NopLogger)
 	requireNoError(t, err)
 	session := CreateScyllaManagerDBSession(t)
 

--- a/pkg/service/one2onerestore/service_integration_test.go
+++ b/pkg/service/one2onerestore/service_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -29,7 +30,10 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func TestOne2OneRestoreService(t *testing.T) {
+func TestOne2OneRestoreServiceIntegration(t *testing.T) {
+	if tablets := os.Getenv("TABLETS"); tablets == "enabled" {
+		t.Skip("1-1-restore is available only for v-nodes")
+	}
 	h := newTestHelper(t, ManagedClusterHosts())
 
 	clusterSession := CreateSessionAndDropAllKeyspaces(t, h.client)

--- a/pkg/service/one2onerestore/worker_tables.go
+++ b/pkg/service/one2onerestore/worker_tables.go
@@ -1,0 +1,159 @@
+// Copyright (C) 2025 ScyllaDB
+
+package one2onerestore
+
+import (
+	"cmp"
+	"context"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
+)
+
+func (w *worker) restoreTables(ctx context.Context, manifests []*backupspec.ManifestInfo, hosts []Host, nodeMappings []nodeMapping) error {
+	// we can safely ignore error here because node mappings must've been validated up to this point.
+	targetBySourceHostID, _ := mapTargetHostToSource(hosts, nodeMappings) //nolint
+
+	err := parallel.Run(len(manifests), parallel.NoLimit, func(i int) error {
+		m := manifests[i]
+		h := targetBySourceHostID[m.NodeID]
+
+		mc, err := w.getManifestContent(ctx, h.Addr, m)
+		if err != nil {
+			return errors.Wrap(err, "manifest content")
+		}
+		index, err := mc.ReadIndex()
+		if err != nil {
+			return errors.Wrap(err, "read index")
+		}
+		// sort in descending order, so we download the biggest tables first
+		slices.SortFunc(index, func(a, b backupspec.FilesMeta) int {
+			return cmp.Compare(b.Size, a.Size)
+		})
+
+		const (
+			repeatInterval  = 10 * time.Second
+			pollIntervalSec = 10
+		)
+		for _, table := range index {
+			w.logger.Info(ctx, "Restoring data", "ks", table.Keyspace, "table", table.Table, "size", table.Size)
+
+			jobID, err := w.createDownloadJob(ctx, table, m, h)
+			if err != nil {
+				return errors.Wrapf(err, "create download job: %s.%s", table.Keyspace, table.Table)
+			}
+
+			if err := w.waitJob(ctx, h, jobID, pollIntervalSec); err != nil {
+				return errors.Wrapf(err, "wait job: %s.%s", table.Keyspace, table.Table)
+			}
+
+			if err := w.refreshNode(ctx, table, h, repeatInterval); err != nil {
+				return errors.Wrapf(err, "refresh node: %s.%s", table.Keyspace, table.Table)
+			}
+		}
+
+		return nil
+	}, parallel.NopNotify)
+
+	return err
+}
+
+func (w *worker) createDownloadJob(ctx context.Context, table backupspec.FilesMeta, m *backupspec.ManifestInfo, h Host) (int64, error) {
+	uploadDir := backupspec.UploadTableDir(table.Keyspace, table.Table, table.Version)
+	remoteDir := m.LocationSSTableVersionDir(table.Keyspace, table.Table, table.Version)
+	jobID, err := w.client.RcloneCopyPaths(ctx, h.Addr, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, uploadDir, remoteDir, table.Files)
+	if err != nil {
+		return 0, errors.Wrapf(err, "copy dir: %s", m.LocationSSTableVersionDir(table.Keyspace, table.Table, table.Version))
+	}
+	return jobID, nil
+}
+
+// Scylla operation might take a really long (and difficult to estimate) time.
+// This func exits ONLY on: success, context cancel or non-timeout related error.
+func (w *worker) refreshNode(ctx context.Context, table backupspec.FilesMeta, h Host, repeatInterval time.Duration) error {
+	running, err := w.client.LoadSSTables(ctx, h.Addr, table.Keyspace, table.Table, false, false)
+	if running || errContains(err, "timeout") {
+		w.logger.Info(ctx, "Waiting for SSTables loading to finish",
+			"host", h,
+			"error", err,
+		)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(repeatInterval):
+		}
+		return w.refreshNode(ctx, table, h, repeatInterval)
+	}
+	return err
+}
+
+func errContains(err error, s string) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), s)
+}
+
+func (w *worker) waitJob(ctx context.Context, h Host, jobID int64, pollIntervalSec int) (err error) {
+	defer func() {
+		cleanCtx := context.Background()
+		// On error stop job
+		if err != nil {
+			w.stopJob(cleanCtx, jobID, h.Addr)
+		}
+		// On exit clear stats
+		w.clearJobStats(cleanCtx, jobID, h.Addr)
+	}()
+
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
+		job, err := w.client.RcloneJobProgress(ctx, h.Addr, jobID, pollIntervalSec)
+		if err != nil {
+			return errors.Wrap(err, "fetch job info")
+		}
+
+		switch scyllaclient.RcloneJobStatus(job.Status) {
+		case scyllaclient.JobError:
+			return errors.Errorf("job error (%d): %s: host %s", jobID, job.Error, h.Addr)
+		case scyllaclient.JobSuccess:
+			w.logger.Info(ctx, "Job done",
+				"job_id", jobID,
+				"host", h,
+				"took", time.Time(job.CompletedAt).Sub(time.Time(job.StartedAt)),
+			)
+			return nil
+		case scyllaclient.JobRunning:
+			continue
+		case scyllaclient.JobNotFound:
+			return errors.New("job not found")
+		}
+	}
+}
+
+func (w *worker) clearJobStats(ctx context.Context, jobID int64, host string) {
+	if err := w.client.RcloneDeleteJobStats(ctx, host, jobID); err != nil {
+		w.logger.Error(ctx, "Failed to clear job stats",
+			"host", host,
+			"id", jobID,
+			"error", err,
+		)
+	}
+}
+
+func (w *worker) stopJob(ctx context.Context, jobID int64, host string) {
+	if err := w.client.RcloneJobStop(ctx, host, jobID); err != nil {
+		w.logger.Error(ctx, "Failed to stop job",
+			"host", host,
+			"id", jobID,
+			"error", err,
+		)
+	}
+}

--- a/pkg/service/one2onerestore/worker_tables_test.go
+++ b/pkg/service/one2onerestore/worker_tables_test.go
@@ -1,0 +1,157 @@
+// Copyright (C) 2025 ScyllaDB
+
+package one2onerestore
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient/scyllaclienttest"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+)
+
+func TestWorkerRefreshNode(t *testing.T) {
+	testCases := []struct {
+		name            string
+		handler         http.Handler
+		contextProvider func() context.Context
+
+		expectedCalls int
+		expectedErr   bool
+	}{
+		{
+			name: "Everything works",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("OK"))
+			}),
+			contextProvider: context.Background,
+			expectedCalls:   1,
+		},
+		{
+			name: "Retries when Already in progress",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// This magic header is set by testHandler.
+				i := r.Header.Get("test-call-i")
+
+				if i == "1" {
+					w.WriteHeader(http.StatusInternalServerError)
+					w.Write([]byte(`{"message": "Already loading SSTables", "code": 500}`))
+					return
+				}
+				w.Write([]byte("OK"))
+
+			}),
+			contextProvider: context.Background,
+			expectedCalls:   2,
+		},
+		{
+			name: "Retries when timeout",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// This magic header is set by testHandler.
+				i := r.Header.Get("test-call-i")
+
+				if i == "1" {
+					w.WriteHeader(http.StatusRequestTimeout)
+					w.Write([]byte(`{"message": "timeout", "code": 408}`))
+					return
+				}
+				w.Write([]byte("OK"))
+
+			}),
+			contextProvider: context.Background,
+			expectedCalls:   2,
+		},
+		{
+			name: "Exit on ctx.Err",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(100 * time.Millisecond)
+				w.Write([]byte("OK"))
+
+			}),
+			contextProvider: func() context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+				_ = cancel
+				return ctx
+			},
+			expectedErr:   true,
+			expectedCalls: 1,
+		},
+		{
+			name: "Exit on unexpected err",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+				w.Write([]byte(`{"message": "wtf", "code": 418}`))
+			}),
+			contextProvider: context.Background,
+			expectedErr:     true,
+			expectedCalls:   1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			handler := &testHandler{Handler: tc.handler}
+			ts := httptest.NewServer(handler)
+			defer ts.Close()
+
+			tsAddr, err := url.Parse(ts.URL)
+			requireNoError(t, err)
+
+			w := &worker{
+				client: scyllaclienttest.MakeClient(t, tsAddr.Hostname(), tsAddr.Port()),
+			}
+
+			const repeatInterval = 1 * time.Second
+			err = w.refreshNode(tc.contextProvider(), backupspec.FilesMeta{}, Host{Addr: tsAddr.Hostname()}, repeatInterval)
+			if !tc.expectedErr {
+				requireNoError(t, err)
+			}
+			if tc.expectedErr {
+				requireError(t, err)
+			}
+			requireTrue(t,
+				tc.expectedCalls == handler.calls,
+				fmt.Sprintf("Expected %d calls, but got %d", tc.expectedCalls, handler.calls))
+		})
+	}
+}
+
+func requireNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	}
+}
+
+func requireError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("Expected err, but got nil")
+	}
+}
+
+func requireTrue(t *testing.T, b bool, msg string) {
+	t.Helper()
+	if !b {
+		t.Fatal(msg)
+	}
+}
+
+type testHandler struct {
+	http.Handler
+	// Keep track of how many times handler func has been called
+	// so we can test retries policy.
+	calls int
+}
+
+func (th *testHandler) ServeHTTP(w http.ResponseWriter, t *http.Request) {
+	th.calls++
+	t.Header.Add("test-call-i", fmt.Sprint(th.calls))
+	th.Handler.ServeHTTP(w, t)
+}


### PR DESCRIPTION
This adds copy data stage for the 1-1-restore with simple integration test (create backup, truncate tables, restore).
Data is copied by each node, table by table and after copy data dir job loadSStables is called.

Refs: #4202 #4203 


P.S. For now I've added 1-1-restore integration test under  `Test other, smaller packages` check as it small enough (run takes about 30s) and doesn't cover a lot of use cases.

Also this pr includes full support for `--keyspace` parameter (meaning you can filter tabels, use `!` and etc), but it will be changed in separate PR accordingly to #4253 

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
