### PR TITLE
goreleaser: Update latest tag on docker hub to actual latest

### DIFF
--- a/dist/.goreleaser-docker.yaml
+++ b/dist/.goreleaser-docker.yaml
@@ -82,5 +82,26 @@ docker_manifests:
     - --insecure
     skip_push: false
 
+  - id: scylla-manager-latest
+    name_template: "scylladb/scylla-manager:latest"
+    image_templates:
+    - "scylladb/scylla-manager:{{ .Version }}-x86_64"
+    - "scylladb/scylla-manager:{{ .Version }}-aarch64"
+    create_flags:
+    - --insecure
+    push_flags:
+    - --insecure
+    skip_push: .Env.SKIP_LATEST_RELEASE
+  
+  - id: scylla-manager-agent-latest
+    name_template: "scylladb/scylla-manager-agent:latest"
+    image_templates:
+    - "scylladb/scylla-manager-agent:{{ .Version }}-x86_64"
+    - "scylladb/scylla-manager-agent:{{ .Version }}-aarch64"
+    create_flags:
+    - --insecure
+    push_flags:
+    - --insecure
+    skip_push: .Env.SKIP_LATEST_RELEASE
 checksum:
   name_template: 'checksums'

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -21,7 +21,7 @@ GORELEASER := goreleaser --clean
 release:
 	git tag -f $(VERSION_NAME)
 	$(GORELEASER) $(publish) --skip=validate --config .goreleaser.yaml
-	$(GORELEASER) --skip=validate --config .goreleaser-docker.yaml
+	SKIP_LATEST_RELEASE=true $(GORELEASER) --skip=validate --config .goreleaser-docker.yaml
 
 .PHONY: snapshot
 snapshot:

--- a/dist/docker/scylla-manager-agent.dockerfile
+++ b/dist/docker/scylla-manager-agent.dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/redhat/ubi9-minimal:latest
 ARG ARCH=x86_64
 
-RUN microdnf update && \
+RUN microdnf -y update && \
     microdnf -y upgrade && \
     microdnf install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*

--- a/dist/docker/scylla-manager.dockerfile
+++ b/dist/docker/scylla-manager.dockerfile
@@ -1,7 +1,7 @@
 FROM docker.io/redhat/ubi9-minimal:latest
 ARG ARCH=x86_64
 
-RUN microdnf update && \
+RUN microdnf -y update && \
     microdnf -y upgrade && \
     microdnf install -y ca-certificates && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
update latest to actual latest tag available by running docker pull scylladb/scylla-manager:latest

Fixes:scylladb#4250
