### PR TITLE
Scheduler: don't skip cron activations

### DIFF
--- a/pkg/scheduler/activation.go
+++ b/pkg/scheduler/activation.go
@@ -20,6 +20,22 @@ type Activation[K comparable] struct {
 	Retry      int8
 	Properties Properties
 	Stop       time.Time
+
+	// PreRescheduleActivation keeps track of initial run activation time.
+	// It is set only for run activations rescheduled by maintenance window
+	// or retries. It helps to improve reschedule mechanism.
+	// PreRescheduleActivation should be accessed by InitialActivation.
+	PreRescheduleActivation time.Time
+}
+
+// InitialActivation returns the activation time of the first run in task
+// execution sequence. Task execution sequence starts with the initial run
+// followed by reschedules triggered by maintenance window and/or retries.
+func InitialActivation[K comparable](a Activation[K]) time.Time {
+	if a.PreRescheduleActivation.IsZero() {
+		return a.Time
+	}
+	return a.PreRescheduleActivation
 }
 
 // activationHeap implements heap.Interface.


### PR DESCRIPTION
Previous behavior for a long run:
```
Cron activation: |-A-------A-------A------ ...
Task execution:  |-[EEEEEEEE]------[EEE]-- ...
```
Fixed behavior:
```
Cron activation: |-A-------A-------A------ ...
Task execution:  |-[EEEEEEEE][EEE]-[EEE]-- ...
```

Previous behavior for retries:
```
Cron activation:      |-A-------A-------A----- ...
Task execution/retry: |-[E]-[R]-[R]-----[EE]-- ...
```

Fixed behavior:
```
Cron activation:      |-A-------A-------A----- ...
Task execution/retry: |-[E]-[R]-[R][EE]-[EE]-- ...
```

Fixes #4309
