### PR TITLE
feat(manager docker) switch to be based on ubi9-minimal

### DIFF
--- a/dist/.goreleaser-docker.yaml
+++ b/dist/.goreleaser-docker.yaml
@@ -29,8 +29,8 @@ dockers:
       - docker/scylla-manager.yaml
       - release/
     build_flag_templates:
-      - "--build-arg=ARCH=arm64"
-      - "--platform=linux/arm64"
+      - "--build-arg=ARCH=aarch64"
+      - "--platform=linux/aarch64"
 
   - ids:
     use: docker
@@ -56,8 +56,8 @@ dockers:
       - docker/scylla-manager.yaml
       - release
     build_flag_templates:
-      - "--build-arg=ARCH=arm64"
-      - "--platform=linux/arm64"
+      - "--build-arg=ARCH=aarch64"
+      - "--platform=linux/aarch64"
 
 docker_manifests:
   - id: scylla-manager

--- a/dist/docker/scylla-manager-agent.dockerfile
+++ b/dist/docker/scylla-manager-agent.dockerfile
@@ -1,15 +1,13 @@
-FROM ubuntu
-ARG ARCH=amd64
+FROM docker.io/redhat/ubi9-minimal:latest
+ARG ARCH=x86_64
 
-RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends ca-certificates && \
-    apt-get autoremove -y && \
-    apt-get clean && \
+RUN microdnf update && \
+    microdnf -y upgrade && \
+    microdnf install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-COPY release/scylla-manager-agent*$ARCH.deb /
-RUN dpkg -i scylla-manager-agent*$ARCH.deb && rm /scylla-manager-agent*.deb
+COPY release/scylla-manager-agent*$ARCH.rpm /
+RUN rpm -ivh scylla-manager-agent*$ARCH.rpm && rm /scylla-manager-agent*.rpm
 
 USER scylla-manager
 ENV HOME=/var/lib/scylla-manager/

--- a/dist/docker/scylla-manager.dockerfile
+++ b/dist/docker/scylla-manager.dockerfile
@@ -1,15 +1,13 @@
-FROM ubuntu
-ARG ARCH=amd64
+FROM docker.io/redhat/ubi9-minimal:latest
+ARG ARCH=x86_64
 
-RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get install -y --no-install-recommends ca-certificates && \
-    apt-get autoremove -y && \
-    apt-get clean && \
+RUN microdnf update && \
+    microdnf -y upgrade && \
+    microdnf install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*
 
-COPY release/scylla-manager-*$ARCH.deb /
-RUN dpkg -i scylla-manager-*$ARCH.deb && rm /scylla-manager-*.deb
+COPY release/scylla-manager-*$ARCH.rpm /
+RUN rpm -ivh scylla-manager-*$ARCH.rpm && rm /scylla-manager-*.rpm
 COPY docker/scylla-manager.yaml /etc/scylla-manager/
 
 USER scylla-manager


### PR DESCRIPTION
To achieve OpenShift certification for the Scylla-Operator, our Scylla Manager container images must be based on Red Hat's UBI images.

Fixes: https://github.com/scylladb/scylla-manager/issues/4242
