### PR TITLE
goreleaser: ignore backupspec/* tags

### DIFF
--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -2,6 +2,10 @@ project_name: scylla-manager
 dist: release
 version: 2
 
+git:
+  ignore_tags:
+    - "backupspec/*"
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
As per title name. 

Tag for submodule "backupspec" is added what creates the problem with goreleaser in one of the jenkins pipeline.
This PR is to just ignore this tag by goreleaser.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
