### PR TITLE
Remove restore test retries

### DIFF
--- a/pkg/service/restore/helper_integration_test.go
+++ b/pkg/service/restore/helper_integration_test.go
@@ -68,6 +68,7 @@ func newCluster(t *testing.T, hosts []string) clusterHelper {
 	logger := log.NewDevelopmentWithLevel(zapcore.InfoLevel)
 	hrt := NewHackableRoundTripper(scyllaclient.DefaultTransport())
 	clientCfg := scyllaclient.TestConfig(hosts, AgentAuthToken())
+	clientCfg.Backoff.MaxRetries = 0
 	client := newTestClient(t, hrt, logger.Named("client"), &clientCfg)
 
 	for _, h := range hosts {

--- a/pkg/service/restore/restore_integration_test.go
+++ b/pkg/service/restore/restore_integration_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/scylladb/go-log"
 	"github.com/scylladb/gocqlx/v2/qb"
 	"github.com/scylladb/scylla-manager/backupspec"
 	schematable "github.com/scylladb/scylla-manager/v3/pkg/schema/table"
@@ -35,7 +34,6 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/util/query"
 
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
-	"go.uber.org/zap/zapcore"
 )
 
 func TestRestoreTablesUserIntegration(t *testing.T) {
@@ -743,10 +741,6 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 
 func TestRestoreTablesBatchRetryIntegration(t *testing.T) {
 	h := newTestHelper(t, ManagedSecondClusterHosts(), ManagedClusterHosts())
-	// Ensure no built-in retries
-	clientCfg := scyllaclient.TestConfig(ManagedClusterHosts(), AgentAuthToken())
-	clientCfg.Backoff.MaxRetries = 0
-	h.dstCluster.Client = newTestClient(t, h.dstCluster.Hrt, log.NewDevelopmentWithLevel(zapcore.InfoLevel).Named("client"), &clientCfg)
 
 	Print("Keyspace setup")
 	ksStmt := "CREATE KEYSPACE %q WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': %d}"


### PR DESCRIPTION
Client side retries shouldn't be required for restore tests.
On the other hand, they might hide some issues, so it's better
to disable it by default.