### PR TITLE
feat(1-1-restore): reduces --keyspace param features to keyspace level filtering only

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/scylladb/go-set v1.0.2
 	github.com/scylladb/gocqlx/v2 v2.8.0
-	github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250129134654-ad359657f571
+	github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250203113154-c0fcaa6e8380
 	github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250122142320-e1127475cc4c
 	github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250122142320-e1127475cc4c
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1062,8 +1062,8 @@ github.com/scylladb/google-api-go-client v0.34.1-patched h1:DW+T0HA+74o6FDr3TFzV
 github.com/scylladb/google-api-go-client v0.34.1-patched/go.mod h1:RriRmS2wJXH+2yd9PRTEcR380U9AXmurWwznqVhzsSc=
 github.com/scylladb/rclone v1.54.1-0.20240312172628-afe1fd2aa65e h1:lJRphCtu+nKd+mfo8whOTeFkgjMWvk8iCSlqgibKSa8=
 github.com/scylladb/rclone v1.54.1-0.20240312172628-afe1fd2aa65e/go.mod h1:JGZp4EvCUK+6AM1Fe1dye5xvihTc/Bk0WnHHSCJOePM=
-github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250129134654-ad359657f571 h1:oZihHS9xlhRbzOeQeFz0VlsD61mdh+arBfFS8i8YcKQ=
-github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250129134654-ad359657f571/go.mod h1:IUo0KL/TTqXUg8ur6sGhAc1jDDF8TBV6LYVTKB2AlIQ=
+github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250203113154-c0fcaa6e8380 h1:SZaDf3cR+3HreZ8ewQU3ai4KZBFo+FZTkKX1Z4lve1E=
+github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250203113154-c0fcaa6e8380/go.mod h1:IUo0KL/TTqXUg8ur6sGhAc1jDDF8TBV6LYVTKB2AlIQ=
 github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250122142320-e1127475cc4c h1:RLgSH0r/TI+Aw1f2bHUqnjVOI+8cOc9eX5Kr73N9Iuc=
 github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250122142320-e1127475cc4c/go.mod h1:VKqHSrDj9zfgCKilpbdpmqV1TjmSglt/df79eIg6wuI=
 github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250122142320-e1127475cc4c h1:1qkWdf5FbOwW3iE712s7mwOFSHaTRf9vlZ1LW+HDmVE=

--- a/pkg/service/one2onerestore/model_test.go
+++ b/pkg/service/one2onerestore/model_test.go
@@ -124,42 +124,54 @@ func TestValidateNodesMapping(t *testing.T) {
 
 func TestValidateKeyspaceFilter(t *testing.T) {
 	testCases := []struct {
-		name        string
-		keyspace    []string
-		expectedErr string
+		name           string
+		keyspaceFilter []string
+		keyspaces      []string
+		expectedErr    string
 	}{
 		{
-			name:     "Only keyspace level filtering",
-			keyspace: []string{"hello", "system"},
+			name:           "Only keyspace level filtering",
+			keyspaceFilter: []string{"hello", "system"},
+			keyspaces:      []string{"system", "hello", "world"},
 		},
 		{
-			name:        "Include all * is supported (default)",
-			keyspace:    []string{"*"},
-			expectedErr: "",
+			name:           "Include all * is supported (default)",
+			keyspaceFilter: []string{"*"},
+			keyspaces:      []string{"hello", "world"},
+			expectedErr:    "",
 		},
 		{
-			name:        "Wildcard patterns are not supported",
-			keyspace:    []string{"hello*"},
-			expectedErr: "wildcard pattern(*) is not supported: hello*",
+			name:           "Wildcard patterns are not supported",
+			keyspaceFilter: []string{"hello*"},
+			keyspaces:      []string{"hello", "helloworld"},
+			expectedErr:    "only existing keyspaces can be provided, but got: hello*",
 		},
 		{
-			name:        "Wildcard patterns are not supported2",
-			keyspace:    []string{"*", "hi"},
-			expectedErr: "wildcard pattern(*) is not supported: *",
+			name:           "Wildcard patterns are not supported2",
+			keyspaceFilter: []string{"*", "hi"},
+			keyspaces:      []string{"hi", "hey"},
+			expectedErr:    "only existing keyspaces can be provided, but got: *",
 		},
 		{
-			name:        "Table level is not allowed",
-			keyspace:    []string{"hello", "system.table"},
-			expectedErr: "only keyspace level filtering is allowed, but table is provided: system.table",
+			name:           "Table level is not allowed",
+			keyspaceFilter: []string{"hello", "system.table"},
+			keyspaces:      []string{"hello", "system"},
+			expectedErr:    "only existing keyspaces can be provided, but got: system.table",
 		},
 		{
-			name:        "Exclude filters are not supported",
-			keyspace:    []string{"hello", "!world"},
-			expectedErr: "exclude filter(!) is not supported: !world",
+			name:           "Exclude filters are not supported",
+			keyspaceFilter: []string{"hello", "!world"},
+			keyspaces:      []string{"hello", "world"},
+			expectedErr:    "only existing keyspaces can be provided, but got: !world",
 		},
 		{
-			name:     "Empty(nil) filters",
-			keyspace: nil,
+			name:           "Alternator keyspaces are supported",
+			keyspaceFilter: []string{"alternator_Tab_le-With1.da_sh2-aNd.d33ot.-"},
+			keyspaces:      []string{"hello", "alternator_Tab_le-With1.da_sh2-aNd.d33ot.-"},
+		},
+		{
+			name:           "Empty(nil) filters",
+			keyspaceFilter: nil,
 		},
 	}
 
@@ -171,7 +183,7 @@ func TestValidateKeyspaceFilter(t *testing.T) {
 			return err.Error()
 		}
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateKeyspaceFilter(tc.keyspace)
+			err := validateKeyspaceFilter(tc.keyspaceFilter, tc.keyspaces)
 			if errMsg(err) != tc.expectedErr {
 				t.Fatalf("Expected err %q, but got %q", tc.expectedErr, errMsg(err))
 			}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -401,7 +401,7 @@ github.com/scylladb/gocqlx/v2/dbutil
 github.com/scylladb/gocqlx/v2/migrate
 github.com/scylladb/gocqlx/v2/qb
 github.com/scylladb/gocqlx/v2/table
-# github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250129134654-ad359657f571
+# github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250203113154-c0fcaa6e8380
 ## explicit; go 1.23.2
 github.com/scylladb/scylla-manager/v3/pkg/managerclient
 github.com/scylladb/scylla-manager/v3/pkg/managerclient/table


### PR DESCRIPTION
This reduces functionality of `--keyspace` parameter to support only:
 - keyspace level filtering. Table level filtering (system.table_name) is forbidden.
 - only include filtering. Excluding(!) is forbidden.
 - wildcards (\*) are forbidden. The only exception is when the only filter that is provided is a single character (*), meaning that all keyspaces should be included into restore process - it's a default value if `--keyspace` is not provided.

Refs: #4253

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
