### PR TITLE
feat(1-1-restore): sets tombstone_gc mode to repair 

### DIFF
--- a/pkg/service/one2onerestore/model.go
+++ b/pkg/service/one2onerestore/model.go
@@ -66,6 +66,20 @@ type hostWorkload struct {
 	host            Host
 	manifestInfo    *ManifestInfo
 	manifestContent *ManifestContentWithIndex
+
+	tablesToRestore []scyllaTable
+}
+
+type scyllaTable struct{ keyspace, table string }
+
+func getTablesToRestore(workload []hostWorkload) map[scyllaTable]struct{} {
+	tablesToRestore := map[scyllaTable]struct{}{}
+	for _, wl := range workload {
+		for _, table := range wl.tablesToRestore {
+			tablesToRestore[table] = struct{}{}
+		}
+	}
+	return tablesToRestore
 }
 
 func (t *Target) validateProperties(keyspaces []string) error {

--- a/pkg/service/one2onerestore/service.go
+++ b/pkg/service/one2onerestore/service.go
@@ -87,7 +87,7 @@ func (s *Service) One2OneRestore(ctx context.Context, clusterID, taskID, runID u
 	}
 	s.logger.Info(ctx, "Can proceed with 1-1-restore")
 
-	workload, err := w.prepareHostWorkload(ctx, manifests, hosts, target.NodesMapping)
+	workload, err := w.prepareHostWorkload(ctx, manifests, hosts, target)
 	if err != nil {
 		return errors.Wrap(err, "prepare hosts workload")
 	}

--- a/pkg/service/one2onerestore/worker.go
+++ b/pkg/service/one2onerestore/worker.go
@@ -54,6 +54,10 @@ func (w *worker) parseTarget(ctx context.Context, properties json.RawMessage) (T
 
 // restore is an actual 1-1-restore stages.
 func (w *worker) restore(ctx context.Context, workload []hostWorkload, target Target) (err error) {
+	if err := w.setTombstoneGCModeRepair(ctx, workload, target.Keyspace); err != nil {
+		return errors.Wrap(err, "tombstone_gc mode")
+	}
+
 	views, err := w.dropViews(ctx, workload, target.Keyspace)
 	if err != nil {
 		return errors.Wrap(err, "drop views")

--- a/pkg/service/one2onerestore/worker.go
+++ b/pkg/service/one2onerestore/worker.go
@@ -5,6 +5,8 @@ package one2onerestore
 import (
 	"context"
 	"encoding/json"
+	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -14,7 +16,9 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/query"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/version"
 	"go.uber.org/multierr"
 )
 
@@ -39,6 +43,12 @@ func (w *worker) parseTarget(ctx context.Context, properties json.RawMessage) (T
 	if err := target.validateProperties(keyspaces); err != nil {
 		return Target{}, errors.Wrap(err, "invalid target")
 	}
+	skip, err := skipRestorePatterns(ctx, w.client, w.clusterSession)
+	if err != nil {
+		return Target{}, errors.Wrap(err, "skip restore patterns")
+	}
+	w.logger.Info(ctx, "Extended excluded tables pattern", "pattern", skip)
+	target.Keyspace = append(target.Keyspace, skip...)
 	return target, nil
 }
 
@@ -169,4 +179,111 @@ func alterSchemaRetryWrapper(ctx context.Context, op func() error, notify func(e
 	}
 
 	return retry.WithNotify(ctx, wrappedOp, backoff, notify)
+}
+
+func skipRestorePatterns(ctx context.Context, client *scyllaclient.Client, session gocqlx.Session) ([]string, error) {
+	keyspaces, err := client.KeyspacesByType(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "get keyspaces by type")
+	}
+	tables, err := client.AllTables(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "get all tables")
+	}
+
+	var skip []string
+	// Skip local data.
+	// Note that this also covers the raft based tables (e.g. system and system_schema).
+	for _, ks := range keyspaces[scyllaclient.KeyspaceTypeAll] {
+		if !slices.Contains(keyspaces[scyllaclient.KeyspaceTypeNonLocal], ks) {
+			skip = append(skip, ks)
+		}
+	}
+
+	// Skip outdated tables.
+	// Note that even though system_auth is not used in Scylla 6.0,
+	// it might still be present there (leftover after upgrade).
+	// That's why SM should always skip known outdated tables so that backups
+	// from older Scylla versions don't cause unexpected problems.
+	if err := isRestoreAuthAndServiceLevelsFromSStablesSupported(ctx, client); err != nil {
+		if errors.Is(err, errRestoreAuthAndServiceLevelsUnsupportedScyllaVersion) {
+			skip = append(skip, "system_auth", "system_distributed.service_levels")
+		} else {
+			return nil, errors.Wrap(err, "check auth and service levels restore support")
+		}
+	}
+
+	// Skip system cdc tables
+	systemCDCTableRegex := regexp.MustCompile(`(^|_)cdc(_|$)`)
+	for ks, tabs := range tables {
+		// Local keyspaces were already excluded
+		if !slices.Contains(keyspaces[scyllaclient.KeyspaceTypeNonLocal], ks) {
+			continue
+		}
+		// Here we only skip system cdc tables
+		if slices.Contains(keyspaces[scyllaclient.KeyspaceTypeUser], ks) {
+			continue
+		}
+		for _, t := range tabs {
+			if systemCDCTableRegex.MatchString(t) {
+				skip = append(skip, ks+"."+t)
+			}
+		}
+	}
+
+	// Skip user cdc tables
+	skip = append(skip, "*.*_scylla_cdc_log")
+
+	// Skip views
+	views, err := query.GetAllViews(session)
+	if err != nil {
+		return nil, errors.Wrap(err, "get cluster views")
+	}
+	skip = append(skip, views.List()...)
+
+	// Exclude collected patterns
+	out := make([]string, 0, len(skip))
+	for _, p := range skip {
+		out = append(out, "!"+p)
+	}
+	return out, nil
+}
+
+// errRestoreAuthAndServiceLevelsUnsupportedScyllaVersion means that restore auth and service levels procedure is not safe for used Scylla configuration.
+var errRestoreAuthAndServiceLevelsUnsupportedScyllaVersion = errors.Errorf("restoring authentication and service levels is not supported for given ScyllaDB version")
+
+// isRestoreAuthAndServiceLevelsFromSStablesSupported checks if restore auth and service levels procedure is supported for used Scylla configuration.
+// Because of #3869 and #3875, there is no way fo SM to safely restore auth and service levels into cluster with
+// version higher or equal to OSS 6.0 or ENT 2024.2.
+func isRestoreAuthAndServiceLevelsFromSStablesSupported(ctx context.Context, client *scyllaclient.Client) error {
+	const (
+		ossConstraint = ">= 6.0, < 2000"
+		entConstraint = ">= 2024.2, > 1000"
+	)
+
+	status, err := client.Status(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get status")
+	}
+	for _, n := range status {
+		ni, err := client.NodeInfo(ctx, n.Addr)
+		if err != nil {
+			return errors.Wrapf(err, "get node %s info", n.Addr)
+		}
+
+		ossNotSupported, err := version.CheckConstraint(ni.ScyllaVersion, ossConstraint)
+		if err != nil {
+			return errors.Wrapf(err, "check version constraint for %s", n.Addr)
+		}
+		entNotSupported, err := version.CheckConstraint(ni.ScyllaVersion, entConstraint)
+		if err != nil {
+			return errors.Wrapf(err, "check version constraint for %s", n.Addr)
+		}
+
+		if ossNotSupported || entNotSupported {
+			return errRestoreAuthAndServiceLevelsUnsupportedScyllaVersion
+		}
+	}
+
+	return nil
 }

--- a/pkg/service/one2onerestore/worker_tgc.go
+++ b/pkg/service/one2onerestore/worker_tgc.go
@@ -1,0 +1,181 @@
+// Copyright (C) 2025 ScyllaDB
+
+package one2onerestore
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/go-set/strset"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
+
+	"github.com/scylladb/gocqlx/v2"
+	"github.com/scylladb/gocqlx/v2/qb"
+)
+
+// Docs: https://docs.scylladb.com/stable/cql/ddl.html#tombstones-gc-options.
+type tombstoneGCMode string
+
+const (
+	modeDisabled  tombstoneGCMode = "disabled"
+	modeTimeout   tombstoneGCMode = "timeout"
+	modeRepair    tombstoneGCMode = "repair"
+	modeImmediate tombstoneGCMode = "immediate"
+)
+
+// setTombstoneGCModeRepair sets tombstone gc mode to repair to avoid data resurrection issues during restore.
+func (w *worker) setTombstoneGCModeRepair(ctx context.Context, workload []hostWorkload, keyspaceFilter []string) error {
+	w.awaitSchemaAgreement(ctx, w.clusterSession)
+
+	type backupTable struct {
+		keyspace, table string
+	}
+
+	tablesToRestore := map[backupTable]struct{}{}
+
+	for _, wl := range workload {
+		err := wl.manifestContent.ForEachIndexIter(keyspaceFilter, func(fm backupspec.FilesMeta) {
+			tablesToRestore[backupTable{keyspace: fm.Keyspace, table: fm.Table}] = struct{}{}
+		})
+		if err != nil {
+			return errors.Wrap(err, "manifest content files")
+		}
+	}
+
+	for table := range tablesToRestore {
+		mode, err := w.getTableTombstoneGCMode(table.keyspace, table.table)
+		if err != nil {
+			return errors.Wrap(err, "get tombstone_gc mode")
+		}
+		// No need to change tombstone gc mode.
+		if mode == modeDisabled || mode == modeImmediate || mode == modeRepair {
+			w.logger.Info(ctx, "Skipping set tombstone_gc mode", "table", table, "mode", mode)
+			continue
+		}
+		if err := w.setTableTombstoneGCMode(ctx, table.keyspace, table.table, modeRepair); err != nil {
+			return errors.Wrap(err, "set tombstone_gc mode repair")
+		}
+	}
+
+	return nil
+}
+
+// getTableTombstoneGCMode returns table's tombstone_gc mode.
+func (w *worker) getTableTombstoneGCMode(keyspace, table string) (tombstoneGCMode, error) {
+	var ext map[string]string
+	q := qb.Select("system_schema.tables").
+		Columns("extensions").
+		Where(qb.Eq("keyspace_name"), qb.Eq("table_name")).
+		Query(w.clusterSession).
+		Bind(keyspace, table)
+
+	defer q.Release()
+	err := q.Scan(&ext)
+	if err != nil {
+		return "", err
+	}
+
+	// Timeout (just using gc_grace_seconds) is the default mode
+	mode, ok := ext["tombstone_gc"]
+	if !ok {
+		return modeTimeout, nil
+	}
+
+	allModes := []tombstoneGCMode{modeDisabled, modeTimeout, modeRepair, modeImmediate}
+	for _, m := range allModes {
+		if strings.Contains(mode, string(m)) {
+			return m, nil
+		}
+	}
+	return "", errors.Errorf("unrecognized tombstone_gc mode: %s", mode)
+}
+
+// setTableTombstoneGCMode alters 'tombstone_gc' mode.
+func (w *worker) setTableTombstoneGCMode(ctx context.Context, keyspace, table string, mode tombstoneGCMode) error {
+	w.logger.Info(ctx, "Alter table's tombstone_gc mode",
+		"keyspace", keyspace,
+		"table", table,
+	)
+
+	op := func() error {
+		return w.clusterSession.ExecStmt(alterTableTombstoneGCStmt(keyspace, table, mode))
+	}
+
+	notify := func(err error, wait time.Duration) {
+		w.logger.Info(ctx, "Altering table's tombstone_gc mode failed",
+			"keyspace", keyspace,
+			"table", table,
+			"error", err,
+			"wait", wait,
+		)
+	}
+
+	return alterSchemaRetryWrapper(ctx, op, notify)
+}
+
+func alterTableTombstoneGCStmt(keyspace, table string, mode tombstoneGCMode) string {
+	return fmt.Sprintf(`ALTER TABLE %q.%q WITH tombstone_gc = {'mode': '%s'}`, keyspace, table, mode)
+}
+
+func (w *worker) awaitSchemaAgreement(ctx context.Context, clusterSession gocqlx.Session) {
+	w.logger.Info(ctx, "Awaiting schema agreement...")
+
+	var stepError error
+	defer func(start time.Time) {
+		if stepError != nil {
+			w.logger.Error(ctx, "Awaiting schema agreement failed see exact errors above", "duration", timeutc.Since(start))
+		} else {
+			w.logger.Info(ctx, "Done awaiting schema agreement", "duration", timeutc.Since(start))
+		}
+	}(timeutc.Now())
+
+	const (
+		waitMin        = 15 * time.Second // nolint: revive
+		waitMax        = 1 * time.Minute
+		maxElapsedTime = 15 * time.Minute
+		multiplier     = 2
+		jitter         = 0.2
+	)
+
+	backoff := retry.NewExponentialBackoff(
+		waitMin,
+		maxElapsedTime,
+		waitMax,
+		multiplier,
+		jitter,
+	)
+
+	notify := func(err error, wait time.Duration) {
+		w.logger.Info(ctx, "Schema agreement not reached, retrying...", "error", err, "wait", wait)
+	}
+
+	const (
+		peerSchemasStmt = "SELECT schema_version FROM system.peers"
+		localSchemaStmt = "SELECT schema_version FROM system.local WHERE key='local'"
+	)
+
+	stepError = retry.WithNotify(ctx, func() error {
+		var v []string
+		if err := clusterSession.Query(peerSchemasStmt, nil).SelectRelease(&v); err != nil {
+			return retry.Permanent(err)
+		}
+		var lv string
+		if err := clusterSession.Query(localSchemaStmt, nil).GetRelease(&lv); err != nil {
+			return retry.Permanent(err)
+		}
+
+		// Join all versions
+		m := strset.New(v...)
+		m.Add(lv)
+		if m.Size() > 1 {
+			return errors.Errorf("cluster schema versions not consistent: %s", m.List())
+		}
+
+		return nil
+	}, backoff, notify)
+}


### PR DESCRIPTION
This sets tombstone_gc mode to 'repair' to avoid data resurrection.
If tables mode is already 'repair', 'disabled' or 'immediate', then it won't be changed.

I'm not 100% sure if it's a safe to leave 'immediate' unchanged, but from the docs seems ok. 

P.S.
Also this adds skipping of local system tables - the same way we have in
regular restore service.

P.S.2 : )
I think it may turn out that we need to set tombstone gc mode to 'repair' for views as well. I've created https://github.com/scylladb/scylla-manager/issues/4261 to investigate this.


---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
