### PR TITLE
feat(1-1-restore): fail validation if tablet-based keyspaces are present

### DIFF
--- a/pkg/service/one2onerestore/model.go
+++ b/pkg/service/one2onerestore/model.go
@@ -91,7 +91,7 @@ func getTablesToRestore(workload []hostWorkload) map[scyllaTable]struct{} {
 	return tablesToRestore
 }
 
-func (t *Target) validateProperties(keyspaces []string) error {
+func (t *Target) validateProperties(allKeyspaces []string) error {
 	if len(t.Location) == 0 {
 		return errors.New("missing location")
 	}
@@ -101,7 +101,7 @@ func (t *Target) validateProperties(keyspaces []string) error {
 	if t.SourceClusterID == uuid.Nil {
 		return errors.New("source cluster id is empty")
 	}
-	if err := validateKeyspaceFilter(t.Keyspace, keyspaces); err != nil {
+	if err := validateKeyspaceFilter(t.Keyspace, allKeyspaces); err != nil {
 		return errors.Wrap(err, "keyspace filter")
 	}
 	if err := validateNodesMapping(t.NodesMapping); err != nil {

--- a/pkg/service/one2onerestore/progress_integration_test.go
+++ b/pkg/service/one2onerestore/progress_integration_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestGetProgressIntegration(t *testing.T) {
-	if tablets := os.Getenv("TABLETS"); tablets == "enabled" {
+	if tablets := os.Getenv("TABLETS"); tablets == "enabled" || tablets == "none" {
 		t.Skip("1-1-restore is available only for v-nodes")
 	}
 	loc := backupspec.Location{

--- a/pkg/service/one2onerestore/service_integration_test.go
+++ b/pkg/service/one2onerestore/service_integration_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestOne2OneRestoreServiceIntegration(t *testing.T) {
-	if tablets := os.Getenv("TABLETS"); tablets == "enabled" {
+	if tablets := os.Getenv("TABLETS"); tablets == "enabled" || tablets == "none" {
 		t.Skip("1-1-restore is available only for v-nodes")
 	}
 	h := newTestHelper(t, ManagedClusterHosts())

--- a/pkg/service/one2onerestore/worker.go
+++ b/pkg/service/one2onerestore/worker.go
@@ -226,6 +226,8 @@ func skipRestorePatterns(ctx context.Context, client *scyllaclient.Client, sessi
 			skip = append(skip, ks)
 		}
 	}
+	// See https://github.com/scylladb/scylla-enterprise/issues/4168
+	skip = append(skip, "system_replicated_keys")
 
 	// Skip outdated tables.
 	// Note that even though system_auth is not used in Scylla 6.0,

--- a/pkg/service/one2onerestore/worker.go
+++ b/pkg/service/one2onerestore/worker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/scylla-manager/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/inexlist/ksfilter"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/query"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
@@ -54,6 +55,14 @@ func (w *worker) parseTarget(ctx context.Context, properties json.RawMessage) (T
 	}
 	w.logger.Info(ctx, "Extended excluded tables pattern", "pattern", skip)
 	target.Keyspace = append(target.Keyspace, skip...)
+
+	tabletKeyspaces, err := w.client.FilteredKeyspaces(ctx, scyllaclient.KeyspaceTypeUser, scyllaclient.ReplicationTablet)
+	if err != nil {
+		return Target{}, errors.Wrap(err, "get tablet keyspaces")
+	}
+	if err := tabletKeyspacesAreNotSupported(target.Keyspace, tabletKeyspaces); err != nil {
+		return Target{}, err
+	}
 	return target, nil
 }
 
@@ -303,5 +312,19 @@ func isRestoreAuthAndServiceLevelsFromSStablesSupported(ctx context.Context, cli
 		}
 	}
 
+	return nil
+}
+
+// 1-1-restore can work only with vnode replication keyspaces.
+func tabletKeyspacesAreNotSupported(keyspaceFilter, tabletKeyspaces []string) error {
+	filter, err := ksfilter.NewFilter(keyspaceFilter)
+	if err != nil {
+		return errors.Wrap(err, "new keyspace filter")
+	}
+	for _, ks := range tabletKeyspaces {
+		if filter.Check(ks, "") {
+			return errors.Errorf("1-1-restore doesn't support tablet based replication. Keyspace: %s", ks)
+		}
+	}
 	return nil
 }

--- a/pkg/service/one2onerestore/worker_test.go
+++ b/pkg/service/one2onerestore/worker_test.go
@@ -83,3 +83,43 @@ func TestFindNodeFromDC(t *testing.T) {
 		})
 	}
 }
+
+func TestTabletKeyspacesAreNotSupported(t *testing.T) {
+	testCases := []struct {
+		name            string
+		keyspaceFilter  []string
+		tabletKeyspaces []string
+		expectedErr     string
+	}{
+		{
+			name:            "no tablet keyspaces",
+			keyspaceFilter:  []string{"*"},
+			tabletKeyspaces: nil,
+		},
+		{
+			name:            "tablet keyspace, but not included into the keyspaceFilter",
+			keyspaceFilter:  []string{"vnode-keyspace"},
+			tabletKeyspaces: []string{"tablet-keyspace"},
+		},
+		{
+			name:            "tablet keyspace, included into the keyspacesFilter",
+			keyspaceFilter:  []string{"*"},
+			tabletKeyspaces: []string{"tablet-keyspace"},
+			expectedErr:     "1-1-restore doesn't support tablet based replication. Keyspace: tablet-keyspace",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tabletKeyspacesAreNotSupported(tc.keyspaceFilter, tc.tabletKeyspaces)
+			if err != nil {
+				if tc.expectedErr != err.Error() {
+					t.Fatalf("Expected err: %s, but got %s", tc.expectedErr, err.Error())
+				}
+			}
+			if err == nil && tc.expectedErr != "" {
+				t.Fatalf("Expected err: %s, but got nil", tc.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds additional validation to check that there are no tablet based keyspaces in the cluster, because 1-1-restore can work only with vnodes.

Refs: #4254

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
