### PR TITLE
Refactor repair tests

### DIFF
--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2025 ScyllaDB
+
+//go:build all || integration
+// +build all integration
+
+package repair_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/scylladb/go-log"
+	"github.com/scylladb/gocqlx/v2"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
+)
+
+// Read only, should be used for checking testing environment
+// like Scylla version or tablets.
+var globalNodeInfo *scyllaclient.NodeInfo
+
+// Used to fill globalNodeInfo before running the tests.
+func TestMain(m *testing.M) {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+
+	config := scyllaclient.TestConfig(ManagedClusterHosts(), AgentAuthToken())
+
+	logger := log.NewDevelopment().Named("Setup")
+	c, err := scyllaclient.NewClient(config, logger)
+	if err != nil {
+		logger.Fatal(context.Background(), "Failed to create client", "error", err)
+	}
+
+	globalNodeInfo, err = c.AnyNodeInfo(context.Background())
+	if err != nil {
+		logger.Fatal(context.Background(), "Failed to get global node info", "error", err)
+	}
+
+	os.Exit(m.Run())
+}
+
+// Creates vnode keyspace.
+func createVnodeKeyspace(t *testing.T, session gocqlx.Session, keyspace string, rf1, rf2 int) {
+	stmt := "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': %d, 'dc2': %d}"
+	if globalNodeInfo.EnableTablets {
+		stmt += " AND tablets = {'enabled': false}"
+	}
+	ExecStmt(t, session, fmt.Sprintf(stmt, keyspace, rf1, rf2))
+}
+
+// Creates tablet keyspace or skips the test if that's not possible.
+func createTabletKeyspace(t *testing.T, session gocqlx.Session, keyspace string, rf1, rf2, tablets int) {
+	if !globalNodeInfo.EnableTablets {
+		t.Skip("Test requires tablets enabled in order to create tablet keyspace")
+	}
+	stmt := "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': %d, 'dc2': %d} AND tablets = {'enabled': true, 'initial': %d}"
+	ExecStmt(t, session, fmt.Sprintf(stmt, keyspace, rf1, rf2, tablets))
+}
+
+// Creates keyspace with default replication type (vnode or tablets).
+func createDefaultKeyspace(t *testing.T, session gocqlx.Session, keyspace string, rf1, rf2, tablets int) {
+	if globalNodeInfo.EnableTablets {
+		stmt := "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': %d, 'dc2': %d} AND tablets = {'enabled': true, 'initial': %d}"
+		ExecStmt(t, session, fmt.Sprintf(stmt, keyspace, rf1, rf2, tablets))
+		return
+	}
+	stmt := "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': %d, 'dc2': %d}"
+	ExecStmt(t, session, fmt.Sprintf(stmt, keyspace, rf1, rf2))
+}
+
+func dropKeyspace(t *testing.T, session gocqlx.Session, keyspace string) {
+	ExecStmt(t, session, fmt.Sprintf("DROP KEYSPACE IF EXISTS %q", keyspace))
+}

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -89,7 +89,7 @@ func dropKeyspace(t *testing.T, session gocqlx.Session, keyspace string) {
 	ExecStmt(t, session, fmt.Sprintf("DROP KEYSPACE IF EXISTS %q", keyspace))
 }
 
-type repairSchedReq struct {
+type repairReq struct {
 	// always set
 	host       string
 	keyspace   string
@@ -102,7 +102,7 @@ type repairSchedReq struct {
 	RangesParallelism      int
 }
 
-func (r repairSchedReq) fullTable() string {
+func (r repairReq) fullTable() string {
 	return r.keyspace + "." + r.table
 }
 
@@ -111,8 +111,8 @@ type repairStatusReq struct {
 	id   string
 }
 
-type repairSchedResp struct {
-	repairSchedReq
+type repairResp struct {
+	repairReq
 	id string
 }
 type repairStatusResp struct {
@@ -129,47 +129,47 @@ const (
 )
 
 const (
-	oldRepairSchedPathPrefix  = "/storage_service/repair_async"
-	oldRepairStatusPathPrefix = "/storage_service/repair_status"
-	killRepairPathPrefix      = "/storage_service/force_terminate_repair"
+	repairAsyncEndpoint          = "/storage_service/repair_async"
+	repairStatusEndpoint         = "/storage_service/repair_status"
+	forceTerminateRepairEndpoint = "/storage_service/force_terminate_repair"
 )
 
-func isOldRepairSchedReq(req *http.Request) bool {
-	return strings.HasPrefix(req.URL.Path, oldRepairSchedPathPrefix) && req.Method == http.MethodPost
+func isRepairAsyncReq(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, repairAsyncEndpoint) && req.Method == http.MethodPost
 }
 
-func isRepairSchedReq(req *http.Request) bool {
-	return isOldRepairSchedReq(req)
+func isRepairReq(req *http.Request) bool {
+	return isRepairAsyncReq(req)
 }
 
-func isOldRepairStatusReq(req *http.Request) bool {
-	return strings.HasPrefix(req.URL.Path, oldRepairStatusPathPrefix) && req.Method == http.MethodGet
+func isRepairAsyncStatusReq(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, repairStatusEndpoint) && req.Method == http.MethodGet
 }
 
 func isRepairStatusReq(req *http.Request) bool {
-	return isOldRepairStatusReq(req)
+	return isRepairAsyncStatusReq(req)
 }
 
-func isKillRepairReq(req *http.Request) bool {
-	return strings.HasPrefix(req.URL.Path, killRepairPathPrefix) && req.Method == http.MethodPost
+func isForceTerminateRepairReq(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, forceTerminateRepairEndpoint) && req.Method == http.MethodPost
 }
 
-func newRepairSchedReq(t *testing.T, req *http.Request) (repairSchedReq, bool) {
-	if isOldRepairSchedReq(req) {
-		return newOldRepairSchedReq(t, req), true
+func parseRepairReq(t *testing.T, req *http.Request) (repairReq, bool) {
+	if isRepairAsyncReq(req) {
+		return parseRepairAsyncReq(t, req), true
 	}
-	return repairSchedReq{}, false
+	return repairReq{}, false
 }
 
-func newOldRepairSchedReq(t *testing.T, req *http.Request) repairSchedReq {
-	if !isOldRepairSchedReq(req) {
+func parseRepairAsyncReq(t *testing.T, req *http.Request) repairReq {
+	if !isRepairAsyncReq(req) {
 		t.Error("Not old repair sched req")
-		return repairSchedReq{}
+		return repairReq{}
 	}
 
-	sched := repairSchedReq{
+	sched := repairReq{
 		host:                   req.Host,
-		keyspace:               strings.TrimPrefix(req.URL.Path, oldRepairSchedPathPrefix+"/"),
+		keyspace:               strings.TrimPrefix(req.URL.Path, repairAsyncEndpoint+"/"),
 		table:                  req.URL.Query().Get("columnFamilies"),
 		replicaSet:             strings.Split(req.URL.Query().Get("hosts"), ","),
 		ranges:                 parseRanges(t, req.URL.Query().Get("ranges")),
@@ -179,27 +179,27 @@ func newOldRepairSchedReq(t *testing.T, req *http.Request) repairSchedReq {
 		rangesParallelism, err := strconv.Atoi(rawRangesParallelism)
 		if err != nil {
 			t.Error(err)
-			return repairSchedReq{}
+			return repairReq{}
 		}
 		sched.RangesParallelism = rangesParallelism
 	}
 	if sched.keyspace == "" || sched.table == "" || len(sched.replicaSet) == 0 {
 		t.Error("Not fully initialized old repair sched req")
-		return repairSchedReq{}
+		return repairReq{}
 	}
 
 	return sched
 }
 
-func newRepairStatusReq(t *testing.T, req *http.Request) (repairStatusReq, bool) {
-	if isOldRepairStatusReq(req) {
-		return newOldRepairStatusReq(t, req), true
+func parseRepairStatusReq(t *testing.T, req *http.Request) (repairStatusReq, bool) {
+	if isRepairAsyncStatusReq(req) {
+		return parseRepairAsyncStatusReq(t, req), true
 	}
 	return repairStatusReq{}, false
 }
 
-func newOldRepairStatusReq(t *testing.T, req *http.Request) repairStatusReq {
-	if !isOldRepairStatusReq(req) {
+func parseRepairAsyncStatusReq(t *testing.T, req *http.Request) repairStatusReq {
+	if !isRepairAsyncStatusReq(req) {
 		t.Error("Not old repair status req")
 		return repairStatusReq{}
 	}
@@ -216,48 +216,48 @@ func newOldRepairStatusReq(t *testing.T, req *http.Request) repairStatusReq {
 	return status
 }
 
-func newRepairSchedResp(t *testing.T, resp *http.Response) (repairSchedResp, bool) {
+func parseRepairResp(t *testing.T, resp *http.Response) (repairResp, bool) {
 	if resp.StatusCode != http.StatusOK {
-		return repairSchedResp{}, false
+		return repairResp{}, false
 	}
-	if isOldRepairSchedReq(resp.Request) {
-		return newOldRepairSchedResp(t, resp), true
+	if isRepairAsyncReq(resp.Request) {
+		return parseRepairAsyncResp(t, resp), true
 	}
-	return repairSchedResp{}, false
+	return repairResp{}, false
 
 }
 
-func newOldRepairSchedResp(t *testing.T, resp *http.Response) repairSchedResp {
-	req, ok := newRepairSchedReq(t, resp.Request)
+func parseRepairAsyncResp(t *testing.T, resp *http.Response) repairResp {
+	req, ok := parseRepairReq(t, resp.Request)
 	if !ok {
 		t.Error("Not repair sched resp")
-		return repairSchedResp{}
+		return repairResp{}
 	}
 
-	sched := repairSchedResp{
-		repairSchedReq: req,
-		id:             string(copyRespBody(t, resp)),
+	sched := repairResp{
+		repairReq: req,
+		id:        string(copyRespBody(t, resp)),
 	}
 	if sched.id == "" {
 		t.Error("Not fully initialized repair sched resp")
-		return repairSchedResp{}
+		return repairResp{}
 	}
 
 	return sched
 }
 
-func newRepairStatusResp(t *testing.T, resp *http.Response) (repairStatusResp, bool) {
+func parseRepairStatusResp(t *testing.T, resp *http.Response) (repairStatusResp, bool) {
 	if resp.StatusCode != http.StatusOK {
 		return repairStatusResp{}, false
 	}
-	if isOldRepairStatusReq(resp.Request) {
-		return newOldRepairStatusResp(t, resp), true
+	if isRepairAsyncStatusReq(resp.Request) {
+		return parseRepairAsyncStatusResp(t, resp), true
 	}
 	return repairStatusResp{}, false
 }
 
-func newOldRepairStatusResp(t *testing.T, resp *http.Response) repairStatusResp {
-	req, ok := newRepairStatusReq(t, resp.Request)
+func parseRepairAsyncStatusResp(t *testing.T, resp *http.Response) repairStatusResp {
+	req, ok := parseRepairStatusReq(t, resp.Request)
 	if !ok {
 		t.Error("Not repair status resp")
 		return repairStatusResp{}
@@ -283,17 +283,17 @@ func newOldRepairStatusResp(t *testing.T, resp *http.Response) repairStatusResp 
 	}
 }
 
-func mockRepairSchedRespBody(t *testing.T, req *http.Request) (io.ReadCloser, bool) {
-	if isOldRepairSchedReq(req) {
-		return mockOldRepairSchedRespBody(t, req), true
+func mockRepairRespBody(t *testing.T, req *http.Request) (io.ReadCloser, bool) {
+	if isRepairAsyncReq(req) {
+		return mockRepairAsyncRespBody(t, req), true
 	}
 	return nil, false
 }
 
 var repairTaskCounter int32
 
-func mockOldRepairSchedRespBody(t *testing.T, req *http.Request) io.ReadCloser {
-	if !isOldRepairSchedReq(req) {
+func mockRepairAsyncRespBody(t *testing.T, req *http.Request) io.ReadCloser {
+	if !isRepairAsyncReq(req) {
 		t.Error("Not old repair sched req")
 	}
 
@@ -301,14 +301,14 @@ func mockOldRepairSchedRespBody(t *testing.T, req *http.Request) io.ReadCloser {
 }
 
 func mockRepairStatusRespBody(t *testing.T, req *http.Request, status repairStatus) (io.ReadCloser, bool) {
-	if isOldRepairStatusReq(req) {
-		return mockOldRepairStatusRespBody(t, req, status), true
+	if isRepairAsyncStatusReq(req) {
+		return mockRepairAsyncStatusRespBody(t, req, status), true
 	}
 	return nil, false
 }
 
-func mockOldRepairStatusRespBody(t *testing.T, req *http.Request, status repairStatus) io.ReadCloser {
-	if !isOldRepairStatusReq(req) {
+func mockRepairAsyncStatusRespBody(t *testing.T, req *http.Request, status repairStatus) io.ReadCloser {
+	if !isRepairAsyncStatusReq(req) {
 		t.Error("Not old repair status req")
 		return nil
 	}
@@ -331,7 +331,7 @@ func mockOldRepairStatusRespBody(t *testing.T, req *http.Request, status repairS
 
 func repairStatusInterceptor(t *testing.T, status repairStatus) http.RoundTripper {
 	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		if body, ok := mockRepairSchedRespBody(t, req); ok {
+		if body, ok := mockRepairRespBody(t, req); ok {
 			resp := httpx.MakeResponse(req, http.StatusOK)
 			resp.Body = body
 			return resp, nil
@@ -349,7 +349,7 @@ func repairHoldInterceptor(t *testing.T, ctx context.Context, after int64) http.
 	cnt := &atomic.Int64{}
 	cnt.Add(after)
 	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		if body, ok := mockRepairSchedRespBody(t, req); ok {
+		if body, ok := mockRepairRespBody(t, req); ok {
 			resp := httpx.MakeResponse(req, http.StatusOK)
 			resp.Body = body
 			return resp, nil
@@ -370,7 +370,7 @@ func repairHoldInterceptor(t *testing.T, ctx context.Context, after int64) http.
 func repairRunningInterceptor() (http.RoundTripper, chan struct{}) {
 	done := make(chan struct{})
 	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		if isRepairSchedReq(req) {
+		if isRepairReq(req) {
 			select {
 			case <-done:
 			default:
@@ -383,7 +383,7 @@ func repairRunningInterceptor() (http.RoundTripper, chan struct{}) {
 
 func repairReqAssertHostInterceptor(t *testing.T, host string) http.RoundTripper {
 	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		if r, ok := newRepairSchedReq(t, req); ok {
+		if r, ok := parseRepairReq(t, req); ok {
 			if !slices.Contains(r.replicaSet, host) {
 				err := fmt.Errorf("hosts query param (%v) are missing host (%s)", r.replicaSet, host)
 				t.Error(err)

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -154,6 +154,8 @@ func isForceTerminateRepairReq(req *http.Request) bool {
 	return strings.HasPrefix(req.URL.Path, forceTerminateRepairEndpoint) && req.Method == http.MethodPost
 }
 
+// Returns parsed repair request and true if provided with repair request.
+// If provided with any other request, returns an empty struct and false.
 func parseRepairReq(t *testing.T, req *http.Request) (repairReq, bool) {
 	if isRepairAsyncReq(req) {
 		return parseRepairAsyncReq(t, req), true
@@ -191,6 +193,8 @@ func parseRepairAsyncReq(t *testing.T, req *http.Request) repairReq {
 	return sched
 }
 
+// Returns parsed repair status request and true if provided with repair status request.
+// If provided with any other request, returns an empty struct and false.
 func parseRepairStatusReq(t *testing.T, req *http.Request) (repairStatusReq, bool) {
 	if isRepairAsyncStatusReq(req) {
 		return parseRepairAsyncStatusReq(t, req), true
@@ -216,6 +220,8 @@ func parseRepairAsyncStatusReq(t *testing.T, req *http.Request) repairStatusReq 
 	return status
 }
 
+// Returns parsed repair response and true if provided with repair response.
+// If provided with any other response, returns an empty struct and false.
 func parseRepairResp(t *testing.T, resp *http.Response) (repairResp, bool) {
 	if resp.StatusCode != http.StatusOK {
 		return repairResp{}, false
@@ -246,6 +252,8 @@ func parseRepairAsyncResp(t *testing.T, resp *http.Response) repairResp {
 	return sched
 }
 
+// Returns parsed repair status response and true if provided with repair status response.
+// If provided with any other response, returns an empty struct and false.
 func parseRepairStatusResp(t *testing.T, resp *http.Response) (repairStatusResp, bool) {
 	if resp.StatusCode != http.StatusOK {
 		return repairStatusResp{}, false
@@ -283,6 +291,8 @@ func parseRepairAsyncStatusResp(t *testing.T, resp *http.Response) repairStatusR
 	}
 }
 
+// Returns mocked body of repair response and true if provided with repair request.
+// If provided with any other request, returns nil and false.
 func mockRepairRespBody(t *testing.T, req *http.Request) (io.ReadCloser, bool) {
 	if isRepairAsyncReq(req) {
 		return mockRepairAsyncRespBody(t, req), true
@@ -300,6 +310,8 @@ func mockRepairAsyncRespBody(t *testing.T, req *http.Request) io.ReadCloser {
 	return io.NopCloser(bytes.NewBufferString(fmt.Sprint(atomic.AddInt32(&repairTaskCounter, 1))))
 }
 
+// Returns mocked body of repair status response and true if provided with repair status request.
+// If provided with any other request, returns nil and false.
 func mockRepairStatusRespBody(t *testing.T, req *http.Request, status repairStatus) (io.ReadCloser, bool) {
 	if isRepairAsyncStatusReq(req) {
 		return mockRepairAsyncStatusRespBody(t, req, status), true

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -6,10 +6,18 @@
 package repair_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/scylladb/go-log"
@@ -18,6 +26,7 @@ import (
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/httpx"
 )
 
 // Read only, should be used for checking testing environment
@@ -77,4 +86,359 @@ func createDefaultKeyspace(t *testing.T, session gocqlx.Session, keyspace string
 
 func dropKeyspace(t *testing.T, session gocqlx.Session, keyspace string) {
 	ExecStmt(t, session, fmt.Sprintf("DROP KEYSPACE IF EXISTS %q", keyspace))
+}
+
+type repairSchedReq struct {
+	// always set
+	host       string
+	keyspace   string
+	table      string
+	replicaSet []string
+	ranges     []scyllaclient.TokenRange
+
+	// optional
+	SmallTableOptimization bool
+	RangesParallelism      int
+}
+
+func (r repairSchedReq) fullTable() string {
+	return r.keyspace + "." + r.table
+}
+
+type repairStatusReq struct {
+	host string
+	id   string
+}
+
+type repairSchedResp struct {
+	repairSchedReq
+	id string
+}
+type repairStatusResp struct {
+	repairStatusReq
+	status repairStatus
+}
+
+type repairStatus int
+
+const (
+	repairStatusDone repairStatus = iota
+	repairStatusFailed
+	repairStatusRunning
+)
+
+const (
+	oldRepairSchedPathPrefix  = "/storage_service/repair_async"
+	oldRepairStatusPathPrefix = "/storage_service/repair_status"
+	killRepairPathPrefix      = "/storage_service/force_terminate_repair"
+)
+
+func isOldRepairSchedReq(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, oldRepairSchedPathPrefix) && req.Method == http.MethodPost
+}
+
+func isRepairSchedReq(req *http.Request) bool {
+	return isOldRepairSchedReq(req)
+}
+
+func isOldRepairStatusReq(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, oldRepairStatusPathPrefix) && req.Method == http.MethodGet
+}
+
+func isRepairStatusReq(req *http.Request) bool {
+	return isOldRepairStatusReq(req)
+}
+
+func isKillRepairReq(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, killRepairPathPrefix) && req.Method == http.MethodPost
+}
+
+func newRepairSchedReq(t *testing.T, req *http.Request) (repairSchedReq, bool) {
+	if isOldRepairSchedReq(req) {
+		return newOldRepairSchedReq(t, req), true
+	}
+	return repairSchedReq{}, false
+}
+
+func newOldRepairSchedReq(t *testing.T, req *http.Request) repairSchedReq {
+	if !isOldRepairSchedReq(req) {
+		t.Error("Not old repair sched req")
+		return repairSchedReq{}
+	}
+
+	sched := repairSchedReq{
+		host:                   req.Host,
+		keyspace:               strings.TrimPrefix(req.URL.Path, oldRepairSchedPathPrefix+"/"),
+		table:                  req.URL.Query().Get("columnFamilies"),
+		replicaSet:             strings.Split(req.URL.Query().Get("hosts"), ","),
+		ranges:                 parseRanges(t, req.URL.Query().Get("ranges")),
+		SmallTableOptimization: req.URL.Query().Get("small_table_optimization") == "true",
+	}
+	if rawRangesParallelism := req.URL.Query().Get("ranges_parallelism"); rawRangesParallelism != "" {
+		rangesParallelism, err := strconv.Atoi(rawRangesParallelism)
+		if err != nil {
+			t.Error(err)
+			return repairSchedReq{}
+		}
+		sched.RangesParallelism = rangesParallelism
+	}
+	if sched.keyspace == "" || sched.table == "" || len(sched.replicaSet) == 0 {
+		t.Error("Not fully initialized old repair sched req")
+		return repairSchedReq{}
+	}
+
+	return sched
+}
+
+func newRepairStatusReq(t *testing.T, req *http.Request) (repairStatusReq, bool) {
+	if isOldRepairStatusReq(req) {
+		return newOldRepairStatusReq(t, req), true
+	}
+	return repairStatusReq{}, false
+}
+
+func newOldRepairStatusReq(t *testing.T, req *http.Request) repairStatusReq {
+	if !isOldRepairStatusReq(req) {
+		t.Error("Not old repair status req")
+		return repairStatusReq{}
+	}
+
+	status := repairStatusReq{
+		host: req.Host,
+		id:   req.URL.Query().Get("id"),
+	}
+	if status.id == "" {
+		t.Error("Not fully initialized old repair status req")
+		return repairStatusReq{}
+	}
+
+	return status
+}
+
+func newRepairSchedResp(t *testing.T, resp *http.Response) (repairSchedResp, bool) {
+	if resp.StatusCode != http.StatusOK {
+		return repairSchedResp{}, false
+	}
+	if isOldRepairSchedReq(resp.Request) {
+		return newOldRepairSchedResp(t, resp), true
+	}
+	return repairSchedResp{}, false
+
+}
+
+func newOldRepairSchedResp(t *testing.T, resp *http.Response) repairSchedResp {
+	req, ok := newRepairSchedReq(t, resp.Request)
+	if !ok {
+		t.Error("Not repair sched resp")
+		return repairSchedResp{}
+	}
+
+	sched := repairSchedResp{
+		repairSchedReq: req,
+		id:             string(copyRespBody(t, resp)),
+	}
+	if sched.id == "" {
+		t.Error("Not fully initialized repair sched resp")
+		return repairSchedResp{}
+	}
+
+	return sched
+}
+
+func newRepairStatusResp(t *testing.T, resp *http.Response) (repairStatusResp, bool) {
+	if resp.StatusCode != http.StatusOK {
+		return repairStatusResp{}, false
+	}
+	if isOldRepairStatusReq(resp.Request) {
+		return newOldRepairStatusResp(t, resp), true
+	}
+	return repairStatusResp{}, false
+}
+
+func newOldRepairStatusResp(t *testing.T, resp *http.Response) repairStatusResp {
+	req, ok := newRepairStatusReq(t, resp.Request)
+	if !ok {
+		t.Error("Not repair status resp")
+		return repairStatusResp{}
+	}
+
+	body := string(copyRespBody(t, resp))
+	var status repairStatus
+	switch scyllaclient.CommandStatus(strings.Trim(body, "\"")) {
+	case scyllaclient.CommandSuccessful:
+		status = repairStatusDone
+	case scyllaclient.CommandFailed:
+		status = repairStatusFailed
+	case scyllaclient.CommandRunning:
+		status = repairStatusRunning
+	default:
+		t.Error("Unknown old repair status: " + body)
+		return repairStatusResp{}
+	}
+
+	return repairStatusResp{
+		repairStatusReq: req,
+		status:          status,
+	}
+}
+
+func mockRepairSchedRespBody(t *testing.T, req *http.Request) (io.ReadCloser, bool) {
+	if isOldRepairSchedReq(req) {
+		return mockOldRepairSchedRespBody(t, req), true
+	}
+	return nil, false
+}
+
+var repairTaskCounter int32
+
+func mockOldRepairSchedRespBody(t *testing.T, req *http.Request) io.ReadCloser {
+	if !isOldRepairSchedReq(req) {
+		t.Error("Not old repair sched req")
+	}
+
+	return io.NopCloser(bytes.NewBufferString(fmt.Sprint(atomic.AddInt32(&repairTaskCounter, 1))))
+}
+
+func mockRepairStatusRespBody(t *testing.T, req *http.Request, status repairStatus) (io.ReadCloser, bool) {
+	if isOldRepairStatusReq(req) {
+		return mockOldRepairStatusRespBody(t, req, status), true
+	}
+	return nil, false
+}
+
+func mockOldRepairStatusRespBody(t *testing.T, req *http.Request, status repairStatus) io.ReadCloser {
+	if !isOldRepairStatusReq(req) {
+		t.Error("Not old repair status req")
+		return nil
+	}
+
+	var s scyllaclient.CommandStatus
+	switch status {
+	case repairStatusDone:
+		s = scyllaclient.CommandSuccessful
+	case repairStatusFailed:
+		s = scyllaclient.CommandFailed
+	case repairStatusRunning:
+		s = scyllaclient.CommandRunning
+	default:
+		t.Errorf("Unknown old repair status: %d", status)
+		return nil
+	}
+
+	return io.NopCloser(bytes.NewBufferString(fmt.Sprintf("%q", s)))
+}
+
+func repairStatusInterceptor(t *testing.T, status repairStatus) http.RoundTripper {
+	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if body, ok := mockRepairSchedRespBody(t, req); ok {
+			resp := httpx.MakeResponse(req, http.StatusOK)
+			resp.Body = body
+			return resp, nil
+		}
+		if body, ok := mockRepairStatusRespBody(t, req, status); ok {
+			resp := httpx.MakeResponse(req, http.StatusOK)
+			resp.Body = body
+			return resp, nil
+		}
+		return nil, nil
+	})
+}
+
+func repairHoldInterceptor(t *testing.T, ctx context.Context, after int64) http.RoundTripper {
+	cnt := &atomic.Int64{}
+	cnt.Add(after)
+	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if body, ok := mockRepairSchedRespBody(t, req); ok {
+			resp := httpx.MakeResponse(req, http.StatusOK)
+			resp.Body = body
+			return resp, nil
+		}
+		if body, ok := mockRepairStatusRespBody(t, req, repairStatusDone); ok {
+			resp := httpx.MakeResponse(req, 200)
+			resp.Body = body
+			if v := cnt.Add(-1); v < 0 {
+				<-ctx.Done()
+				return resp, nil
+			}
+			return resp, nil
+		}
+		return nil, nil
+	})
+}
+
+func repairReqAssertHostInterceptor(t *testing.T, host string) http.RoundTripper {
+	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if r, ok := newRepairSchedReq(t, req); ok {
+			if !slices.Contains(r.replicaSet, host) {
+				err := fmt.Errorf("hosts query param (%v) are missing host (%s)", r.replicaSet, host)
+				t.Error(err)
+				return nil, err
+			}
+		}
+		return nil, nil
+	})
+}
+
+func countInterceptor(counter *int32, reqMatcher func(*http.Request) bool) http.RoundTripper {
+	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if reqMatcher(req) {
+			atomic.AddInt32(counter, 1)
+		}
+		return nil, nil
+	})
+}
+
+func dialErrorInterceptor() http.RoundTripper {
+	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return nil, errors.New("mock dial error")
+	})
+}
+
+func combineInterceptors(interceptors ...http.RoundTripper) http.RoundTripper {
+	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		for _, i := range interceptors {
+			resp, err := i.RoundTrip(req)
+			if resp != nil || err != nil {
+				return resp, err
+			}
+		}
+		return nil, nil
+	})
+}
+
+func parseRanges(t *testing.T, dumpedRanges string) []scyllaclient.TokenRange {
+	if dumpedRanges == "" {
+		return nil
+	}
+	var out []scyllaclient.TokenRange
+	for _, r := range strings.Split(dumpedRanges, ",") {
+		tokens := strings.Split(r, ":")
+		s, err := strconv.ParseInt(tokens[0], 10, 64)
+		if err != nil {
+			t.Error(err)
+			return nil
+		}
+		e, err := strconv.ParseInt(tokens[1], 10, 64)
+		if err != nil {
+			t.Error(err)
+			return nil
+		}
+		out = append(out, scyllaclient.TokenRange{
+			StartToken: s,
+			EndToken:   e,
+		})
+	}
+	return out
+}
+
+func copyRespBody(t *testing.T, resp *http.Response) []byte {
+	var copiedBody bytes.Buffer
+	tee := io.TeeReader(resp.Body, &copiedBody)
+	body, err := io.ReadAll(tee)
+	if err != nil {
+		t.Error(err)
+		return nil
+	}
+	resp.Body = io.NopCloser(&copiedBody)
+	return body
 }

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -61,7 +61,7 @@ func newRepairTestHelper(t *testing.T, session gocqlx.Session, config repair.Con
 	logger := log.NewDevelopmentWithLevel(zapcore.InfoLevel)
 
 	hrt := NewHackableRoundTripper(scyllaclient.DefaultTransport())
-	hrt.SetInterceptor(repairStatusInterceptor(t, repairStatusDone))
+	hrt.SetInterceptor(repairMockInterceptor(t, repairStatusDone))
 	c := newTestClient(t, hrt, log.NopLogger)
 	s := newTestService(t, session, c, config, logger, clusterID)
 
@@ -535,7 +535,7 @@ func TestServiceRepairOneJobPerHostIntegration(t *testing.T) {
 
 func TestServiceRepairOrderIntegration(t *testing.T) {
 	hrt := NewHackableRoundTripper(scyllaclient.DefaultTransport())
-	hrt.SetInterceptor(repairStatusInterceptor(t, repairStatusDone))
+	hrt.SetInterceptor(repairMockInterceptor(t, repairStatusDone))
 	c := newTestClient(t, hrt, log.NopLogger)
 	ctx := context.Background()
 
@@ -728,7 +728,7 @@ func TestServiceRepairResumeAllRangesIntegration(t *testing.T) {
 	// It also checks if too many token ranges were redundantly repaired multiple times.
 
 	hrt := NewHackableRoundTripper(scyllaclient.DefaultTransport())
-	hrt.SetInterceptor(repairStatusInterceptor(t, repairStatusDone))
+	hrt.SetInterceptor(repairMockInterceptor(t, repairStatusDone))
 	c := newTestClient(t, hrt, log.NopLogger)
 	ctx := context.Background()
 
@@ -1437,7 +1437,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		h.assertRunning(shortWait)
 
 		Print("And: errors occur")
-		h.Hrt.SetInterceptor(repairStatusInterceptor(t, repairStatusFailed))
+		h.Hrt.SetInterceptor(repairMockInterceptor(t, repairStatusFailed))
 		holdCancel()
 
 		Print("Then: repair completes with error")
@@ -1446,7 +1446,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		Print("When: create a new run")
 		h.RunID = uuid.NewTime()
 
-		h.Hrt.SetInterceptor(repairStatusInterceptor(t, repairStatusDone))
+		h.Hrt.SetInterceptor(repairMockInterceptor(t, repairStatusDone))
 
 		Print("And: run repair")
 		h.runRepair(ctx, allUnits(nil))
@@ -1477,7 +1477,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		h.Hrt.SetInterceptor(dialErrorInterceptor())
 		holdCancel()
 		time.AfterFunc(2*h.Client.Config().Timeout, func() {
-			h.Hrt.SetInterceptor(repairStatusInterceptor(t, repairStatusDone))
+			h.Hrt.SetInterceptor(repairMockInterceptor(t, repairStatusDone))
 		})
 
 		Print("And: repair contains error")
@@ -1514,7 +1514,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		h.Hrt.SetInterceptor(dialErrorInterceptor())
 		holdCancel()
 		time.AfterFunc(3*h.Client.Config().Timeout, func() {
-			h.Hrt.SetInterceptor(repairStatusInterceptor(t, repairStatusDone))
+			h.Hrt.SetInterceptor(repairMockInterceptor(t, repairStatusDone))
 		})
 
 		Print("Then: repair completes with error")
@@ -1661,7 +1661,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 			var killRepairCalled int32
 			h.Hrt.SetInterceptor(combineInterceptors(
 				countInterceptor(&killRepairCalled, isForceTerminateRepairReq),
-				repairStatusInterceptor(t, repairStatusFailed),
+				repairMockInterceptor(t, repairStatusFailed),
 			))
 			holdCancel()
 
@@ -1711,7 +1711,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 				return nil, nil
 			}),
 			countInterceptor(&repairCalled, isRepairReq),
-			repairStatusInterceptor(t, repairStatusDone),
+			repairMockInterceptor(t, repairStatusDone),
 		))
 
 		Print("When: run repair")
@@ -1780,7 +1780,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 				}
 				return nil, nil
 			}),
-			repairStatusInterceptor(t, repairStatusDone),
+			repairMockInterceptor(t, repairStatusDone),
 		))
 
 		Print("When: run repair")
@@ -1855,7 +1855,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		Print("Then: repair is running")
 		h.assertRunning(shortWait)
 
-		h.Hrt.SetInterceptor(repairStatusInterceptor(t, repairStatusDone))
+		h.Hrt.SetInterceptor(repairMockInterceptor(t, repairStatusDone))
 
 		Print("Then: repair is done")
 		h.assertDone(longWait)
@@ -1884,7 +1884,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		var repairCalled int32
 		h.Hrt.SetInterceptor(combineInterceptors(
 			countInterceptor(&repairCalled, isRepairReq),
-			repairStatusInterceptor(t, repairStatusDone),
+			repairMockInterceptor(t, repairStatusDone),
 		))
 		h.runRepair(ctx, map[string]any{
 			"keyspace": []string{testKeyspace + "." + testTable},

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1145,7 +1145,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		defer cancel()
 
 		Print("When: run repair")
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, ctx, 2))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 2))
 		h.runRepair(ctx, multipleUnits(map[string]any{
 			"small_table_threshold": repairAllSmallTableThreshold,
 		}))
@@ -1191,7 +1191,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		defer cancel()
 
 		Print("When: run repair")
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, ctx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 1))
 		h.runRepair(ctx, multipleUnits(nil))
 
 		Print("Then: repair is running")
@@ -1209,7 +1209,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		Print("And: run repair")
 		ctx, cancel = context.WithCancel(context.Background())
 		defer cancel()
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, ctx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 1))
 		h.runRepair(ctx, multipleUnits(nil))
 
 		Print("Then: repair is running")
@@ -1253,7 +1253,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 			"intensity":             propIntensity,
 			"small_table_threshold": -1,
 		})
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, ctx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 1))
 		h.runRepair(ctx, props)
 
 		Print("Then: repair is running")
@@ -1285,7 +1285,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		Print("And: resume repair")
 		ctx = context.Background()
 		holdCtx, holdCancel := context.WithCancel(ctx)
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, holdCtx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 1))
 		h.runRepair(ctx, props)
 
 		Print("Then: resumed repair is running")
@@ -1304,7 +1304,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		Print("And: run fresh repair")
 		h.RunID = uuid.NewTime()
 		holdCtx, holdCancel = context.WithCancel(ctx)
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, holdCtx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 1))
 		h.runRepair(ctx, props)
 
 		Print("Then: fresh repair is running")
@@ -1332,7 +1332,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		})
 
 		Print("When: run repair")
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, ctx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 1))
 		h.runRepair(ctx, props)
 
 		Print("Then: repair is running")
@@ -1350,7 +1350,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		Print("And: run repair")
 		ctx, cancel = context.WithCancel(context.Background())
 		defer cancel()
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, ctx, 0))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 0))
 		h.runRepair(ctx, props)
 
 		WaitCond(h.T, func() bool {
@@ -1376,7 +1376,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		defer cancel()
 
 		Print("When: run repair")
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, ctx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 1))
 		h.runRepair(ctx, multipleUnits(nil))
 
 		Print("Then: repair is running")
@@ -1427,7 +1427,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 
 		Print("When: run repair")
 		holdCtx, holdCancel := context.WithCancel(ctx)
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, holdCtx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 1))
 		h.runRepair(ctx, allUnits(map[string]any{
 			"fail_fast":             true,
 			"small_table_threshold": repairAllSmallTableThreshold,
@@ -1465,7 +1465,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 
 		Print("When: run repair")
 		holdCtx, holdCancel := context.WithCancel(context.Background())
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, holdCtx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 1))
 		h.runRepair(ctx, multipleUnits(map[string]any{
 			"small_table_threshold": repairAllSmallTableThreshold,
 		}))
@@ -1501,7 +1501,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 
 		Print("When: run repair")
 		holdCtx, holdCancel := context.WithCancel(context.Background())
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, holdCtx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 1))
 		h.runRepair(ctx, allUnits(map[string]any{
 			"fail_fast":             true,
 			"small_table_threshold": repairAllSmallTableThreshold,
@@ -1651,7 +1651,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 
 			Print("When: run repair")
 			holdCtx, holdCancel := context.WithCancel(context.Background())
-			h.Hrt.SetInterceptor(repairHoldInterceptor(t, holdCtx, 2))
+			h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 2))
 			h.runRepair(ctx, props)
 
 			Print("When: repair is running")
@@ -1843,7 +1843,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 
 		Print("When: repair status is not responding in time")
 		holdCtx, holdCancel := context.WithCancel(ctx)
-		h.Hrt.SetInterceptor(repairHoldInterceptor(t, holdCtx, 0))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 0))
 
 		Print("And: run repair")
 		h.runRepair(ctx, allUnits(map[string]any{


### PR DESCRIPTION
This is a ground work for introducing new tablet repair API into repair service tests.
It mainly:
- separates interceptor request parsing from the test code, so that it's easier to extend it with new tablet repair endpoints
- tries not to rely on tablet table ranges count, as the new tablet repair API will repair an entire table with a single call
- improves vnode/tablet keyspace creation
