### PR TITLE
feat(1-1-restore): adds progress tracking of 1-1-restore

### DIFF
--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -221,12 +221,13 @@ func (s *server) onClusterChange(ctx context.Context, c cluster.Change) error {
 
 func (s *server) makeServers(ctx context.Context) error {
 	services := restapi.Services{
-		Cluster:     s.clusterSvc,
-		HealthCheck: s.healthSvc,
-		Repair:      s.repairSvc,
-		Backup:      s.backupSvc,
-		Restore:     s.restoreSvc,
-		Scheduler:   s.schedSvc,
+		Cluster:        s.clusterSvc,
+		HealthCheck:    s.healthSvc,
+		Repair:         s.repairSvc,
+		Backup:         s.backupSvc,
+		Restore:        s.restoreSvc,
+		Scheduler:      s.schedSvc,
+		One2OneRestore: s.one2OneRestoreSvc,
 	}
 	h := restapi.New(services, s.logger.Named("http"))
 

--- a/pkg/restapi/services.go
+++ b/pkg/restapi/services.go
@@ -10,6 +10,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/healthcheck"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/one2onerestore"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/repair"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/restore"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/scheduler"
@@ -18,12 +19,13 @@ import (
 
 // Services contains REST API services.
 type Services struct {
-	Cluster     ClusterService
-	HealthCheck HealthCheckService
-	Repair      RepairService
-	Backup      BackupService
-	Restore     RestoreService
-	Scheduler   SchedService
+	Cluster        ClusterService
+	HealthCheck    HealthCheckService
+	Repair         RepairService
+	Backup         BackupService
+	Restore        RestoreService
+	Scheduler      SchedService
+	One2OneRestore One2OneRestoreService
 }
 
 // ClusterService service interface for the REST API handlers.
@@ -91,4 +93,9 @@ type SchedService interface {
 	IsSuspended(ctx context.Context, clusterID uuid.UUID) bool
 	Suspend(ctx context.Context, clusterID uuid.UUID) error
 	Resume(ctx context.Context, clusterID uuid.UUID, startTasks bool) error
+}
+
+// One2OneRestoreService service interface for the 1-1-restore REST API handlers.
+type One2OneRestoreService interface {
+	GetProgress(ctx context.Context, clusterID, taskID, runID uuid.UUID, properties json.RawMessage) (one2onerestore.Progress, error)
 }

--- a/pkg/restapi/task.go
+++ b/pkg/restapi/task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/one2onerestore"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/repair"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/restore"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/scheduler"
@@ -469,6 +470,8 @@ func (h *taskHandler) taskRunProgress(w http.ResponseWriter, r *http.Request) {
 				prog.Progress = restore.Progress{}
 			case scheduler.ValidateBackupTask:
 				prog.Progress = backup.ValidationHostProgress{}
+			case scheduler.One2OneRestoreTask:
+				prog.Progress = one2onerestore.Progress{}
 			}
 			render.Respond(w, r, prog)
 			return
@@ -503,6 +506,8 @@ func (h *taskHandler) taskRunProgress(w http.ResponseWriter, r *http.Request) {
 		pr, err = h.Restore.GetProgress(r.Context(), t.ClusterID, t.ID, prog.Run.ID)
 	case scheduler.ValidateBackupTask:
 		pr, err = h.Backup.GetValidationProgress(r.Context(), t.ClusterID, t.ID, prog.Run.ID)
+	case scheduler.One2OneRestoreTask:
+		pr, err = h.One2OneRestore.GetProgress(r.Context(), t.ClusterID, t.ID, prog.Run.ID, t.Properties)
 	default:
 		respondBadRequest(w, r, errors.Errorf("unsupported task type %s", t.Type))
 		return

--- a/pkg/schema/table/table.go
+++ b/pkg/schema/table/table.go
@@ -64,14 +64,14 @@ var (
 		Name: "cluster",
 		Columns: []string{
 			"auth_token",
+			"force_non_ssl_session_port",
+			"force_tls_disabled",
+			"host",
 			"id",
 			"known_hosts",
 			"labels",
 			"name",
 			"port",
-			"force_tls_disabled",
-			"force_non_ssl_session_port",
-			"host",
 		},
 		PartKey: []string{
 			"id",
@@ -107,6 +107,49 @@ var (
 			"name",
 		},
 		SortKey: []string{},
+	})
+
+	One2onerestoreRunProgress = table.New(table.Metadata{
+		Name: "one2onerestore_run_progress",
+		Columns: []string{
+			"agent_job_id",
+			"cluster_id",
+			"completed_at",
+			"downloaded",
+			"error",
+			"failed",
+			"host",
+			"keyspace_name",
+			"remote_sstable_dir",
+			"run_id",
+			"scylla_task_id",
+			"shard_cnt",
+			"skipped",
+			"stage",
+			"started_at",
+			"table_name",
+			"table_size",
+			"task_id",
+			"tombstone_gc",
+			"versioned_progress",
+			"view_build_status",
+			"view_name",
+			"view_type",
+		},
+		PartKey: []string{
+			"cluster_id",
+			"task_id",
+			"run_id",
+		},
+		SortKey: []string{
+			"remote_sstable_dir",
+			"keyspace_name",
+			"table_name",
+			"view_name",
+			"host",
+			"agent_job_id",
+			"scylla_task_id",
+		},
 	})
 
 	RepairRun = table.New(table.Metadata{

--- a/pkg/service/one2onerestore/progress.go
+++ b/pkg/service/one2onerestore/progress.go
@@ -1,0 +1,339 @@
+// Copyright (C) 2025 ScyllaDB
+
+package one2onerestore
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/gocqlx/v2/qb"
+	"github.com/scylladb/scylla-manager/v3/pkg/schema/table"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+)
+
+func (w *worker) alterTGCProgress(ctx context.Context, table scyllaTable, mode tombstoneGCMode) *RunProgress {
+	started := timeutc.Now()
+	pr := RunProgress{
+		Stage: StageAlterTGC,
+
+		ClusterID: w.runInfo.ClusterID,
+		TaskID:    w.runInfo.TaskID,
+		RunID:     w.runInfo.RunID,
+
+		KeyspaceName: table.keyspace,
+		TableName:    table.table,
+		TombstoneGC:  string(mode),
+		StartedAt:    &started,
+	}
+
+	if err := w.insertRunProgress(ctx, &pr); err != nil {
+		w.logger.Error(ctx, "Alter tombstone_gc mode progress", "err", err, "pr", pr)
+	}
+	return &pr
+}
+
+func (w *worker) updateTGCProgress(ctx context.Context, pr *RunProgress, mode tombstoneGCMode, completedAt time.Time) {
+	pr.CompletedAt = &completedAt
+	pr.TombstoneGC = string(mode)
+
+	if err := w.insertRunProgress(ctx, pr); err != nil {
+		w.logger.Error(ctx, "Update alter tombstone_gc mode progress", "err", err, "pr", pr)
+	}
+}
+
+func (w *worker) dropViewProgress(ctx context.Context, view View) *RunProgress {
+	started := timeutc.Now()
+	pr := RunProgress{
+		Stage: StageDropViews,
+
+		ClusterID: w.runInfo.ClusterID,
+		TaskID:    w.runInfo.TaskID,
+		RunID:     w.runInfo.RunID,
+
+		KeyspaceName:    view.Keyspace,
+		TableName:       view.BaseTable,
+		ViewName:        view.View,
+		ViewType:        view.Type,
+		ViewBuildStatus: view.BuildStatus,
+		StartedAt:       &started,
+	}
+
+	if err := w.insertRunProgress(ctx, &pr); err != nil {
+		w.logger.Error(ctx, "DropView progress", "err", err, "pr", pr)
+	}
+	return &pr
+}
+
+func (w *worker) updateDropViewProgress(ctx context.Context, pr *RunProgress, completedAt time.Time) {
+	pr.CompletedAt = &completedAt
+	if err := w.insertRunProgress(ctx, pr); err != nil {
+		w.logger.Error(ctx, "Update dropView progress", "err", err, "pr", pr)
+	}
+}
+
+func (w *worker) reCreateViewProgress(ctx context.Context, view View) *RunProgress {
+	started := timeutc.Now()
+	pr := RunProgress{
+		Stage: StageRecreateViews,
+
+		ClusterID: w.runInfo.ClusterID,
+		TaskID:    w.runInfo.TaskID,
+		RunID:     w.runInfo.RunID,
+
+		KeyspaceName:    view.Keyspace,
+		TableName:       view.BaseTable,
+		ViewName:        view.View,
+		ViewType:        view.Type,
+		ViewBuildStatus: view.BuildStatus,
+		StartedAt:       &started,
+	}
+
+	if err := w.insertRunProgress(ctx, &pr); err != nil {
+		w.logger.Error(ctx, "Recreate view progress", "err", err, "pr", pr)
+	}
+	return &pr
+}
+
+func (w *worker) updateReCreateViewProgress(ctx context.Context, pr *RunProgress, status scyllaclient.ViewBuildStatus) {
+	completedAt := timeutc.Now()
+	if status == scyllaclient.StatusSuccess {
+		pr.CompletedAt = &completedAt
+	}
+	pr.ViewBuildStatus = status
+	if err := w.insertRunProgress(ctx, pr); err != nil {
+		w.logger.Error(ctx, "Update recreate view progress", "err", err, "pr", pr)
+	}
+}
+
+func (w *worker) downloadProgress(ctx context.Context, remoteDir, host string, shardCount int, jobID int64, table backupspec.FilesMeta) *RunProgress {
+	started := timeutc.Now()
+	pr := RunProgress{
+		Stage: StageData,
+
+		ClusterID: w.runInfo.ClusterID,
+		TaskID:    w.runInfo.TaskID,
+		RunID:     w.runInfo.RunID,
+
+		KeyspaceName:     table.Keyspace,
+		TableName:        table.Table,
+		RemoteSSTableDir: remoteDir,
+		AgentJobID:       jobID,
+		Host:             host,
+		ShardCnt:         shardCount,
+		TableSize:        table.Size,
+		StartedAt:        &started,
+	}
+
+	if err := w.insertRunProgress(ctx, &pr); err != nil {
+		w.logger.Error(ctx, "Download progress", "err", err, "pr", pr)
+	}
+	return &pr
+}
+
+func (w *worker) updateDownloadProgress(ctx context.Context, pr *RunProgress, job *scyllaclient.RcloneJobProgress) {
+	startedAt, completedAt := time.Time(job.StartedAt), time.Time(job.CompletedAt)
+	if !startedAt.IsZero() {
+		pr.StartedAt = &startedAt
+	}
+	if !completedAt.IsZero() {
+		pr.CompletedAt = &completedAt
+	}
+	pr.Error = job.Error
+	pr.Downloaded = job.Uploaded
+	pr.Skipped = job.Skipped
+	pr.Failed = job.Failed
+
+	if err := w.insertRunProgress(ctx, pr); err != nil {
+		w.logger.Error(ctx, "Update download progress", "err", err, "pr", pr)
+	}
+}
+
+func (w *worker) progressDone(ctx context.Context, start, end time.Time) {
+	pr := RunProgress{
+		Stage: StageDone,
+
+		ClusterID: w.runInfo.ClusterID,
+		TaskID:    w.runInfo.TaskID,
+		RunID:     w.runInfo.RunID,
+
+		StartedAt:   &start,
+		CompletedAt: &end,
+	}
+	if err := w.insertRunProgress(ctx, &pr); err != nil {
+		w.logger.Error(ctx, "Done progress", "err", err, "pr", pr)
+	}
+}
+
+func (w *worker) insertRunProgress(ctx context.Context, pr *RunProgress) error {
+	// The main reason for these checks is the ability to 'mock' this function simply by
+	// passing empty RunProgress.
+	if pr.ClusterID == uuid.Nil || pr.TaskID == uuid.Nil || pr.RunID == uuid.Nil {
+		return errors.New("ClusterID, TaskID and RunID can't be empty")
+	}
+	q := table.One2onerestoreRunProgress.InsertQueryContext(ctx, w.managerSession).BindStruct(pr)
+	return q.ExecRelease()
+}
+
+func (w *worker) getProgress(ctx context.Context, target Target) (Progress, error) {
+	q := table.One2onerestoreRunProgress.SelectQueryContext(ctx, w.managerSession)
+	iter := q.BindMap(qb.M{
+		"cluster_id": w.runInfo.ClusterID,
+		"task_id":    w.runInfo.TaskID,
+		"run_id":     w.runInfo.RunID,
+	}).Iter()
+
+	pr := w.aggregateProgress(iter, target.SnapshotTag)
+
+	if err := iter.Close(); err != nil {
+		return Progress{}, errors.Wrap(err, "close iterator")
+	}
+	return pr, nil
+}
+
+type dbIterator interface {
+	StructScan(v any) bool
+}
+
+func (w *worker) aggregateProgress(iter dbIterator, snapshotTag string) Progress {
+	var (
+		tablesProgress = map[scyllaTable]TableProgress{}
+		hostsProgress  = map[string]HostProgress{}
+		views          []View
+		pr             RunProgress
+		latestRP       RunProgress
+		resultProgress progress
+	)
+
+	for iter.StructScan(&pr) {
+		latestRP = latestStage(latestRP, pr)
+		resultProgress = incrementProgress(resultProgress, toProgress(pr))
+		switch pr.Stage {
+		case StageData:
+			tKey := scyllaTable{keyspace: pr.KeyspaceName, table: pr.TableName}
+			tp := tablesProgress[tKey]
+			tp.Table = pr.TableName
+			tp.Error += pr.Error
+			tp.progress = incrementProgress(tp.progress, toProgress(pr))
+			tablesProgress[tKey] = tp
+
+			hp := hostsProgress[pr.Host]
+			hp.Host = pr.Host
+			hp.ShardCnt = pr.ShardCnt
+			hp.DownloadedBytes += pr.Downloaded
+			hp.DownloadDuration += durationMiliseconds(pr.StartedAt, pr.CompletedAt)
+			hostsProgress[pr.Host] = hp
+		case StageAlterTGC:
+			tKey := scyllaTable{keyspace: pr.KeyspaceName, table: pr.TableName}
+			tp := tablesProgress[tKey]
+			tp.progress = incrementProgress(tp.progress, toProgress(pr))
+			tp.Table = pr.TableName
+			tp.TombstoneGC = tombstoneGCMode(pr.TombstoneGC)
+			tablesProgress[tKey] = tp
+		case StageDropViews, StageRecreateViews:
+			views = append(views, View{
+				Keyspace:    pr.KeyspaceName,
+				View:        pr.ViewName,
+				Type:        pr.ViewType,
+				BaseTable:   pr.TableName,
+				BuildStatus: pr.ViewBuildStatus,
+			})
+		}
+	}
+
+	ksProgress := map[string]KeyspaceProgress{}
+	for key, tp := range tablesProgress {
+		kp := ksProgress[key.keyspace]
+		kp.Keyspace = key.keyspace
+		kp.progress = incrementProgress(kp.progress, tp.progress)
+		kp.Tables = append(kp.Tables, tp)
+		ksProgress[key.keyspace] = kp
+	}
+
+	return Progress{
+		progress: resultProgress,
+
+		Stage:       latestRP.Stage,
+		SnapshotTag: snapshotTag,
+		Keyspaces:   slices.Collect(maps.Values(ksProgress)),
+		Hosts:       slices.Collect(maps.Values(hostsProgress)),
+		Views:       views,
+	}
+}
+
+func toProgress(rp RunProgress) progress {
+	return progress{
+		Size:        rp.TableSize,
+		Restored:    rp.Downloaded - rp.Failed - rp.Skipped,
+		Downloaded:  rp.Downloaded,
+		Failed:      rp.Failed,
+		StartedAt:   rp.StartedAt,
+		CompletedAt: rp.CompletedAt,
+	}
+}
+
+func incrementProgress(dst, src progress) progress {
+	dst.Size += src.Size
+	dst.Downloaded += src.Downloaded
+	dst.Restored += src.Restored
+	dst.Failed += src.Failed
+	dst.StartedAt = minTime(dst.StartedAt, src.StartedAt)
+	dst.CompletedAt = maxTime(dst.CompletedAt, src.CompletedAt)
+	return dst
+}
+
+func latestStage(a, b RunProgress) RunProgress {
+	if a.Stage == StageDone {
+		return a
+	}
+	if b.Stage == StageDone {
+		return b
+	}
+	if beforeTime(a.StartedAt, b.StartedAt) {
+		return b
+	}
+	return a
+}
+
+func durationMiliseconds(start, end *time.Time) int64 {
+	if start == nil || end == nil {
+		return 0
+	}
+	return end.Sub(*start).Milliseconds()
+}
+
+func minTime(a, b *time.Time) *time.Time {
+	if a == nil {
+		return b
+	}
+
+	if beforeTime(a, b) {
+		return a
+	}
+	return b
+}
+
+func maxTime(a, b *time.Time) *time.Time {
+	if b == nil {
+		return nil
+	}
+	if beforeTime(a, b) {
+		return b
+	}
+	return a
+}
+
+func beforeTime(a, b *time.Time) bool {
+	if a == nil {
+		return true
+	}
+	if b == nil {
+		return false
+	}
+	return a.Before(*b)
+}

--- a/pkg/service/one2onerestore/progress_integration_test.go
+++ b/pkg/service/one2onerestore/progress_integration_test.go
@@ -1,0 +1,235 @@
+// Copyright (C) 2025 ScyllaDB
+
+//go:build all || integration
+// +build all integration
+
+package one2onerestore
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+)
+
+func TestGetProgressIntegration(t *testing.T) {
+	if tablets := os.Getenv("TABLETS"); tablets == "enabled" {
+		t.Skip("1-1-restore is available only for v-nodes")
+	}
+	loc := backupspec.Location{
+		Provider: backupspec.S3,
+		Path:     "my-1-1-restore-test",
+	}
+	testutils.S3InitBucket(t, loc.Path)
+	w, _ := newTestWorker(t, testconfig.ManagedClusterHosts())
+	h := newTestHelper(t, testconfig.ManagedClusterHosts())
+	w.runInfo = struct{ ClusterID, TaskID, RunID uuid.UUID }{
+		ClusterID: h.clusterID,
+		TaskID:    h.taskID,
+		RunID:     h.runID,
+	}
+	snapshotTag := h.runBackup(t, map[string]any{
+		"location": []backupspec.Location{loc},
+	})
+	clusterSession := db.CreateSessionAndDropAllKeyspaces(t, h.client)
+	ksName := "testgetprogress"
+	db.WriteData(t, clusterSession, ksName, 10)
+	mvName := "testmv"
+	db.CreateMaterializedView(t, clusterSession, ksName, db.BigTableName, mvName)
+
+	if srcCnt := rowCount(t, clusterSession, ksName, db.BigTableName); srcCnt == 0 {
+		t.Fatalf("Unexpected row count in table: 0")
+	}
+
+	target := Target{
+		Keyspace:        []string{ksName},
+		SourceClusterID: h.clusterID,
+		SnapshotTag:     snapshotTag,
+		Location:        []backupspec.Location{loc},
+		NodesMapping:    getNodeMappings(t, w.client),
+	}
+	manifests, hosts, err := w.getAllSnapshotManifestsAndTargetHosts(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Unexpected err, getAllSnapshotManifestsAndTargetHosts: %v", err)
+	}
+
+	workload, err := w.prepareHostWorkload(context.Background(), manifests, hosts, target)
+	if err != nil {
+		t.Fatalf("Unexpected err, prepareHostWorkload: %v", err)
+	}
+
+	testutils.Print("ALTER_TGC Stage")
+	err = w.setTombstoneGCModeRepair(context.Background(), workload)
+	if err != nil {
+		t.Fatalf("Unexpected err, setTombstoneGCModeRepair: %v", err)
+	}
+
+	pr, err := w.getProgress(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Unexpected err, getProgress: %v", err)
+	}
+	if pr.Stage != StageAlterTGC {
+		t.Fatalf("Expected stage ALTER_TGC, but got %s", pr.Stage)
+	}
+	validateKeyspaces(t, pr.Keyspaces)
+
+	testutils.Print("DROP_VIEWS Stage")
+	views, err := w.dropViews(context.Background(), workload)
+	if err != nil {
+		t.Fatalf("Unexpected err, dropViews: %v", err)
+	}
+
+	pr, err = w.getProgress(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Unexpected err, getProgress: %v", err)
+	}
+	if pr.Stage != StageDropViews {
+		t.Fatalf("Expected stage DROP_VIEW, but got %s", pr.Stage)
+	}
+	validateViews(t, pr.Views, "")
+
+	testutils.Print("DATA Stage")
+	if err := w.restoreTables(context.Background(), workload, target.Keyspace); err != nil {
+		t.Fatalf("Unexpected err, restoreTables: %v", err)
+	}
+	pr, err = w.getProgress(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Unexpected err, getProgress: %v", err)
+	}
+	if pr.Stage != StageData {
+		t.Fatalf("Expected stage DATA, but got %s", pr.Stage)
+	}
+	validateKeyspaces(t, pr.Keyspaces)
+	validateHosts(t, pr.Hosts)
+
+	testutils.Print("RECREATE_VIEWS Stage")
+	if err := w.reCreateViews(context.Background(), views); err != nil {
+		t.Fatalf("Unexpected err, reCreateViews: %v", err)
+	}
+	pr, err = w.getProgress(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Unexpected err, getProgress: %v", err)
+	}
+	if pr.Stage != StageRecreateViews {
+		t.Fatalf("Expected stage RECREATE_VIEW, but got %s", pr.Stage)
+	}
+	validateViews(t, pr.Views, scyllaclient.StatusSuccess)
+
+	testutils.Print("DONE Stage")
+	w.progressDone(context.Background(), timeutc.Now(), timeutc.Now())
+	pr, err = w.getProgress(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Unexpected err, getProgress: %v", err)
+	}
+	validateGetProgress(t, pr, snapshotTag)
+}
+
+func validateGetProgress(t *testing.T, pr Progress, tag string) {
+	t.Helper()
+	if pr.SnapshotTag != tag {
+		t.Fatalf("Expected snapshot tag %s, but got %s", tag, pr.SnapshotTag)
+	}
+	if pr.Stage != StageDone {
+		t.Fatalf("Expected stage DONE, but got %s", pr.Stage)
+	}
+	validateProgress(t, pr.progress)
+	validateKeyspaces(t, pr.Keyspaces)
+	validateHosts(t, pr.Hosts)
+	validateViews(t, pr.Views, scyllaclient.StatusSuccess)
+}
+
+func validateProgress(t *testing.T, p progress) {
+	t.Helper()
+	if p.Size != p.Restored {
+		t.Fatalf("Expected to restore %d, but restored %d", p.Size, p.Restored)
+	}
+	if p.Size != p.Downloaded {
+		t.Fatalf("Expected to download %d, but got %d", p.Size, p.Downloaded)
+	}
+	if p.Failed != 0 {
+		t.Fatalf("Expected failed to be 0, but got: %d", p.Failed)
+	}
+	if p.StartedAt == nil {
+		t.Fatalf("Expected StartedAt != nil, but got nil")
+	}
+	if p.CompletedAt == nil {
+		t.Fatalf("Expected CompletedAt != nil, but got nil")
+	}
+}
+
+func validateKeyspaces(t *testing.T, keyspaces []KeyspaceProgress) {
+	t.Helper()
+	if len(keyspaces) == 0 {
+		t.Fatalf("Expected len(keyspaces) > 0, but got 0")
+	}
+	for _, kp := range keyspaces {
+		validateProgress(t, kp.progress)
+		if kp.Keyspace == "" {
+			t.Fatalf("Expected not empty keyspace name, but got ''")
+		}
+		if len(kp.Tables) == 0 {
+			t.Fatalf("Expected %s len(tables) > 0, but got 0", kp.Keyspace)
+		}
+		for _, tp := range kp.Tables {
+			validateProgress(t, tp.progress)
+			if tp.Table == "" {
+				t.Fatalf("Expected not empty %s table name, but got ''", kp.Keyspace)
+			}
+			if tp.TombstoneGC != modeRepair {
+				t.Fatalf("Expected tombstone_gc mode of %s.%s to be repair, but got %s", kp.Keyspace, tp.Table, tp.TombstoneGC)
+			}
+		}
+	}
+}
+
+func validateHosts(t *testing.T, hosts []HostProgress) {
+	t.Helper()
+	if len(hosts) != 6 {
+		t.Fatalf("Expected len(hosts) == 6, but got %d", len(hosts))
+	}
+	for _, hp := range hosts {
+		if hp.Host == "" {
+			t.Fatalf("Expected not empty host, but got ''")
+		}
+		if hp.ShardCnt == 0 {
+			t.Fatalf("Expected %s host ShardCound != 0, but got 0", hp.Host)
+		}
+		if hp.DownloadedBytes == 0 {
+			t.Fatalf("Expected not empty %s host DownloadedBytes, but got 0", hp.Host)
+		}
+		if hp.DownloadDuration == 0 {
+			t.Fatalf("Expected not empty %s host DownloadDuration, but got 0", hp.Host)
+		}
+	}
+}
+
+func validateViews(t *testing.T, views []View, expectedBuildStatus scyllaclient.ViewBuildStatus) {
+	t.Helper()
+	if len(views) == 0 {
+		t.Fatalf("Expected len(views) > 0, but got 0")
+	}
+	for _, v := range views {
+		if v.Keyspace == "" {
+			t.Fatalf("Expected not empty view.Keyspace, but got ''")
+		}
+		if v.BaseTable == "" {
+			t.Fatalf("Expected not empty view.BaseTable, but got ''")
+		}
+		if v.View == "" {
+			t.Fatalf("Expected not empty view.View, but got ''")
+		}
+		if v.Type == "" {
+			t.Fatalf("Expected not empty view.Type, but got ''")
+		}
+		if v.BuildStatus != expectedBuildStatus {
+			t.Fatalf("Expected view.BuildStatus '%s', but got '%s'", expectedBuildStatus, v.BuildStatus)
+		}
+	}
+}

--- a/pkg/service/one2onerestore/progress_integration_test.go
+++ b/pkg/service/one2onerestore/progress_integration_test.go
@@ -35,9 +35,6 @@ func TestGetProgressIntegration(t *testing.T) {
 		TaskID:    h.taskID,
 		RunID:     h.runID,
 	}
-	snapshotTag := h.runBackup(t, map[string]any{
-		"location": []backupspec.Location{loc},
-	})
 	clusterSession := db.CreateSessionAndDropAllKeyspaces(t, h.client)
 	ksName := "testgetprogress"
 	db.WriteData(t, clusterSession, ksName, 10)
@@ -47,6 +44,10 @@ func TestGetProgressIntegration(t *testing.T) {
 	if srcCnt := rowCount(t, clusterSession, ksName, db.BigTableName); srcCnt == 0 {
 		t.Fatalf("Unexpected row count in table: 0")
 	}
+
+	snapshotTag := h.runBackup(t, map[string]any{
+		"location": []backupspec.Location{loc},
+	})
 
 	target := Target{
 		Keyspace:        []string{ksName},

--- a/pkg/service/one2onerestore/progress_test.go
+++ b/pkg/service/one2onerestore/progress_test.go
@@ -1,0 +1,130 @@
+// Copyright (C) 2025 ScyllaDB
+
+package one2onerestore
+
+import (
+	"encoding/json"
+	"iter"
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils"
+)
+
+func TestAggregateProgress(t *testing.T) {
+	testCases := []struct {
+		name        string
+		rows        string
+		snapshotTag string
+		expected    Progress
+	}{
+		{
+			name:        "Only data stage",
+			rows:        "testdata/only_data.json",
+			snapshotTag: "snapshot_tag",
+		},
+		{
+			name:        "Only alter tombstone_gc mode stage",
+			rows:        "testdata/only_tgc.json",
+			snapshotTag: "snapshot_tag",
+		},
+		{
+			name:        "Only drop views stage",
+			rows:        "testdata/only_drop_views.json",
+			snapshotTag: "snapshot_tag",
+		},
+		{
+			name:        "Data and drop views stage",
+			rows:        "testdata/data_and_drop_views.json",
+			snapshotTag: "snapshot_tag",
+		},
+		{
+			name:        "Data and recreate views stage",
+			rows:        "testdata/data_and_recreate_views.json",
+			snapshotTag: "snapshot_tag",
+		},
+		{
+			name:        "All stages",
+			rows:        "testdata/all_stages.json",
+			snapshotTag: "snapshot_tag",
+		},
+		{
+			name:        "Data stage in progress",
+			rows:        "testdata/data_stage_in_progress.json",
+			snapshotTag: "snapshot_tag",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iter, stop := newDBTest(t, tc.rows)
+			defer stop()
+
+			pr := (&worker{}).aggregateProgress(iter, tc.snapshotTag)
+
+			testutils.SaveGoldenJSONFileIfNeeded(t, &pr)
+			var expectedProgress Progress
+			testutils.LoadGoldenJSONFile(t, &expectedProgress)
+
+			sortKeyspacesOpt := cmpopts.SortSlices(func(a, b KeyspaceProgress) bool {
+				return a.Keyspace < b.Keyspace
+			})
+			sortTablesOpt := cmpopts.SortSlices(func(a, b TableProgress) bool {
+				return a.Table < b.Table
+			})
+			sortHostsOpt := cmpopts.SortSlices(func(a, b HostProgress) bool {
+				return a.Host < b.Host
+			})
+			unexportedOpts := cmp.AllowUnexported(Progress{}, KeyspaceProgress{}, TableProgress{})
+			opts := []cmp.Option{
+				sortKeyspacesOpt,
+				sortTablesOpt,
+				sortHostsOpt,
+				unexportedOpts,
+			}
+			if diff := cmp.Diff(expectedProgress, pr, opts...); diff != "" {
+				t.Fatalf("Actual != Expected:\n%v", diff)
+			}
+		})
+	}
+}
+
+func newDBTest(t *testing.T, dataPath string) (it *dbIterTest, stop func()) {
+	t.Helper()
+	data, err := os.ReadFile(dataPath)
+	if err != nil {
+		t.Fatalf("open test data file: %v", err)
+	}
+	var rows []RunProgress
+	if err := json.Unmarshal(data, &rows); err != nil {
+		t.Fatalf("unmarshal test data file: %v", err)
+	}
+	next, stop := iter.Pull(slices.Values(rows))
+	return &dbIterTest{
+		next: next,
+	}, stop
+}
+
+type dbIterTest struct {
+	next func() (RunProgress, bool)
+}
+
+func (db *dbIterTest) StructScan(v any) bool {
+	pr, ok := v.(*RunProgress)
+	if !ok {
+		return false
+	}
+	row, ok := db.next()
+	if !ok {
+		return false
+	}
+	*pr = row
+	return true
+}
+
+func toPtr[T any](t T) *T {
+	return &t
+}

--- a/pkg/service/one2onerestore/service.go
+++ b/pkg/service/one2onerestore/service.go
@@ -24,6 +24,9 @@ type Servicer interface {
 	One2OneRestore(ctx context.Context, clusterID, taskID, runID uuid.UUID, properties json.RawMessage) error
 	// Runner creates a Runner that handles 1-1-restore operations.
 	Runner() Runner
+
+	// GetProgress returns progress of the 1-1-restore task run identified by runID.
+	GetProgress(ctx context.Context, clusterID, taskID, runID uuid.UUID, properties json.RawMessage) (Progress, error)
 }
 
 // Service for the 1-1-restore.
@@ -66,7 +69,7 @@ func (s *Service) One2OneRestore(ctx context.Context, clusterID, taskID, runID u
 		"run_id", runID,
 	)
 
-	w, err := s.newWorker(ctx, clusterID)
+	w, err := s.newWorker(ctx, clusterID, taskID, runID)
 	if err != nil {
 		return errors.Wrap(err, "new worker")
 	}
@@ -97,10 +100,11 @@ func (s *Service) One2OneRestore(ctx context.Context, clusterID, taskID, runID u
 		return errors.Wrap(err, "restore data")
 	}
 	s.logger.Info(ctx, "Data restore is completed", "took", timeutc.Since(start))
+	w.progressDone(ctx, start, timeutc.Now())
 	return nil
 }
 
-func (s *Service) newWorker(ctx context.Context, clusterID uuid.UUID) (worker, error) {
+func (s *Service) newWorker(ctx context.Context, clusterID, taskID, runID uuid.UUID) (worker, error) {
 	client, err := s.scyllaClient(ctx, clusterID)
 	if err != nil {
 		return worker{}, errors.Wrap(err, "get client")
@@ -117,5 +121,28 @@ func (s *Service) newWorker(ctx context.Context, clusterID uuid.UUID) (worker, e
 		clusterSession: clusterSession,
 
 		logger: s.logger,
+
+		runInfo: struct{ ClusterID, TaskID, RunID uuid.UUID }{
+			ClusterID: clusterID,
+			TaskID:    taskID,
+			RunID:     runID,
+		},
 	}, nil
+}
+
+// GetProgress aggregates progress for the run of the task and breaks it down by keyspace and table.
+func (s *Service) GetProgress(ctx context.Context, clusterID, taskID, runID uuid.UUID, properties json.RawMessage) (Progress, error) {
+	w, err := s.newWorker(ctx, clusterID, taskID, runID)
+	if err != nil {
+		return Progress{}, errors.Wrap(err, "new worker")
+	}
+	target, err := w.parseTarget(ctx, properties)
+	if err != nil {
+		return Progress{}, errors.Wrap(err, "parse target")
+	}
+	pr, err := w.getProgress(ctx, target)
+	if err != nil {
+		return Progress{}, errors.Wrap(err, "get progress")
+	}
+	return pr, nil
 }

--- a/pkg/service/one2onerestore/service_integration_test.go
+++ b/pkg/service/one2onerestore/service_integration_test.go
@@ -6,6 +6,7 @@
 package one2onerestore
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -84,6 +85,13 @@ func TestOne2OneRestoreServiceIntegration(t *testing.T) {
 	if mode != modeRepair {
 		t.Fatalf("Expected repair mode, but got %s", string(mode))
 	}
+
+	Print("Validate progress")
+	pr, err := h.restoreSvc.GetProgress(context.Background(), h.clusterID, h.taskID, h.runID, h.props)
+	if err != nil {
+		t.Fatalf("Unexpected err: %v", err)
+	}
+	validateGetProgress(t, pr, tag)
 }
 
 func truncateAllTablesInKeyspace(tb testing.TB, session gocqlx.Session, ks string) {

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/All_stages.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/All_stages.golden.json
@@ -1,0 +1,73 @@
+{
+  "size": 30,
+  "restored": 30,
+  "downloaded": 30,
+  "failed": 0,
+  "started_at": "2025-01-01T11:58:01Z",
+  "completed_at": "2025-01-01T12:00:06Z",
+  "snapshot_tag": "snapshot_tag",
+  "keyspaces": [
+    {
+      "size": 30,
+      "restored": 30,
+      "downloaded": 30,
+      "failed": 0,
+      "started_at": "2025-01-01T11:58:01Z",
+      "completed_at": "2025-01-01T12:00:03Z",
+      "keyspace": "ks1",
+      "tables": [
+        {
+          "size": 10,
+          "restored": 10,
+          "downloaded": 10,
+          "failed": 0,
+          "started_at": "2025-01-01T11:58:01Z",
+          "completed_at": "2025-01-01T12:00:01Z",
+          "table": "t1",
+          "tombstone_gc": "repair"
+        },
+        {
+          "size": 20,
+          "restored": 20,
+          "downloaded": 20,
+          "failed": 0,
+          "started_at": "2025-01-01T11:58:03Z",
+          "completed_at": "2025-01-01T12:00:03Z",
+          "table": "t2",
+          "tombstone_gc": "repair"
+        }
+      ]
+    }
+  ],
+  "hosts": [
+    {
+      "host": "192.168.1.1",
+      "shard_cnt": 4,
+      "downloaded_bytes": 10,
+      "download_duration": 1000
+    },
+    {
+      "host": "192.168.1.2",
+      "shard_cnt": 4,
+      "downloaded_bytes": 20,
+      "download_duration": 2000
+    }
+  ],
+  "views": [
+    {
+      "keyspace": "ks1",
+      "view": "v1",
+      "type": "MaterializedView",
+      "base_table": "t1",
+      "status": "SUCCESS"
+    },
+    {
+      "keyspace": "ks1",
+      "view": "v2",
+      "type": "MaterializedView",
+      "base_table": "t2",
+      "status": "SUCCESS"
+    }
+  ],
+  "stage": "DONE"
+}

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Data_and_drop_views_stage.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Data_and_drop_views_stage.golden.json
@@ -1,0 +1,73 @@
+{
+  "size": 30,
+  "restored": 30,
+  "downloaded": 30,
+  "failed": 0,
+  "started_at": "2025-01-01T11:59:01Z",
+  "completed_at": "2025-01-01T12:00:03Z",
+  "snapshot_tag": "snapshot_tag",
+  "keyspaces": [
+    {
+      "size": 30,
+      "restored": 30,
+      "downloaded": 30,
+      "failed": 0,
+      "started_at": "2025-01-01T12:00:00Z",
+      "completed_at": "2025-01-01T12:00:03Z",
+      "keyspace": "ks1",
+      "tables": [
+        {
+          "size": 10,
+          "restored": 10,
+          "downloaded": 10,
+          "failed": 0,
+          "started_at": "2025-01-01T12:00:00Z",
+          "completed_at": "2025-01-01T12:00:01Z",
+          "table": "t1",
+          "tombstone_gc": ""
+        },
+        {
+          "size": 20,
+          "restored": 20,
+          "downloaded": 20,
+          "failed": 0,
+          "started_at": "2025-01-01T12:00:01Z",
+          "completed_at": "2025-01-01T12:00:03Z",
+          "table": "t2",
+          "tombstone_gc": ""
+        }
+      ]
+    }
+  ],
+  "hosts": [
+    {
+      "host": "192.168.1.1",
+      "shard_cnt": 4,
+      "downloaded_bytes": 10,
+      "download_duration": 1000
+    },
+    {
+      "host": "192.168.1.2",
+      "shard_cnt": 4,
+      "downloaded_bytes": 20,
+      "download_duration": 2000
+    }
+  ],
+  "views": [
+    {
+      "keyspace": "ks1",
+      "view": "v1",
+      "type": "MaterializedView",
+      "base_table": "t1",
+      "status": ""
+    },
+    {
+      "keyspace": "ks1",
+      "view": "v2",
+      "type": "MaterializedView",
+      "base_table": "t2",
+      "status": ""
+    }
+  ],
+  "stage": "DATA"
+}

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Data_and_recreate_views_stage.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Data_and_recreate_views_stage.golden.json
@@ -1,0 +1,73 @@
+{
+  "size": 30,
+  "restored": 30,
+  "downloaded": 30,
+  "failed": 0,
+  "started_at": "2025-01-01T12:00:00Z",
+  "completed_at": "2025-01-01T12:00:04Z",
+  "snapshot_tag": "snapshot_tag",
+  "keyspaces": [
+    {
+      "size": 30,
+      "restored": 30,
+      "downloaded": 30,
+      "failed": 0,
+      "started_at": "2025-01-01T12:00:00Z",
+      "completed_at": "2025-01-01T12:00:03Z",
+      "keyspace": "ks1",
+      "tables": [
+        {
+          "size": 10,
+          "restored": 10,
+          "downloaded": 10,
+          "failed": 0,
+          "started_at": "2025-01-01T12:00:00Z",
+          "completed_at": "2025-01-01T12:00:01Z",
+          "table": "t1",
+          "tombstone_gc": ""
+        },
+        {
+          "size": 20,
+          "restored": 20,
+          "downloaded": 20,
+          "failed": 0,
+          "started_at": "2025-01-01T12:00:01Z",
+          "completed_at": "2025-01-01T12:00:03Z",
+          "table": "t2",
+          "tombstone_gc": ""
+        }
+      ]
+    }
+  ],
+  "hosts": [
+    {
+      "host": "192.168.1.1",
+      "shard_cnt": 4,
+      "downloaded_bytes": 10,
+      "download_duration": 1000
+    },
+    {
+      "host": "192.168.1.2",
+      "shard_cnt": 4,
+      "downloaded_bytes": 20,
+      "download_duration": 2000
+    }
+  ],
+  "views": [
+    {
+      "keyspace": "ks1",
+      "view": "v1",
+      "type": "MaterializedView",
+      "base_table": "t1",
+      "status": "SUCCESS"
+    },
+    {
+      "keyspace": "ks1",
+      "view": "v2",
+      "type": "MaterializedView",
+      "base_table": "t2",
+      "status": "SUCCESS"
+    }
+  ],
+  "stage": "RECREATE_VIEWS"
+}

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Data_stage_in_progress.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Data_stage_in_progress.golden.json
@@ -1,0 +1,57 @@
+{
+  "size": 30,
+  "restored": 0,
+  "downloaded": 0,
+  "failed": 0,
+  "started_at": "2025-01-01T11:58:01Z",
+  "completed_at": null,
+  "snapshot_tag": "snapshot_tag",
+  "keyspaces": [
+    {
+      "size": 30,
+      "restored": 0,
+      "downloaded": 0,
+      "failed": 0,
+      "started_at": "2025-01-01T11:58:01Z",
+      "completed_at": null,
+      "keyspace": "ks1",
+      "tables": [
+        {
+          "size": 10,
+          "restored": 0,
+          "downloaded": 0,
+          "failed": 0,
+          "started_at": "2025-01-01T11:58:01Z",
+          "completed_at": null,
+          "table": "t1",
+          "tombstone_gc": "repair"
+        },
+        {
+          "size": 20,
+          "restored": 0,
+          "downloaded": 0,
+          "failed": 0,
+          "started_at": "2025-01-01T11:58:03Z",
+          "completed_at": null,
+          "table": "t2",
+          "tombstone_gc": "repair"
+        }
+      ]
+    }
+  ],
+  "hosts": [
+    {
+      "host": "192.168.1.1",
+      "shard_cnt": 4,
+      "downloaded_bytes": 0,
+      "download_duration": 0
+    },
+    {
+      "host": "192.168.1.2",
+      "shard_cnt": 4,
+      "downloaded_bytes": 0,
+      "download_duration": 0
+    }
+  ],
+  "stage": "DATA"
+}

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Only_alter_tombstone_gc_mode_stage.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Only_alter_tombstone_gc_mode_stage.golden.json
@@ -1,0 +1,43 @@
+{
+  "size": 0,
+  "restored": 0,
+  "downloaded": 0,
+  "failed": 0,
+  "started_at": "2025-01-01T11:58:01Z",
+  "completed_at": "2025-01-01T11:58:04Z",
+  "snapshot_tag": "snapshot_tag",
+  "keyspaces": [
+    {
+      "size": 0,
+      "restored": 0,
+      "downloaded": 0,
+      "failed": 0,
+      "started_at": "2025-01-01T11:58:01Z",
+      "completed_at": "2025-01-01T11:58:04Z",
+      "keyspace": "ks1",
+      "tables": [
+        {
+          "size": 0,
+          "restored": 0,
+          "downloaded": 0,
+          "failed": 0,
+          "started_at": "2025-01-01T11:58:01Z",
+          "completed_at": "2025-01-01T11:58:03Z",
+          "table": "t1",
+          "tombstone_gc": "repair"
+        },
+        {
+          "size": 0,
+          "restored": 0,
+          "downloaded": 0,
+          "failed": 0,
+          "started_at": "2025-01-01T11:58:03Z",
+          "completed_at": "2025-01-01T11:58:04Z",
+          "table": "t2",
+          "tombstone_gc": "repair"
+        }
+      ]
+    }
+  ],
+  "stage": "ALTER_TGC"
+}

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Only_data_stage.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Only_data_stage.golden.json
@@ -1,0 +1,57 @@
+{
+  "size": 30,
+  "restored": 30,
+  "downloaded": 30,
+  "failed": 0,
+  "started_at": "2025-01-01T12:00:00Z",
+  "completed_at": "2025-01-01T12:00:03Z",
+  "snapshot_tag": "snapshot_tag",
+  "keyspaces": [
+    {
+      "size": 30,
+      "restored": 30,
+      "downloaded": 30,
+      "failed": 0,
+      "started_at": "2025-01-01T12:00:00Z",
+      "completed_at": "2025-01-01T12:00:03Z",
+      "keyspace": "ks1",
+      "tables": [
+        {
+          "size": 10,
+          "restored": 10,
+          "downloaded": 10,
+          "failed": 0,
+          "started_at": "2025-01-01T12:00:00Z",
+          "completed_at": "2025-01-01T12:00:01Z",
+          "table": "t1",
+          "tombstone_gc": ""
+        },
+        {
+          "size": 20,
+          "restored": 20,
+          "downloaded": 20,
+          "failed": 0,
+          "started_at": "2025-01-01T12:00:01Z",
+          "completed_at": "2025-01-01T12:00:03Z",
+          "table": "t2",
+          "tombstone_gc": ""
+        }
+      ]
+    }
+  ],
+  "hosts": [
+    {
+      "host": "192.168.1.1",
+      "shard_cnt": 4,
+      "downloaded_bytes": 10,
+      "download_duration": 1000
+    },
+    {
+      "host": "192.168.1.2",
+      "shard_cnt": 4,
+      "downloaded_bytes": 20,
+      "download_duration": 2000
+    }
+  ],
+  "stage": "DATA"
+}

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Only_drop_views_stage.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Only_drop_views_stage.golden.json
@@ -1,0 +1,26 @@
+{
+  "size": 0,
+  "restored": 0,
+  "downloaded": 0,
+  "failed": 0,
+  "started_at": "2025-01-01T11:59:01Z",
+  "completed_at": "2025-01-01T11:59:04Z",
+  "snapshot_tag": "snapshot_tag",
+  "views": [
+    {
+      "keyspace": "ks1",
+      "view": "v1",
+      "type": "MaterializedView",
+      "base_table": "t1",
+      "status": ""
+    },
+    {
+      "keyspace": "ks1",
+      "view": "v2",
+      "type": "MaterializedView",
+      "base_table": "t2",
+      "status": ""
+    }
+  ],
+  "stage": "DROP_VIEWS"
+}

--- a/pkg/service/one2onerestore/testdata/all_stages.json
+++ b/pkg/service/one2onerestore/testdata/all_stages.json
@@ -1,0 +1,71 @@
+[
+  {
+    "Stage": "ALTER_TGC",
+    "StartedAt": "2025-01-01T11:58:01Z",
+    "CompletedAt": "2025-01-01T11:58:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "TombstoneGC": "repair"
+  },
+  {
+    "Stage": "ALTER_TGC",
+    "StartedAt": "2025-01-01T11:58:03Z",
+    "CompletedAt": "2025-01-01T11:58:04Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "TombstoneGC": "repair"
+  },
+  {
+    "Stage": "DATA",
+    "StartedAt": "2025-01-01T12:00:00Z",
+    "CompletedAt": "2025-01-01T12:00:01Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "TableSize": 10,
+    "Host": "192.168.1.1",
+    "ShardCnt": 4,
+    "Downloaded": 10,
+    "Skipped": 0,
+    "Failed": 0,
+    "AgentJobID": 1
+  },
+  {
+    "Stage": "DATA",
+    "StartedAt": "2025-01-01T12:00:01Z",
+    "CompletedAt": "2025-01-01T12:00:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "TableSize": 20,
+    "Host": "192.168.1.2",
+    "ShardCnt": 4,
+    "Downloaded": 20,
+    "Skipped": 0,
+    "Failed": 0,
+    "AgentJobID": 1
+  },
+  {
+    "Stage": "RECREATE_VIEWS",
+    "StartedAt": "2025-01-01T12:00:01Z",
+    "CompletedAt": "2025-01-01T12:00:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "ViewName": "v1",
+    "ViewType": "MaterializedView",
+    "ViewBuildStatus": "SUCCESS"
+  },
+  {
+    "Stage": "RECREATE_VIEWS",
+    "StartedAt": "2025-01-01T12:01:03Z",
+    "CompletedAt": "2025-01-01T12:00:04Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "ViewName": "v2",
+    "ViewType": "MaterializedView",
+    "ViewBuildStatus": "SUCCESS"
+  },
+  {
+    "Stage": "DONE",
+    "StartedAt": "2025-01-01T11:58:01Z",
+    "CompletedAt": "2025-01-01T12:00:06Z"
+  }
+]

--- a/pkg/service/one2onerestore/testdata/data_and_drop_views.json
+++ b/pkg/service/one2onerestore/testdata/data_and_drop_views.json
@@ -1,0 +1,48 @@
+[
+  {
+    "Stage": "DATA",
+    "StartedAt": "2025-01-01T12:00:00Z",
+    "CompletedAt": "2025-01-01T12:00:01Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "TableSize": 10,
+    "Host": "192.168.1.1",
+    "ShardCnt": 4,
+    "Downloaded": 10,
+    "Skipped": 0,
+    "Failed": 0,
+    "AgentJobID": 1
+  },
+  {
+    "Stage": "DATA",
+    "StartedAt": "2025-01-01T12:00:01Z",
+    "CompletedAt": "2025-01-01T12:00:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "TableSize": 20,
+    "Host": "192.168.1.2",
+    "ShardCnt": 4,
+    "Downloaded": 20,
+    "Skipped": 0,
+    "Failed": 0,
+    "AgentJobID": 1
+  },
+  {
+    "Stage": "DROP_VIEWS",
+    "StartedAt": "2025-01-01T11:59:01Z",
+    "CompletedAt": "2025-01-01T11:59:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "ViewName": "v1",
+    "ViewType": "MaterializedView"
+  },
+  {
+    "Stage": "DROP_VIEWS",
+    "StartedAt": "2025-01-01T11:59:03Z",
+    "CompletedAt": "2025-01-01T11:59:04Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "ViewName": "v2",
+    "ViewType": "MaterializedView"
+  }
+]

--- a/pkg/service/one2onerestore/testdata/data_and_recreate_views.json
+++ b/pkg/service/one2onerestore/testdata/data_and_recreate_views.json
@@ -1,0 +1,50 @@
+[
+  {
+    "Stage": "DATA",
+    "StartedAt": "2025-01-01T12:00:00Z",
+    "CompletedAt": "2025-01-01T12:00:01Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "TableSize": 10,
+    "Host": "192.168.1.1",
+    "ShardCnt": 4,
+    "Downloaded": 10,
+    "Skipped": 0,
+    "Failed": 0,
+    "AgentJobID": 1
+  },
+  {
+    "Stage": "DATA",
+    "StartedAt": "2025-01-01T12:00:01Z",
+    "CompletedAt": "2025-01-01T12:00:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "TableSize": 20,
+    "Host": "192.168.1.2",
+    "ShardCnt": 4,
+    "Downloaded": 20,
+    "Skipped": 0,
+    "Failed": 0,
+    "AgentJobID": 1
+  },
+  {
+    "Stage": "RECREATE_VIEWS",
+    "StartedAt": "2025-01-01T12:00:01Z",
+    "CompletedAt": "2025-01-01T12:00:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "ViewName": "v1",
+    "ViewType": "MaterializedView",
+    "ViewBuildStatus": "SUCCESS"
+  },
+  {
+    "Stage": "RECREATE_VIEWS",
+    "StartedAt": "2025-01-01T12:01:03Z",
+    "CompletedAt": "2025-01-01T12:00:04Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "ViewName": "v2",
+    "ViewType": "MaterializedView",
+    "ViewBuildStatus": "SUCCESS"
+  }
+]

--- a/pkg/service/one2onerestore/testdata/data_stage_in_progress.json
+++ b/pkg/service/one2onerestore/testdata/data_stage_in_progress.json
@@ -1,0 +1,47 @@
+
+[
+  {
+    "Stage": "ALTER_TGC",
+    "StartedAt": "2025-01-01T11:58:01Z",
+    "CompletedAt": "2025-01-01T11:58:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "TombstoneGC": "repair"
+  },
+  {
+    "Stage": "ALTER_TGC",
+    "StartedAt": "2025-01-01T11:58:03Z",
+    "CompletedAt": "2025-01-01T11:58:04Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "TombstoneGC": "repair"
+  },
+  {
+    "Stage": "DATA",
+    "StartedAt": "2025-01-01T12:00:00Z",
+    "CompletedAt": null,
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "TableSize": 10,
+    "Host": "192.168.1.1",
+    "ShardCnt": 4,
+    "Downloaded": 0,
+    "Skipped": 0,
+    "Failed": 0,
+    "AgentJobID": 1
+  },
+  {
+    "Stage": "DATA",
+    "StartedAt": "2025-01-01T12:00:01Z",
+    "CompletedAt": null,
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "TableSize": 20,
+    "Host": "192.168.1.2",
+    "ShardCnt": 4,
+    "Downloaded": 0,
+    "Skipped": 0,
+    "Failed": 0,
+    "AgentJobID": 1
+  }
+]

--- a/pkg/service/one2onerestore/testdata/only_data.json
+++ b/pkg/service/one2onerestore/testdata/only_data.json
@@ -1,0 +1,30 @@
+[
+  {
+    "Stage": "DATA",
+    "StartedAt": "2025-01-01T12:00:00Z",
+    "CompletedAt": "2025-01-01T12:00:01Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "TableSize": 10,
+    "Host": "192.168.1.1",
+    "ShardCnt": 4,
+    "Downloaded": 10,
+    "Skipped": 0,
+    "Failed": 0,
+    "AgentJobID": 1
+  },
+  {
+    "Stage": "DATA",
+    "StartedAt": "2025-01-01T12:00:01Z",
+    "CompletedAt": "2025-01-01T12:00:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "TableSize": 20,
+    "Host": "192.168.1.2",
+    "ShardCnt": 4,
+    "Downloaded": 20,
+    "Skipped": 0,
+    "Failed": 0,
+    "AgentJobID": 1
+  }
+]

--- a/pkg/service/one2onerestore/testdata/only_drop_views.json
+++ b/pkg/service/one2onerestore/testdata/only_drop_views.json
@@ -1,0 +1,20 @@
+[
+  {
+    "Stage": "DROP_VIEWS",
+    "StartedAt": "2025-01-01T11:59:01Z",
+    "CompletedAt": "2025-01-01T11:59:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "ViewName": "v1",
+    "ViewType": "MaterializedView"
+  },
+  {
+    "Stage": "DROP_VIEWS",
+    "StartedAt": "2025-01-01T11:59:03Z",
+    "CompletedAt": "2025-01-01T11:59:04Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "ViewName": "v2",
+    "ViewType": "MaterializedView"
+  }
+]

--- a/pkg/service/one2onerestore/testdata/only_tgc.json
+++ b/pkg/service/one2onerestore/testdata/only_tgc.json
@@ -1,0 +1,18 @@
+[
+  {
+    "Stage": "ALTER_TGC",
+    "StartedAt": "2025-01-01T11:58:01Z",
+    "CompletedAt": "2025-01-01T11:58:03Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t1",
+    "TombstoneGC": "repair"
+  },
+  {
+    "Stage": "ALTER_TGC",
+    "StartedAt": "2025-01-01T11:58:03Z",
+    "CompletedAt": "2025-01-01T11:58:04Z",
+    "KeyspaceName": "ks1",
+    "TableName": "t2",
+    "TombstoneGC": "repair"
+  }
+]

--- a/pkg/service/one2onerestore/worker.go
+++ b/pkg/service/one2onerestore/worker.go
@@ -18,6 +18,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/query"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/version"
 	"go.uber.org/multierr"
 )
@@ -29,6 +30,10 @@ type worker struct {
 	clusterSession gocqlx.Session
 
 	logger log.Logger
+
+	runInfo struct {
+		ClusterID, TaskID, RunID uuid.UUID
+	}
 }
 
 func (w *worker) parseTarget(ctx context.Context, properties json.RawMessage) (Target, error) {
@@ -150,6 +155,7 @@ func (w *worker) prepareHostWorkload(ctx context.Context, manifests []*backupspe
 		if err != nil {
 			return errors.Wrap(err, "manifest content")
 		}
+		h.ShardCount = mc.ShardCount
 		hw := hostWorkload{
 			host:            h,
 			manifestInfo:    m,

--- a/pkg/service/one2onerestore/worker_tgc.go
+++ b/pkg/service/one2onerestore/worker_tgc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/scylladb/gocqlx/v2/qb"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 )
 
 // Docs: https://docs.scylladb.com/stable/cql/ddl.html#tombstones-gc-options.
@@ -30,14 +31,17 @@ func (w *worker) setTombstoneGCModeRepair(ctx context.Context, workload []hostWo
 		if err != nil {
 			return errors.Wrap(err, "get tombstone_gc mode")
 		}
+		pr := w.alterTGCProgress(ctx, table, mode)
 		// No need to change tombstone gc mode.
 		if mode == modeDisabled || mode == modeImmediate || mode == modeRepair {
+			w.updateTGCProgress(ctx, pr, mode, timeutc.Now())
 			w.logger.Info(ctx, "Skipping set tombstone_gc mode", "table", table, "mode", mode)
 			continue
 		}
 		if err := w.setTableTombstoneGCMode(ctx, table.keyspace, table.table, modeRepair); err != nil {
 			return errors.Wrap(err, "set tombstone_gc mode repair")
 		}
+		w.updateTGCProgress(ctx, pr, modeRepair, timeutc.Now())
 	}
 
 	return nil

--- a/pkg/service/one2onerestore/worker_validate_integration_test.go
+++ b/pkg/service/one2onerestore/worker_validate_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math/rand/v2"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 
@@ -23,6 +24,9 @@ import (
 )
 
 func TestWorkerValidateClustersIntegration(t *testing.T) {
+	if tablets := os.Getenv("TABLETS"); tablets == "enabled" {
+		t.Skip("1-1-restore is available only for v-nodes")
+	}
 	loc := backupspec.Location{
 		Provider: backupspec.S3,
 		Path:     "my-1-1-restore-test",
@@ -242,7 +246,7 @@ func newTestWorker(t *testing.T, hosts []string) (*worker, *testutils.HackableRo
 		t.Fatalf("new scylla client: %v", err)
 	}
 
-	managerSession := db.CreateManagedClusterSession(t, false, sc, "", "")
+	managerSession := db.CreateScyllaManagerDBSession(t)
 	clusterSession := db.CreateSession(t, sc)
 
 	w := &worker{

--- a/pkg/service/one2onerestore/worker_views.go
+++ b/pkg/service/one2onerestore/worker_views.go
@@ -29,9 +29,11 @@ func (w *worker) dropViews(ctx context.Context, workload []hostWorkload) ([]View
 	}
 
 	for _, view := range views {
+		pr := w.dropViewProgress(ctx, view)
 		if err := w.dropView(ctx, view); err != nil {
 			return nil, errors.Wrap(err, "drop view")
 		}
+		w.updateDropViewProgress(ctx, pr, timeutc.Now())
 	}
 
 	return views, nil
@@ -172,10 +174,11 @@ func (w *worker) reCreateViews(ctx context.Context, views []View) error {
 		w.logger.Info(ctx, "Re-create views", "took", timeutc.Since(start))
 	}()
 	for _, view := range views {
+		pr := w.reCreateViewProgress(ctx, view)
 		if err := w.createView(ctx, view); err != nil {
 			return errors.Wrap(err, "create view")
 		}
-		if err := w.waitForViewBuilding(ctx, view); err != nil {
+		if err := w.waitForViewBuilding(ctx, view, pr); err != nil {
 			return errors.Wrap(err, "wait for view")
 		}
 	}
@@ -210,7 +213,7 @@ func (w *worker) createView(ctx context.Context, view View) error {
 
 // Scylla operation might take a really long (and difficult to estimate) time.
 // This func exits ONLY on: success, context cancel or error.
-func (w *worker) waitForViewBuilding(ctx context.Context, view View) error {
+func (w *worker) waitForViewBuilding(ctx context.Context, view View, pr *RunProgress) error {
 	viewTableName := view.View
 	if view.Type == SecondaryIndex {
 		viewTableName += "_index"
@@ -220,6 +223,8 @@ func (w *worker) waitForViewBuilding(ctx context.Context, view View) error {
 	if err != nil {
 		return err
 	}
+
+	w.updateReCreateViewProgress(ctx, pr, status)
 
 	if status == scyllaclient.StatusUnknown || status == scyllaclient.StatusStarted {
 		w.logger.Info(ctx, "Waiting for view",
@@ -233,7 +238,7 @@ func (w *worker) waitForViewBuilding(ctx context.Context, view View) error {
 			return ctx.Err()
 		case <-time.After(10 * time.Second):
 		}
-		return w.waitForViewBuilding(ctx, view)
+		return w.waitForViewBuilding(ctx, view, pr)
 	}
 
 	return nil

--- a/pkg/service/one2onerestore/worker_views_test.go
+++ b/pkg/service/one2onerestore/worker_views_test.go
@@ -192,11 +192,10 @@ func TestWaitForViewBuilding(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected err: %v", err)
 			}
-
 			w := &worker{
 				client: scyllaclienttest.MakeClient(t, tsAddr.Hostname(), tsAddr.Port()),
 			}
-			err = w.waitForViewBuilding(tc.contextProvider(), tc.view)
+			err = w.waitForViewBuilding(tc.contextProvider(), tc.view, &RunProgress{})
 			if err != nil && !tc.expectedErr {
 				t.Fatalf("Unexpected err: %v", err)
 			}

--- a/schema/v3.5.0.cql
+++ b/schema/v3.5.0.cql
@@ -1,1 +1,35 @@
 ALTER TYPE restore_view ADD build_status text;
+
+CREATE TABLE one2onerestore_run_progress (
+    cluster_id         uuid,
+    task_id            uuid,
+    run_id             uuid,
+
+    remote_sstable_dir text,
+    keyspace_name      text,
+    table_name         text,
+    table_size         bigint,
+    tombstone_gc       text,
+
+    host               text,
+    shard_cnt          bigint,
+
+    agent_job_id       bigint,
+    scylla_task_id     text,
+
+    started_at         timestamp,
+    completed_at       timestamp,
+
+    error              text,
+    downloaded         bigint,
+    skipped            bigint,
+    failed             bigint,
+    versioned_progress bigint,
+
+    view_name          text,
+    view_type          text,
+    view_build_status  text,
+
+    stage              text,
+    PRIMARY KEY ((cluster_id, task_id, run_id), remote_sstable_dir, keyspace_name, table_name, view_name, host, agent_job_id, scylla_task_id)
+) WITH default_time_to_live = 15552000;


### PR DESCRIPTION
This adds progress tracking of various 1-1-restore stage.
Each progress update represented by RunProgress model saved into db.
w.getProgress is used to aggregate current task progress by Keyspaces,
Tables and Hosts.
Implementation is slightly different from regular restore - there is no *_run table for storing the state - it looks like 1-1-restore is much simpler and *_run_progress table should be enough.

sctool rendering of a 1-1-restore progress will be done in a separate PRs, because it require changes in a separate go module - managerclient. 

Pause/Resume is not part of this pr. 

Refs: #4205 

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
