### PR TITLE
Tablet repair API

### DIFF
--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -214,6 +214,17 @@ func (ni *NodeInfo) SupportsRepairSmallTableOptimization() (bool, error) {
 	return supports, nil
 }
 
+// SupportsTabletRepairNoHostFiltering returns true if /storage_service/tablets/repair API is exposed.
+// It might not necessarily allow for host filtering.
+func (ni *NodeInfo) SupportsTabletRepairNoHostFiltering() (bool, error) {
+	// Detect master builds
+	if scyllaversion.MasterVersion(ni.ScyllaVersion) {
+		return true, nil
+	}
+	// Check ENT
+	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2025.1")
+}
+
 // SafeDescribeMethod describes supported methods to ensure that scylla schema is consistent.
 type SafeDescribeMethod string
 

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -591,6 +591,27 @@ func ReplicaHash(replicaSet []string) uint64 {
 	return hash.Sum64()
 }
 
+// TabletRepair schedules Scylla repair tablet table task and returns its ID.
+// The whole table will be repaired on all nodes with just a single task.
+// The host is only needed so that we know which node should be queried
+// for the task status.
+func (c *Client) TabletRepair(ctx context.Context, keyspace, table, host string) (string, error) {
+	const allTablets = "all"
+	dontAwaitCompletion := "false"
+	p := operations.StorageServiceTabletsRepairPostParams{
+		Context:         forceHost(ctx, host),
+		Ks:              keyspace,
+		Table:           table,
+		Tokens:          allTablets,
+		AwaitCompletion: &dontAwaitCompletion,
+	}
+	resp, err := c.scyllaOps.StorageServiceTabletsRepairPost(&p)
+	if err != nil {
+		return "", err
+	}
+	return resp.GetPayload().TabletTaskID, nil
+}
+
 // Repair invokes async repair and returns the repair command ID.
 func (c *Client) Repair(ctx context.Context, keyspace, table, master string, replicaSet []string, ranges []TokenRange, intensity int, smallTableOpt bool) (int32, error) {
 	dr := dumpRanges(ranges)
@@ -1157,6 +1178,75 @@ func (c *Client) RaftReadBarrier(ctx context.Context, host, groupID string) erro
 		return fmt.Errorf("RaftReadBarrierPost: %w", err)
 	}
 	return nil
+}
+
+// ScyllaTaskState describes Scylla task state.
+type ScyllaTaskState string
+
+// Possible ScyllaTaskState.
+const (
+	ScyllaTaskStateCreated ScyllaTaskState = "created"
+	ScyllaTaskStateRunning ScyllaTaskState = "running"
+	ScyllaTaskStateDone    ScyllaTaskState = "done"
+	ScyllaTaskStateFailed  ScyllaTaskState = "failed"
+)
+
+func isScyllaTaskRunning(err error) bool {
+	// Scylla API call might return earlier due to timeout (see swagger definition)
+	status, _ := StatusCodeAndMessageOf(err)
+	return status == http.StatusRequestTimeout
+}
+
+func scyllaWaitTaskShouldRetryHandler(err error) *bool {
+	if isScyllaTaskRunning(err) {
+		return pointer.BoolPtr(false)
+	}
+	return nil
+}
+
+// ScyllaWaitTask long polls Scylla task status.
+func (c *Client) ScyllaWaitTask(ctx context.Context, host, id string, longPollingSeconds int64) (*models.TaskStatus, error) {
+	ctx = withShouldRetryHandler(ctx, scyllaWaitTaskShouldRetryHandler)
+	ctx = forceHost(ctx, host)
+	ctx = noTimeout(ctx)
+	p := &operations.TaskManagerWaitTaskTaskIDGetParams{
+		Context: ctx,
+		TaskID:  id,
+	}
+	if longPollingSeconds > 0 {
+		p.SetTimeout(&longPollingSeconds)
+	}
+
+	resp, err := c.scyllaOps.TaskManagerWaitTaskTaskIDGet(p)
+	if err != nil {
+		if isScyllaTaskRunning(err) {
+			return c.ScyllaTaskProgress(ctx, host, id)
+		}
+		return nil, err
+	}
+	return resp.GetPayload(), nil
+}
+
+// ScyllaTaskProgress returns provided Scylla task status.
+func (c *Client) ScyllaTaskProgress(ctx context.Context, host, id string) (*models.TaskStatus, error) {
+	resp, err := c.scyllaOps.TaskManagerTaskStatusTaskIDGet(&operations.TaskManagerTaskStatusTaskIDGetParams{
+		Context: forceHost(ctx, host),
+		TaskID:  id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetPayload(), nil
+}
+
+// ScyllaAbortTask aborts provided Scylla task.
+// Note that not all Scylla tasks can be aborted - see models.TaskStatus to check that.
+func (c *Client) ScyllaAbortTask(ctx context.Context, host, id string) error {
+	_, err := c.scyllaOps.TaskManagerAbortTaskTaskIDPost(&operations.TaskManagerAbortTaskTaskIDPostParams{
+		Context: forceHost(ctx, host),
+		TaskID:  id,
+	})
+	return err
 }
 
 // ToCanonicalIP replaces ":0:0" in IPv6 addresses with "::"

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -139,6 +139,7 @@ const (
 	tabletRepairEndpoint         = "/storage_service/tablets/repair"
 	waitTaskEndpoint             = "/task_manager/wait_task"
 	forceTerminateRepairEndpoint = "/storage_service/force_terminate_repair"
+	tabletBalancingEndpoint      = "/storage_service/tablets/balancing"
 )
 
 func isRepairAsyncReq(req *http.Request) bool {
@@ -167,6 +168,10 @@ func isRepairStatusReq(req *http.Request) bool {
 
 func isForceTerminateRepairReq(req *http.Request) bool {
 	return strings.HasPrefix(req.URL.Path, forceTerminateRepairEndpoint) && req.Method == http.MethodPost
+}
+
+func isTabletBalancingReq(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, tabletBalancingEndpoint) && req.Method == http.MethodPost
 }
 
 // Returns parsed repair request and true if provided with repair request.
@@ -414,6 +419,25 @@ func parseTabletRepairStatusResp(t *testing.T, resp *http.Response) repairStatus
 	return repairStatusResp{
 		repairStatusReq: req,
 		status:          status,
+	}
+}
+
+// Returns whether tablet load balancing is enabled and true if provided with tablet balancing request.
+// If provided with any other request, returns false and false.
+func newTabletLoadBalancingReq(t *testing.T, req *http.Request) (enabled bool, ok bool) {
+	if !isTabletBalancingReq(req) {
+		return false, false
+	}
+
+	rawEnabled := req.URL.Query().Get("enabled")
+	switch rawEnabled {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		t.Error("Unexpected 'enabled' query param")
+		return false, false
 	}
 }
 

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -8,6 +8,7 @@ package repair_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -23,11 +24,15 @@ import (
 
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/gocqlx/v2"
+	"github.com/scylladb/scylla-manager/v3/pkg/dht"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/httpx"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/client/operations"
+	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/models"
 )
 
 // Read only, should be used for checking testing environment
@@ -131,6 +136,8 @@ const (
 const (
 	repairAsyncEndpoint          = "/storage_service/repair_async"
 	repairStatusEndpoint         = "/storage_service/repair_status"
+	tabletRepairEndpoint         = "/storage_service/tablets/repair"
+	waitTaskEndpoint             = "/task_manager/wait_task"
 	forceTerminateRepairEndpoint = "/storage_service/force_terminate_repair"
 )
 
@@ -138,16 +145,24 @@ func isRepairAsyncReq(req *http.Request) bool {
 	return strings.HasPrefix(req.URL.Path, repairAsyncEndpoint) && req.Method == http.MethodPost
 }
 
+func isTabletRepairReq(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, tabletRepairEndpoint) && req.Method == http.MethodPost
+}
+
 func isRepairReq(req *http.Request) bool {
-	return isRepairAsyncReq(req)
+	return isRepairAsyncReq(req) || isTabletRepairReq(req)
 }
 
 func isRepairAsyncStatusReq(req *http.Request) bool {
 	return strings.HasPrefix(req.URL.Path, repairStatusEndpoint) && req.Method == http.MethodGet
 }
 
+func isTabletRepairStatusReq(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, waitTaskEndpoint) && req.Method == http.MethodGet
+}
+
 func isRepairStatusReq(req *http.Request) bool {
-	return isRepairAsyncStatusReq(req)
+	return isRepairAsyncStatusReq(req) || isTabletRepairStatusReq(req)
 }
 
 func isForceTerminateRepairReq(req *http.Request) bool {
@@ -159,6 +174,9 @@ func isForceTerminateRepairReq(req *http.Request) bool {
 func parseRepairReq(t *testing.T, req *http.Request) (repairReq, bool) {
 	if isRepairAsyncReq(req) {
 		return parseRepairAsyncReq(t, req), true
+	}
+	if isTabletRepairReq(req) {
+		return parseTabletRepairReq(t, req), true
 	}
 	return repairReq{}, false
 }
@@ -193,11 +211,40 @@ func parseRepairAsyncReq(t *testing.T, req *http.Request) repairReq {
 	return sched
 }
 
+func parseTabletRepairReq(t *testing.T, req *http.Request) repairReq {
+	if !isTabletRepairReq(req) {
+		t.Error("Not tablet repair sched req")
+		return repairReq{}
+	}
+
+	sched := repairReq{
+		host:       req.Host,
+		keyspace:   req.URL.Query().Get("ks"),
+		table:      req.URL.Query().Get("table"),
+		replicaSet: ManagedClusterHosts(),
+		ranges: []scyllaclient.TokenRange{
+			{
+				StartToken: dht.Murmur3MinToken,
+				EndToken:   dht.Murmur3MaxToken,
+			},
+		},
+	}
+	if sched.keyspace == "" || sched.table == "" {
+		t.Error("Not fully initialized tablet repair sched req")
+		return repairReq{}
+	}
+
+	return sched
+}
+
 // Returns parsed repair status request and true if provided with repair status request.
 // If provided with any other request, returns an empty struct and false.
 func parseRepairStatusReq(t *testing.T, req *http.Request) (repairStatusReq, bool) {
 	if isRepairAsyncStatusReq(req) {
 		return parseRepairAsyncStatusReq(t, req), true
+	}
+	if isTabletRepairStatusReq(req) {
+		return parseTabletRepairStatusReq(t, req), true
 	}
 	return repairStatusReq{}, false
 }
@@ -220,6 +267,24 @@ func parseRepairAsyncStatusReq(t *testing.T, req *http.Request) repairStatusReq 
 	return status
 }
 
+func parseTabletRepairStatusReq(t *testing.T, req *http.Request) repairStatusReq {
+	if !isTabletRepairStatusReq(req) {
+		t.Error("Not tablet repair status req")
+		return repairStatusReq{}
+	}
+
+	status := repairStatusReq{
+		host: req.Host,
+		id:   strings.TrimPrefix(req.URL.Path, waitTaskEndpoint+"/"),
+	}
+	if status.id == "" {
+		t.Error("Not fully initialized tablet repair status req")
+		return repairStatusReq{}
+	}
+
+	return status
+}
+
 // Returns parsed repair response and true if provided with repair response.
 // If provided with any other response, returns an empty struct and false.
 func parseRepairResp(t *testing.T, resp *http.Response) (repairResp, bool) {
@@ -229,8 +294,10 @@ func parseRepairResp(t *testing.T, resp *http.Response) (repairResp, bool) {
 	if isRepairAsyncReq(resp.Request) {
 		return parseRepairAsyncResp(t, resp), true
 	}
+	if isTabletRepairReq(resp.Request) {
+		return parseTabletRepairResp(t, resp), true
+	}
 	return repairResp{}, false
-
 }
 
 func parseRepairAsyncResp(t *testing.T, resp *http.Response) repairResp {
@@ -252,6 +319,30 @@ func parseRepairAsyncResp(t *testing.T, resp *http.Response) repairResp {
 	return sched
 }
 
+func parseTabletRepairResp(t *testing.T, resp *http.Response) repairResp {
+	req, ok := parseRepairReq(t, resp.Request)
+	if !ok {
+		t.Error("Not repair sched resp")
+		return repairResp{}
+	}
+
+	var b operations.StorageServiceTabletsRepairPostOKBody
+	if err := json.Unmarshal(copyRespBody(t, resp), &b); err != nil {
+		t.Error(err)
+		return repairResp{}
+	}
+	sched := repairResp{
+		repairReq: req,
+		id:        b.TabletTaskID,
+	}
+	if sched.id == "" {
+		t.Error("Not fully initialized repair sched resp")
+		return repairResp{}
+	}
+
+	return sched
+}
+
 // Returns parsed repair status response and true if provided with repair status response.
 // If provided with any other response, returns an empty struct and false.
 func parseRepairStatusResp(t *testing.T, resp *http.Response) (repairStatusResp, bool) {
@@ -260,6 +351,9 @@ func parseRepairStatusResp(t *testing.T, resp *http.Response) (repairStatusResp,
 	}
 	if isRepairAsyncStatusReq(resp.Request) {
 		return parseRepairAsyncStatusResp(t, resp), true
+	}
+	if isTabletRepairStatusReq(resp.Request) {
+		return parseTabletRepairStatusResp(t, resp), true
 	}
 	return repairStatusResp{}, false
 }
@@ -291,11 +385,46 @@ func parseRepairAsyncStatusResp(t *testing.T, resp *http.Response) repairStatusR
 	}
 }
 
+func parseTabletRepairStatusResp(t *testing.T, resp *http.Response) repairStatusResp {
+	req, ok := parseRepairStatusReq(t, resp.Request)
+	if !ok {
+		t.Error("Not repair status resp")
+		return repairStatusResp{}
+	}
+
+	var taskStatus models.TaskStatus
+	body := copyRespBody(t, resp)
+	if err := json.Unmarshal(body, &taskStatus); err != nil {
+		t.Error(err)
+		return repairStatusResp{}
+	}
+	var status repairStatus
+	switch scyllaclient.ScyllaTaskState(taskStatus.State) {
+	case scyllaclient.ScyllaTaskStateDone:
+		status = repairStatusDone
+	case scyllaclient.ScyllaTaskStateFailed:
+		status = repairStatusFailed
+	case scyllaclient.ScyllaTaskStateCreated, scyllaclient.ScyllaTaskStateRunning:
+		status = repairStatusRunning
+	default:
+		t.Error("Unknown tablet repair status: " + string(body))
+		return repairStatusResp{}
+	}
+
+	return repairStatusResp{
+		repairStatusReq: req,
+		status:          status,
+	}
+}
+
 // Returns mocked body of repair response and true if provided with repair request.
 // If provided with any other request, returns nil and false.
 func mockRepairRespBody(t *testing.T, req *http.Request) (io.ReadCloser, bool) {
 	if isRepairAsyncReq(req) {
 		return mockRepairAsyncRespBody(t, req), true
+	}
+	if isTabletRepairReq(req) {
+		return mockTabletRepairSchedRespBody(t, req), true
 	}
 	return nil, false
 }
@@ -310,11 +439,30 @@ func mockRepairAsyncRespBody(t *testing.T, req *http.Request) io.ReadCloser {
 	return io.NopCloser(bytes.NewBufferString(fmt.Sprint(atomic.AddInt32(&repairTaskCounter, 1))))
 }
 
+func mockTabletRepairSchedRespBody(t *testing.T, req *http.Request) io.ReadCloser {
+	if !isTabletRepairReq(req) {
+		t.Error("Not tablet repair sched req")
+	}
+
+	b, err := json.Marshal(operations.StorageServiceTabletsRepairPostOKBody{
+		TabletTaskID: uuid.NewTime().String(),
+	})
+	if err != nil {
+		t.Error(err)
+		return nil
+	}
+
+	return io.NopCloser(bytes.NewBuffer(b))
+}
+
 // Returns mocked body of repair status response and true if provided with repair status request.
 // If provided with any other request, returns nil and false.
 func mockRepairStatusRespBody(t *testing.T, req *http.Request, status repairStatus) (io.ReadCloser, bool) {
 	if isRepairAsyncStatusReq(req) {
 		return mockRepairAsyncStatusRespBody(t, req, status), true
+	}
+	if isTabletRepairStatusReq(req) {
+		return mockTabletRepairStatusRespBody(t, req, status), true
 	}
 	return nil, false
 }
@@ -339,6 +487,43 @@ func mockRepairAsyncStatusRespBody(t *testing.T, req *http.Request, status repai
 	}
 
 	return io.NopCloser(bytes.NewBufferString(fmt.Sprintf("%q", s)))
+}
+
+func mockTabletRepairStatusRespBody(t *testing.T, req *http.Request, status repairStatus) io.ReadCloser {
+	if !isTabletRepairStatusReq(req) {
+		t.Error("Not tablet repair status req")
+		return nil
+	}
+
+	var s models.TaskStatus
+	switch status {
+	case repairStatusDone:
+		s = models.TaskStatus{
+			ProgressCompleted: 1,
+			ProgressTotal:     1,
+			State:             string(scyllaclient.ScyllaTaskStateDone),
+		}
+	case repairStatusFailed:
+		s = models.TaskStatus{
+			ProgressTotal: 1,
+			State:         string(scyllaclient.ScyllaTaskStateFailed),
+		}
+	case repairStatusRunning:
+		s = models.TaskStatus{
+			ProgressTotal: 1,
+			State:         string(scyllaclient.ScyllaTaskStateRunning),
+		}
+	default:
+		t.Errorf("Unknown tablet repair status: %d", status)
+		return nil
+	}
+
+	b := &bytes.Buffer{}
+	if err := json.NewEncoder(b).Encode(s); err != nil {
+		t.Error(err)
+		return nil
+	}
+	return io.NopCloser(b)
 }
 
 // It allows for mocking responses to both repair and repair status requests.

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -255,6 +255,7 @@ func (s *Service) Repair(ctx context.Context, clusterID, taskID, runID uuid.UUID
 	// Create worker pool
 	workers := workerpool.New[*worker, job, jobResult](gracefulCtx, func(_ context.Context, i int) *worker {
 		return &worker{
+			config:     s.config,
 			client:     client,
 			stopTrying: make(map[string]struct{}),
 			progress:   pm,

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -987,9 +987,10 @@ func TestServiceRepairIntegration(t *testing.T) {
 	h := newRepairTestHelper(t, session, defaultConfig())
 	clusterSession := CreateSessionAndDropAllKeyspaces(t, h.Client)
 
-	createDefaultKeyspace(t, clusterSession, "test_repair", 2, 2)
-	WriteData(t, clusterSession, "test_repair", 1, "test_table_0", "test_table_1")
-	defer dropKeyspace(t, clusterSession, "test_repair")
+	const testKs = "test_repair"
+	createDefaultKeyspace(t, clusterSession, testKs, 2, 2)
+	WriteData(t, clusterSession, testKs, 1, "test_table_0", "test_table_1")
+	defer dropKeyspace(t, clusterSession, testKs)
 
 	t.Run("repair simple", func(t *testing.T) {
 		h := newRepairTestHelper(t, session, defaultConfig())
@@ -1156,7 +1157,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		defer cancel()
 
 		Print("When: run repair")
-		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 2))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 1))
 		h.runRepair(ctx, multipleUnits(map[string]any{
 			"small_table_threshold": repairAllSmallTableThreshold,
 		}))
@@ -1436,6 +1437,11 @@ func TestServiceRepairIntegration(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
+		rd := scyllaclient.NewRingDescriber(ctx, h.Client)
+		if rd.IsTabletKeyspace(testKs) {
+			t.Skip("Test expects vnode keyspace: tablet tables are repaired with a single API call or they don't support resume")
+		}
+
 		Print("When: run repair")
 		holdCtx, holdCancel := context.WithCancel(ctx)
 		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 1))
@@ -1475,18 +1481,17 @@ func TestServiceRepairIntegration(t *testing.T) {
 		defer cancel()
 
 		Print("When: run repair")
-		holdCtx, holdCancel := context.WithCancel(context.Background())
-		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 1))
+		i, running := repairRunningInterceptor()
+		h.Hrt.SetInterceptor(i)
 		h.runRepair(ctx, multipleUnits(map[string]any{
 			"small_table_threshold": repairAllSmallTableThreshold,
 		}))
 
 		Print("Then: repair is running")
-		h.assertRunning(shortWait)
+		chanClosedWithin(t, running, shortWait)
 
 		Print("And: no network for 5s with 1s backoff")
 		h.Hrt.SetInterceptor(dialErrorInterceptor())
-		holdCancel()
 		time.AfterFunc(2*h.Client.Config().Timeout, func() {
 			h.Hrt.SetInterceptor(repairMockInterceptor(t, repairStatusDone))
 		})
@@ -1661,12 +1666,12 @@ func TestServiceRepairIntegration(t *testing.T) {
 			props["fail_fast"] = true
 
 			Print("When: run repair")
-			holdCtx, holdCancel := context.WithCancel(context.Background())
-			h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 2))
+			i, running := repairRunningInterceptor()
+			h.Hrt.SetInterceptor(i)
 			h.runRepair(ctx, props)
 
 			Print("When: repair is running")
-			h.assertRunning(longWait)
+			chanClosedWithin(t, running, shortWait)
 
 			Print("When: Scylla returns failures")
 			var killRepairCalled int32
@@ -1674,7 +1679,6 @@ func TestServiceRepairIntegration(t *testing.T) {
 				countInterceptor(&killRepairCalled, isForceTerminateRepairReq),
 				repairMockInterceptor(t, repairStatusFailed),
 			))
-			holdCancel()
 
 			Print("Then: repair finish with error")
 			h.assertError(longWait)

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"os"
@@ -969,35 +968,22 @@ func restoreWithResume(t *testing.T, target Target, keyspace string, loadCnt, lo
 	}
 
 	a := atomic.NewInt64(0)
+	b := atomic.NewInt64(0)
 	dstH.Hrt.SetInterceptor(httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if strings.HasPrefix(req.URL.Path, "/storage_service/sstables/") && a.Inc() == 1 {
 			Print("And: context1 is canceled")
 			cancel1()
 		}
+		if strings.HasPrefix(req.URL.Path, "/storage_service/repair_async") && b.Inc() == 1 {
+			Print("And: context2 is canceled")
+			cancel2()
+		}
+		if strings.HasPrefix(req.URL.Path, "/storage_service/tablets/repair") && b.Inc() == 1 {
+			Print("And: context2 is canceled")
+			cancel2()
+		}
 		return nil, nil
 	}))
-
-	b := atomic.NewInt64(0)
-	dstH.Hrt.SetRespInterceptor(func(resp *http.Response, err error) (*http.Response, error) {
-		if resp == nil {
-			return nil, nil
-		}
-
-		var copiedBody bytes.Buffer
-		tee := io.TeeReader(resp.Body, &copiedBody)
-		body, _ := io.ReadAll(tee)
-		resp.Body = io.NopCloser(&copiedBody)
-
-		// Response to repair status
-		if resp.Request.URL.Path == "/storage_service/repair_status" && resp.Request.Method == http.MethodGet && resp.Request.URL.Query()["id"][0] != "-1" {
-			status := string(body)
-			if status == "\"SUCCESSFUL\"" && b.Inc() == 1 {
-				Print("And: context2 is canceled")
-				cancel2()
-			}
-		}
-		return nil, nil
-	})
 
 	Print("When: run restore and stop it during load and stream")
 	err = dstH.service.Restore(ctx1, dstH.ClusterID, dstH.TaskID, dstH.RunID, dstH.targetToProperties(target))


### PR DESCRIPTION
This PR adds support for tablet repair API in Scylla 2025.1.0:
- for Scylla < 2025.1.0 - repairing tablet keyspaces stops tablet load balancing and uses old repair API
- for Scylla == 2025.1.0 - SM never stops tablet load balancing, it uses tablet repair API for repairing entire tablet table and old repair API for repairing partial tablet table
- for Scylla >= 2025.1.1 - SM never stops tablet load balancing and always uses tablet repair API which is extended with host filtering capabilities (not yet implemented)

See #4273 for the decision process about not stopping tablet load balancing.

Fixes #4188
