### PR TITLE
fix(repair_test): decrease node start flakiness

### DIFF
--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -299,15 +299,15 @@ func (h *repairTestHelper) startNode(host string, ni *scyllaclient.NodeInfo) {
 		if _, err = cqlping.QueryPing(context.Background(), cfg, TestDBUsername(), TestDBPassword()); err != nil {
 			return false
 		}
-		status, err := h.Client.Status(context.Background())
-		if err != nil {
-			return false
+		for _, other := range ManagedClusterHosts() {
+			status, err := h.Client.Status(scyllaclient.ClientContextWithSelectedHost(context.Background(), other))
+			if err != nil || len(status.Live()) != len(ManagedClusterHosts()) {
+				return false
+			}
 		}
-		return len(status.Live()) == len(ManagedClusterHosts())
+		return true
 	}
-
 	WaitCond(h.T, cond, time.Second, shortWait)
-	time.Sleep(time.Second)
 }
 
 func percentComplete(p repair.Progress) (int, int) {


### PR DESCRIPTION
It's important to wait for all nodes to perceive all nodes as live before moving forward with the test.

Example flakiness: https://github.com/scylladb/scylla-manager/actions/runs/14728318840/job/41336270422?pr=4364