### PR TITLE
docker: small fix-ups for UBI9 containers

### DIFF
--- a/dist/docker/scylla-manager-agent.dockerfile
+++ b/dist/docker/scylla-manager-agent.dockerfile
@@ -1,14 +1,15 @@
-FROM docker.io/redhat/ubi9-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 ARG ARCH=x86_64
+
+COPY release/scylla-manager-agent*$ARCH.rpm /
+COPY license/LICENSE.* /licenses/
 
 RUN microdnf -y update && \
     microdnf -y upgrade && \
     microdnf install -y ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY release/scylla-manager-agent*$ARCH.rpm /
-RUN rpm -ivh scylla-manager-agent*$ARCH.rpm && rm /scylla-manager-agent*.rpm
-COPY license/LICENSE.* /licenses/
+    microdnf clean all && \
+    rpm -ivh scylla-manager-agent*$ARCH.rpm && \
+    rm /scylla-manager-agent*.rpm
 
 USER scylla-manager
 ENV HOME=/var/lib/scylla-manager/

--- a/dist/docker/scylla-manager.dockerfile
+++ b/dist/docker/scylla-manager.dockerfile
@@ -1,15 +1,16 @@
-FROM docker.io/redhat/ubi9-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 ARG ARCH=x86_64
+
+COPY release/scylla-manager-*$ARCH.rpm /
+COPY docker/scylla-manager.yaml /etc/scylla-manager/
+COPY license/LICENSE.* /licenses/
 
 RUN microdnf -y update && \
     microdnf -y upgrade && \
     microdnf install -y ca-certificates && \
-    rm -rf /var/lib/apt/lists/*
-
-COPY release/scylla-manager-*$ARCH.rpm /
-RUN rpm -ivh scylla-manager-*$ARCH.rpm && rm /scylla-manager-*.rpm
-COPY docker/scylla-manager.yaml /etc/scylla-manager/
-COPY license/LICENSE.* /licenses/
+    microdnf clean all && \
+    rpm -ivh scylla-manager-*$ARCH.rpm && \
+    rm /scylla-manager-*.rpm
 
 USER scylla-manager
 ENV HOME=/var/lib/scylla-manager/


### PR DESCRIPTION
Do following fix-ups pointed out on #4280:

- Use Red Hat registry for UBI image
- Minimize layers
- Run cleanup of microdnf

fixes #4280
