### PR TITLE
feat(1-1-restore): adds support for views

### DIFF
--- a/pkg/service/one2onerestore/model.go
+++ b/pkg/service/one2onerestore/model.go
@@ -41,6 +41,32 @@ type Host struct {
 	Addr string
 }
 
+// ViewType either Materialized View or Secondary Index.
+type ViewType string
+
+// ViewType enumeration.
+const (
+	MaterializedView ViewType = "MaterializedView"
+	SecondaryIndex   ViewType = "SecondaryIndex"
+)
+
+// View represents statement used for recreating restored (dropped) views.
+type View struct {
+	Keyspace   string   `json:"keyspace" db:"keyspace_name"`
+	View       string   `json:"view" db:"view_name"`
+	Type       ViewType `json:"type" db:"view_type"`
+	BaseTable  string   `json:"base_table"`
+	CreateStmt string   `json:"create_stmt"`
+}
+
+// hostWorkload represents what data (manifest) from the backup should be handled
+// by which node (host) in the target cluster.
+type hostWorkload struct {
+	host            Host
+	manifestInfo    *ManifestInfo
+	manifestContent *ManifestContentWithIndex
+}
+
 func (t *Target) validateProperties() error {
 	if len(t.Location) == 0 {
 		return errors.New("missing location")

--- a/pkg/service/one2onerestore/service.go
+++ b/pkg/service/one2onerestore/service.go
@@ -87,8 +87,13 @@ func (s *Service) One2OneRestore(ctx context.Context, clusterID, taskID, runID u
 	}
 	s.logger.Info(ctx, "Can proceed with 1-1-restore")
 
+	workload, err := w.prepareHostWorkload(ctx, manifests, hosts, target.NodesMapping)
+	if err != nil {
+		return errors.Wrap(err, "prepare hosts workload")
+	}
+
 	start := timeutc.Now()
-	if err := w.restoreTables(ctx, manifests, hosts, target.NodesMapping, target.Keyspace); err != nil {
+	if err := w.restore(ctx, workload, target); err != nil {
 		return errors.Wrap(err, "restore data")
 	}
 	s.logger.Info(ctx, "Data restore is completed", "took", timeutc.Since(start))

--- a/pkg/service/one2onerestore/worker.go
+++ b/pkg/service/one2onerestore/worker.go
@@ -4,12 +4,16 @@ package one2onerestore
 
 import (
 	"context"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
 )
 
 type worker struct {
@@ -19,6 +23,21 @@ type worker struct {
 	clusterSession gocqlx.Session
 
 	logger log.Logger
+}
+
+// restore is an actual 1-1-restore stages.
+func (w *worker) restore(ctx context.Context, workload []hostWorkload, target Target) (err error) {
+	views, err := w.dropViews(ctx, workload, target.Keyspace)
+	if err != nil {
+		return errors.Wrap(err, "drop views")
+	}
+	defer func() {
+		if rErr := w.reCreateViews(ctx, views); rErr != nil {
+			err = errors.Wrap(rErr, "recreate views")
+		}
+	}()
+
+	return w.restoreTables(ctx, workload, target.Keyspace)
 }
 
 // getAllSnapshotManifestsAndTargetHosts gets backup(source) cluster node represented by manifests and target cluster nodes.
@@ -78,4 +97,56 @@ func nodesToHosts(nodes scyllaclient.NodeStatusInfoSlice) []Host {
 		})
 	}
 	return hosts
+}
+
+// prepareHostWorkload is a helper function that creates a hostWorkload structure convenient for use in later 1-1-restore stages.
+// This avoids the need to repeat operations like node mapping and fetching manifest content.
+func (w *worker) prepareHostWorkload(ctx context.Context, manifests []*backupspec.ManifestInfo, hosts []Host, nodeMappings []nodeMapping) ([]hostWorkload, error) {
+	targetBySourceHostID, err := mapTargetHostToSource(hosts, nodeMappings)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid node mapping")
+	}
+
+	result := make([]hostWorkload, len(manifests))
+	return result, parallel.Run(len(manifests), len(manifests), func(i int) error {
+		m := manifests[i]
+		h := targetBySourceHostID[m.NodeID]
+
+		mc, err := w.getManifestContent(ctx, h.Addr, m)
+		if err != nil {
+			return errors.Wrap(err, "manifest content")
+		}
+		result[i] = hostWorkload{
+			host:            h,
+			manifestInfo:    m,
+			manifestContent: mc,
+		}
+
+		return nil
+	}, parallel.NopNotify)
+}
+
+// alterSchemaRetryWrapper is useful when executing many statements altering schema,
+// as it might take more time for Scylla to process them one after another.
+// This wrapper exits on: success, context cancel, op returned non-timeout error or after maxTotalTime has passed.
+func alterSchemaRetryWrapper(ctx context.Context, op func() error, notify func(err error, wait time.Duration)) error {
+	const (
+		minWait      = 5 * time.Second
+		maxWait      = 1 * time.Minute
+		maxTotalTime = 15 * time.Minute
+		multiplier   = 2
+		jitter       = 0.2
+	)
+	backoff := retry.NewExponentialBackoff(minWait, maxTotalTime, maxWait, multiplier, jitter)
+
+	wrappedOp := func() error {
+		err := op()
+		if err == nil || strings.Contains(err.Error(), "timeout") {
+			return err
+		}
+		// All non-timeout errors shouldn't be retried
+		return retry.Permanent(err)
+	}
+
+	return retry.WithNotify(ctx, wrappedOp, backoff, notify)
 }

--- a/pkg/service/one2onerestore/worker.go
+++ b/pkg/service/one2onerestore/worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
+	"go.uber.org/multierr"
 )
 
 type worker struct {
@@ -33,7 +34,10 @@ func (w *worker) restore(ctx context.Context, workload []hostWorkload, target Ta
 	}
 	defer func() {
 		if rErr := w.reCreateViews(ctx, views); rErr != nil {
-			err = errors.Wrap(rErr, "recreate views")
+			err = multierr.Combine(
+				err,
+				errors.Wrap(rErr, "recreate views"),
+			)
 		}
 	}()
 

--- a/pkg/service/one2onerestore/worker_views.go
+++ b/pkg/service/one2onerestore/worker_views.go
@@ -1,0 +1,252 @@
+// Copyright (C) 2025 ScyllaDB
+
+package one2onerestore
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/pkg/errors"
+	"github.com/scylladb/go-set/strset"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
+)
+
+// dropsViews drops all Materialized View or Secondary Index which base tables are exists in the backup and returns
+// what was dropped, so it can be re-created using worker.reCreateViews.
+func (w *worker) dropViews(ctx context.Context, workload []hostWorkload, keyspaceFilter []string) ([]View, error) {
+	start := timeutc.Now()
+	defer func() {
+		w.logger.Info(ctx, "Drop views", "took", timeutc.Since(start))
+	}()
+
+	tablesToRestore := strset.New()
+	for _, wl := range workload {
+		err := wl.manifestContent.ForEachIndexIter(keyspaceFilter, func(fm backupspec.FilesMeta) {
+			tablesToRestore.Add(fm.Keyspace + "." + fm.Table)
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "manifest content files")
+		}
+	}
+
+	views, err := w.getViews(ctx, tablesToRestore)
+	if err != nil {
+		return nil, errors.Wrap(err, "get views")
+	}
+
+	for _, view := range views {
+		if err := w.dropView(ctx, view); err != nil {
+			return nil, errors.Wrap(err, "drop view")
+		}
+	}
+
+	return views, nil
+}
+
+func (w *worker) dropView(ctx context.Context, view View) error {
+	w.logger.Info(ctx, "Dropping view",
+		"keyspace", view.Keyspace,
+		"view", view.View,
+		"type", view.Type,
+	)
+
+	op := func() error {
+		dropStmt := ""
+		switch view.Type {
+		case SecondaryIndex:
+			dropStmt = "DROP INDEX IF EXISTS %q.%q"
+		case MaterializedView:
+			dropStmt = "DROP MATERIALIZED VIEW IF EXISTS %q.%q"
+		}
+
+		return w.clusterSession.ExecStmt(fmt.Sprintf(dropStmt, view.Keyspace, view.View))
+	}
+
+	notify := func(err error, wait time.Duration) {
+		w.logger.Info(ctx, "Dropping view failed",
+			"keyspace", view.Keyspace,
+			"view", view.View,
+			"type", view.Type,
+			"error", err,
+			"wait", wait,
+		)
+	}
+
+	return alterSchemaRetryWrapper(ctx, op, notify)
+}
+
+func (w *worker) getViews(ctx context.Context, tablesToRestore *strset.Set) ([]View, error) {
+	keyspaces, err := w.client.Keyspaces(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "get keyspaces")
+	}
+
+	var views []View
+	for _, ks := range keyspaces {
+		meta, err := w.clusterSession.KeyspaceMetadata(ks)
+		if err != nil {
+			return nil, errors.Wrapf(err, "get keyspace %s metadata", ks)
+		}
+
+		for _, index := range meta.Indexes {
+			if !tablesToRestore.Has(index.KeyspaceName + "." + index.TableName) {
+				continue
+			}
+			dummyMeta := gocql.KeyspaceMetadata{
+				Indexes: map[string]*gocql.IndexMetadata{index.Name: index},
+			}
+
+			schema, err := dummyMeta.ToCQL()
+			if err != nil {
+				return nil, errors.Wrapf(err, "get index %s.%s create statement", ks, index.Name)
+			}
+
+			// DummyMeta schema consists of create keyspace and create view statements
+			stmt := strings.Split(schema, ";")[1]
+			stmt, err = addIfNotExists(stmt, SecondaryIndex)
+			if err != nil {
+				return nil, err
+			}
+
+			views = append(views, View{
+				Keyspace:   index.KeyspaceName,
+				View:       index.Name,
+				Type:       SecondaryIndex,
+				BaseTable:  index.TableName,
+				CreateStmt: stmt,
+			})
+		}
+
+		for _, view := range meta.Views {
+			if !tablesToRestore.Has(view.KeyspaceName + "." + view.BaseTableName) {
+				continue
+			}
+			dummyMeta := gocql.KeyspaceMetadata{
+				Views: map[string]*gocql.ViewMetadata{view.ViewName: view},
+			}
+
+			schema, err := dummyMeta.ToCQL()
+			if err != nil {
+				return nil, errors.Wrapf(err, "get view %s.%s create statement", ks, view.ViewName)
+			}
+
+			// DummyMeta schema consists of create keyspace and create view statements
+			stmt := strings.Split(schema, ";")[1]
+			stmt, err = addIfNotExists(stmt, MaterializedView)
+			if err != nil {
+				return nil, err
+			}
+
+			views = append(views, View{
+				Keyspace:   view.KeyspaceName,
+				View:       view.ViewName,
+				Type:       MaterializedView,
+				BaseTable:  view.BaseTableName,
+				CreateStmt: stmt,
+			})
+		}
+	}
+
+	return views, nil
+}
+
+var (
+	regexMV = regexp.MustCompile(`CREATE\s*MATERIALIZED\s*VIEW`)
+	regexSI = regexp.MustCompile(`CREATE\s*INDEX`)
+)
+
+// create stmt has to contain "IF NOT EXISTS" clause as we have to be able to resume restore from any point.
+func addIfNotExists(stmt string, t ViewType) (string, error) {
+	var loc []int
+	switch t {
+	case MaterializedView:
+		loc = regexMV.FindStringIndex(stmt)
+	case SecondaryIndex:
+		loc = regexSI.FindStringIndex(stmt)
+	}
+	if loc == nil {
+		return "", fmt.Errorf("unknown create view statement %s", stmt)
+	}
+
+	return stmt[loc[0]:loc[1]] + " IF NOT EXISTS" + stmt[loc[1]:], nil
+}
+
+// reCreateViews re-creates views (materialized views or secondary indexes).
+func (w *worker) reCreateViews(ctx context.Context, views []View) error {
+	start := timeutc.Now()
+	defer func() {
+		w.logger.Info(ctx, "Re-create views", "took", timeutc.Since(start))
+	}()
+	for _, view := range views {
+		if err := w.createView(ctx, view); err != nil {
+			return errors.Wrap(err, "create view")
+		}
+		if err := w.waitForViewBuilding(ctx, view); err != nil {
+			return errors.Wrap(err, "wait for view")
+		}
+	}
+	return nil
+}
+
+// createView creates specified Materialized View or Secondary Index.
+func (w *worker) createView(ctx context.Context, view View) error {
+	w.logger.Info(ctx, "Creating view",
+		"keyspace", view.Keyspace,
+		"view", view.View,
+		"type", view.Type,
+		"statement", view.CreateStmt,
+	)
+
+	op := func() error {
+		return w.clusterSession.ExecStmt(view.CreateStmt)
+	}
+
+	notify := func(err error, wait time.Duration) {
+		w.logger.Info(ctx, "Creating view failed",
+			"keyspace", view.Keyspace,
+			"view", view.View,
+			"type", view.Type,
+			"error", err,
+			"wait", wait,
+		)
+	}
+
+	return alterSchemaRetryWrapper(ctx, op, notify)
+}
+
+// Scylla operation might take a really long (and difficult to estimate) time.
+// This func exits ONLY on: success, context cancel or error.
+func (w *worker) waitForViewBuilding(ctx context.Context, view View) error {
+	viewTableName := view.View
+	if view.Type == SecondaryIndex {
+		viewTableName += "_index"
+	}
+
+	status, err := w.client.ViewBuildStatus(ctx, view.Keyspace, viewTableName)
+	if err != nil {
+		return err
+	}
+
+	if status == scyllaclient.StatusUnknown || status == scyllaclient.StatusStarted {
+		w.logger.Info(ctx, "Waiting for view",
+			"keyspace", view.Keyspace,
+			"view", view.View,
+			"type", view.Type,
+			"status", status,
+		)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Second):
+		}
+		return w.waitForViewBuilding(ctx, view)
+	}
+
+	return nil
+}

--- a/pkg/service/one2onerestore/worker_views_test.go
+++ b/pkg/service/one2onerestore/worker_views_test.go
@@ -1,0 +1,211 @@
+// Copyright (C) 2025 ScyllaDB
+
+package one2onerestore
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient/scyllaclienttest"
+)
+
+func TestAddIfNotExists(t *testing.T) {
+	testCases := []struct {
+		name         string
+		viewType     ViewType
+		stmt         string
+		expectedStmt string
+		expectedErr  bool
+	}{
+		{
+			name:     "Modifies MaterializedView stmt",
+			viewType: MaterializedView,
+			stmt: `CREATE MATERIALIZED VIEW ks.mv AS SELECT a,b FROM ks.t 
+				WHERE b is NOT NULL 
+				PRIMARY KEY(b);`,
+			expectedStmt: `CREATE MATERIALIZED VIEW IF NOT EXISTS ks.mv AS SELECT a,b FROM ks.t 
+				WHERE b is NOT NULL 
+				PRIMARY KEY(b);`,
+			expectedErr: false,
+		},
+		{
+			name:         "Modifies Secondary Index stmt",
+			viewType:     SecondaryIndex,
+			stmt:         `CREATE INDEX buildings_by_city ON buildings (city);`,
+			expectedStmt: `CREATE INDEX IF NOT EXISTS buildings_by_city ON buildings (city);`,
+			expectedErr:  false,
+		},
+		{
+			name:     "Wrong view type, SecondaryIndex instead of MaterializedView",
+			viewType: SecondaryIndex,
+			stmt: `CREATE MATERIALIZED VIEW ks.mv AS SELECT a,b FROM ks.t 
+				WHERE b is NOT NULL 
+				PRIMARY KEY(b);`,
+			expectedErr: true,
+		},
+		{
+			name:        "Wrong view type, MaterializedView instead of SecondaryIndex",
+			viewType:    MaterializedView,
+			stmt:        `CREATE INDEX buildings_by_city ON buildings (city);`,
+			expectedErr: true,
+		},
+		{
+			name:     "Unknown view type",
+			viewType: "Hello",
+			stmt: `CREATE MATERIALIZED VIEW ks.mv AS SELECT a,b FROM ks.t 
+				WHERE b is NOT NULL 
+				PRIMARY KEY(b);`,
+			expectedErr: true,
+		},
+		{
+			name:        "Unknown statement",
+			viewType:    SecondaryIndex,
+			stmt:        "Hello world",
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := addIfNotExists(tc.stmt, tc.viewType)
+			if err != nil && !tc.expectedErr {
+				t.Fatalf("Unexpected err: %v", err)
+			}
+			if err == nil && tc.expectedErr {
+				t.Fatalf("Expected err, but got nil")
+			}
+
+			if actual != tc.expectedStmt {
+				t.Fatalf("Actual != Expected: %q != %q", actual, tc.expectedStmt)
+			}
+		})
+	}
+}
+
+func TestWaitForViewBuilding(t *testing.T) {
+	testCases := []struct {
+		name            string
+		view            View
+		handler         http.HandlerFunc
+		contextProvider func() context.Context
+		expectedCalls   int32
+		expectedErr     bool
+	}{
+		{
+			name: "Everything is fine",
+			view: View{
+				Keyspace: "ks",
+				View:     "mv",
+				Type:     MaterializedView,
+			},
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(`[{"value":"SUCCESS"}]`))
+			}),
+			contextProvider: context.Background,
+			expectedCalls:   1,
+			expectedErr:     false,
+		},
+		{
+			name: "Retries when not SUCCESS",
+			view: View{
+				Keyspace: "ks",
+				View:     "mv",
+				Type:     MaterializedView,
+			},
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// This magic header is set by testHandler.
+				i := r.Header.Get("test-call-i")
+				if i == "1" {
+					w.Write([]byte(`[{"value":"STARTED"}]`))
+					return
+				}
+
+				w.Write([]byte(`[{"value":"SUCCESS"}]`))
+			}),
+			contextProvider: context.Background,
+			expectedCalls:   2,
+			expectedErr:     false,
+		},
+		{
+			name: "Exit on context cancel",
+			view: View{
+				Keyspace: "ks",
+				View:     "mv",
+				Type:     MaterializedView,
+			},
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				time.Sleep(100 * time.Millisecond)
+				w.Write([]byte(`[{"value":"SUCCESS"}]`))
+			}),
+			contextProvider: func() context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+				_ = cancel
+				return ctx
+			},
+			expectedErr:   true,
+			expectedCalls: 1,
+		},
+		{
+			name: "Exit on error",
+			view: View{
+				Keyspace: "ks",
+				View:     "mv",
+				Type:     MaterializedView,
+			},
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+				w.Write([]byte(`{"message": "wtf", "code": 418}`))
+			}),
+			contextProvider: context.Background,
+			expectedErr:     true,
+			expectedCalls:   1,
+		},
+		{
+			name: "Exit on timeout",
+			view: View{
+				Keyspace: "ks",
+				View:     "mv",
+				Type:     MaterializedView,
+			},
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusRequestTimeout)
+				w.Write([]byte(`{"message": "timeout", "code": 408}`))
+			}),
+			contextProvider: context.Background,
+			expectedErr:     true,
+			expectedCalls:   1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			handler := &testHandler{Handler: tc.handler}
+			ts := httptest.NewServer(handler)
+			defer ts.Close()
+
+			tsAddr, err := url.Parse(ts.URL)
+			if err != nil {
+				t.Fatalf("Unexpected err: %v", err)
+			}
+
+			w := &worker{
+				client: scyllaclienttest.MakeClient(t, tsAddr.Hostname(), tsAddr.Port()),
+			}
+			err = w.waitForViewBuilding(tc.contextProvider(), tc.view)
+			if err != nil && !tc.expectedErr {
+				t.Fatalf("Unexpected err: %v", err)
+			}
+			if err == nil && tc.expectedErr {
+				t.Fatalf("Expected err, but got nil")
+			}
+			if tc.expectedCalls != handler.calls.Load() {
+				t.Fatalf("Expected %d calls, but got %d", tc.expectedCalls, handler.calls.Load())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds support for restoring views in 1-1-restore. Views should be dropped before copy data stage and then re-created to avoid data inconsistency between base table and view.
Integration test extended with MaterializedView. 

Refs: #4252

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
