### PR TITLE
docker: fix Docker image to pass OpenShift Certification

### DIFF
--- a/dist/.goreleaser-docker.yaml
+++ b/dist/.goreleaser-docker.yaml
@@ -16,6 +16,15 @@ dockers:
     extra_files:
       - docker/scylla-manager.yaml
       - release
+      - license/
+    build_flag_templates:
+      - "--label=name=scylla-manager"
+      - "--label=maintainer=Michał Jan Matczuk <michal@scylladb.com>"
+      - "--label=vendor=ScyllaDB, Inc."
+      - "--label=version={{.Version}}"
+      - "--label=release=1"
+      - "--label=summary=Scylla Manager"
+      - "--label=description=Scylla Manager"
 
   - ids:
     use: docker
@@ -28,9 +37,17 @@ dockers:
     extra_files:
       - docker/scylla-manager.yaml
       - release/
+      - license/
     build_flag_templates:
       - "--build-arg=ARCH=aarch64"
       - "--platform=linux/aarch64"
+      - "--label=name=scylla-manager"
+      - "--label=maintainer=Michał Jan Matczuk <michal@scylladb.com>"
+      - "--label=vendor=ScyllaDB, Inc."
+      - "--label=version={{.Version}}"
+      - "--label=release=1"
+      - "--label=summary=Scylla Manager"
+      - "--label=description=Scylla Manager"
 
   - ids:
     use: docker
@@ -43,6 +60,15 @@ dockers:
     extra_files:
       - docker/scylla-manager.yaml
       - release
+      - license/
+    build_flag_templates:
+      - "--label=name=scylla-manager-agent"
+      - "--label=maintainer=Michał Jan Matczuk <michal@scylladb.com>"
+      - "--label=vendor=ScyllaDB, Inc."
+      - "--label=version={{.Version}}"
+      - "--label=release=1"
+      - "--label=summary=Scylla Manager Agent"
+      - "--label=description=Scylla Manager Agent"
 
   - ids:
     use: docker
@@ -55,9 +81,17 @@ dockers:
     extra_files:
       - docker/scylla-manager.yaml
       - release
+      - license/
     build_flag_templates:
       - "--build-arg=ARCH=aarch64"
       - "--platform=linux/aarch64"
+      - "--label=name=scylla-manager-agent"
+      - "--label=maintainer=Michał Jan Matczuk <michal@scylladb.com>"
+      - "--label=vendor=ScyllaDB, Inc."
+      - "--label=version={{.Version}}"
+      - "--label=release=1"
+      - "--label=summary=Scylla Manager Agent"
+      - "--label=description=Scylla Manager Agent"
 
 docker_manifests:
   - id: scylla-manager

--- a/dist/docker/scylla-manager-agent.dockerfile
+++ b/dist/docker/scylla-manager-agent.dockerfile
@@ -8,6 +8,7 @@ RUN microdnf -y update && \
 
 COPY release/scylla-manager-agent*$ARCH.rpm /
 RUN rpm -ivh scylla-manager-agent*$ARCH.rpm && rm /scylla-manager-agent*.rpm
+COPY license/LICENSE.* /licenses/
 
 USER scylla-manager
 ENV HOME=/var/lib/scylla-manager/

--- a/dist/docker/scylla-manager.dockerfile
+++ b/dist/docker/scylla-manager.dockerfile
@@ -9,6 +9,7 @@ RUN microdnf -y update && \
 COPY release/scylla-manager-*$ARCH.rpm /
 RUN rpm -ivh scylla-manager-*$ARCH.rpm && rm /scylla-manager-*.rpm
 COPY docker/scylla-manager.yaml /etc/scylla-manager/
+COPY license/LICENSE.* /licenses/
 
 USER scylla-manager
 ENV HOME=/var/lib/scylla-manager/


### PR DESCRIPTION
To make docker image ready for Red Hat OpenShift Software Certification,
we need to fix following requirements which mentioned on the document of
the certification:
 - HasRequiredLabel: we need to define labels which describes the image
 - HasLicense: we need to add license file to /licenses

(described at:
https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html/red_hat_openstack_certification_policy_guide/index)

With this patch, openshift-preflight will returns following result:
  "Preflight result: PASSED"

related #4242
