### PR TITLE
cqlping: perform a query and not a scan

### DIFF
--- a/docs/source/health-check.rst
+++ b/docs/source/health-check.rst
@@ -141,7 +141,7 @@ CQL query health check
 
 You may specify CQL ``username`` and ``password`` flags when adding cluster to Scylla Manager using :ref:`sctool cluster add <cluster-add>` command.
 It's also possible to add or change that using :ref:`sctool cluster update <cluster-update>` command.
-Once Scylla Manager has CQL credential to the cluster, when performing a health check, it would try to connect to each node and execute ``SELECT now() FROM system.local`` query.
+Once Scylla Manager has CQL credential to the cluster, when performing a health check, it would try to connect to each node and execute ``SELECT now() FROM system.local WHERE key='local'`` query.
 
 
 .. _scylla-alternator-health-check:

--- a/pkg/ping/cqlping/cqlping.go
+++ b/pkg/ping/cqlping/cqlping.go
@@ -98,7 +98,7 @@ var cqlUnauthorisedMessage = []string{
 	"Username and/or password are incorrect",
 }
 
-// QueryPing executes "SELECT now() FROM system.local" on a single host.
+// QueryPing executes "SELECT now() FROM system.local WHERE key='local'" on a single host.
 // It returns rtt and error.
 func QueryPing(_ context.Context, config Config, username, password string) (rtt time.Duration, err error) {
 	host, port, err := net.SplitHostPort(config.Addr)
@@ -169,7 +169,7 @@ func QueryPing(_ context.Context, config Config, username, password string) (rtt
 	defer e.Close()
 
 	var date []byte
-	iter := e.Iter("SELECT now() FROM system.local")
+	iter := e.Iter("SELECT now() FROM system.local WHERE key='local'")
 	iter.Scan(&date)
 	return 0, iter.Close()
 }


### PR DESCRIPTION
Very similar to changes we've recently made in the drivers (see scylladb/java-driver#282 and scylladb/python-driver#418 , the query to system.local should be with the WHERE close to prevent a scan and just issue a local query.

Fixes: https://github.com/scylladb/scylla-manager/issues/4329

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
