### PR TITLE
fix(restore): fixes restore stream_duration metric

### DIFF
--- a/pkg/service/restore/tablesdir_worker.go
+++ b/pkg/service/restore/tablesdir_worker.go
@@ -255,7 +255,7 @@ func (w *tablesWorker) onLasEnd(ctx context.Context, b batch, pr *RunProgress) {
 	pr.setRestoreCompletedAt()
 	pr.Restored = pr.Downloaded + pr.VersionedProgress
 	w.metrics.IncreaseRestoreStreamedBytes(w.run.ClusterID, pr.Host, b.Size)
-	w.metrics.IncreaseRestoreStreamDuration(w.run.ClusterID, pr.Host, timeSub(pr.RestoreStartedAt, pr.RestoreCompletedAt, timeutc.Now()))
+	w.metrics.IncreaseRestoreStreamDuration(w.run.ClusterID, pr.Host, timeSub(pr.DownloadCompletedAt, pr.RestoreCompletedAt, timeutc.Now()))
 
 	labels := metrics.RestoreBytesLabels{
 		ClusterID:   b.ClusterID.String(),


### PR DESCRIPTION
This fixes restore `stream_duration` metrics to make it aligned with restore progress. 

Fixes: #4358

Here is how stream_duration is calculated for a restore progress - https://github.com/scylladb/scylla-manager/blob/b29577e75f2da56140aa3128a1fb1ad7fadadbb5/pkg/service/restore/progress.go#L142. 

Tested this fix manually by following reproduce steps from #4358. Other metrics looks good to me. 
Not sure if it worth the effort to add some checks into integration tests.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
