### PR TITLE
Don't support Scylla 6.2 with SM 3.5 (branch-3.5)

### DIFF
--- a/docs/source/compatibility-matrix.rst
+++ b/docs/source/compatibility-matrix.rst
@@ -13,7 +13,7 @@ The following table shows which version of Scylla Manager supports which version
      - ScyllaDB Open Source Version
      - ScyllaDB Enterprise Version
    * - 3.5
-     - 6.2
+     -
      - 2024.1, 2024.2, 2025.1
    * - 3.4
      - 5.4, 6.0, 6.1, 6.2


### PR DESCRIPTION
It might encourage users to keep on using OSS
Scylla with SM that moved to AGPL and does not
have the 5 nodes limitation.

Duplicate of #4338 for `branch-3.5`. 