### PR TITLE
feat(1-1-restore): add metrics to 1-1-restore

### DIFF
--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -145,6 +145,7 @@ func (s *server) makeServices(ctx context.Context) error {
 		s.clusterSvc.GetSession,
 		s.configCacheSvc,
 		s.logger.Named("one2onerestore"),
+		metrics.NewOne2OneRestoreMetrics().MustRegister(),
 	)
 	if err != nil {
 		return errors.Wrapf(err, "one2onerestore service")

--- a/pkg/metrics/one2onerestore.go
+++ b/pkg/metrics/one2onerestore.go
@@ -19,10 +19,11 @@ func NewOne2OneRestoreMetrics() One2OneRestoreMetrics {
 
 	return One2OneRestoreMetrics{
 		remainingBytes: g("Remaining bytes of backup to be restored yet.", "download_remaining_bytes",
-			"source_cluster", "cluster", "snapshot_tag", "location", "dc", "node", "keyspace", "table"),
-		state: g("Defines current state of the 1-1-restore process (downloading/loading/error/done).",
-			"state", "source_cluster", "cluster", "location", "snapshot_tag", "host"),
-		viewBuildStatus: g("Defines build status of recreated view.", "view_build_status", "cluster", "keyspace", "view"),
+			"cluster", "snapshot_tag", "location", "dc", "node", "keyspace", "table"),
+		state: g("Defines current state of the 1-1-restore process (downloading/loading/error/done).", "state",
+			"cluster", "location", "snapshot_tag", "host"),
+		viewBuildStatus: g("Defines build status of recreated view.", "view_build_status",
+			"cluster", "keyspace", "view"),
 	}
 }
 
@@ -49,26 +50,25 @@ func (m One2OneRestoreMetrics) ResetClusterMetrics(clusterID uuid.UUID) {
 
 // One2OneRestoreBytesLabels is a set of labels for restore metrics.
 type One2OneRestoreBytesLabels struct {
-	SourceClusterID, ClusterID string
-	SnapshotTag                string
-	Location                   string
-	DC                         string
-	Node                       string
-	Keyspace                   string
-	Table                      string
+	ClusterID   string
+	SnapshotTag string
+	Location    string
+	DC          string
+	Node        string
+	Keyspace    string
+	Table       string
 }
 
 // SetDownloadRemainingBytes sets download_remaining_bytes metrics.
 func (m One2OneRestoreMetrics) SetDownloadRemainingBytes(labels One2OneRestoreBytesLabels, remainingBytes float64) {
 	l := prometheus.Labels{
-		"source_cluster": labels.SourceClusterID,
-		"cluster":        labels.ClusterID,
-		"snapshot_tag":   labels.SnapshotTag,
-		"location":       labels.Location,
-		"dc":             labels.DC,
-		"node":           labels.Node,
-		"keyspace":       labels.Keyspace,
-		"table":          labels.Table,
+		"cluster":      labels.ClusterID,
+		"snapshot_tag": labels.SnapshotTag,
+		"location":     labels.Location,
+		"dc":           labels.DC,
+		"node":         labels.Node,
+		"keyspace":     labels.Keyspace,
+		"table":        labels.Table,
 	}
 	m.remainingBytes.With(l).Set(remainingBytes)
 }
@@ -88,13 +88,12 @@ const (
 )
 
 // SetOne2OneRestoreState sets 1-1-restore "state" metric.
-func (m One2OneRestoreMetrics) SetOne2OneRestoreState(sourceClusterID, clusterID uuid.UUID, location backupspec.Location, snapshotTag, host string, state One2OneRestoreState) {
+func (m One2OneRestoreMetrics) SetOne2OneRestoreState(clusterID uuid.UUID, location backupspec.Location, snapshotTag, host string, state One2OneRestoreState) {
 	l := prometheus.Labels{
-		"source_cluster": sourceClusterID.String(),
-		"cluster":        clusterID.String(),
-		"location":       location.String(),
-		"snapshot_tag":   snapshotTag,
-		"host":           host,
+		"cluster":      clusterID.String(),
+		"location":     location.String(),
+		"snapshot_tag": snapshotTag,
+		"host":         host,
 	}
 	m.state.With(l).Set(float64(state))
 }

--- a/pkg/metrics/one2onerestore.go
+++ b/pkg/metrics/one2onerestore.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2025 ScyllaDB
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/scylladb/scylla-manager/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+)
+
+type One2OneRestoreMetrics struct {
+	remainingBytes  *prometheus.GaugeVec
+	state           *prometheus.GaugeVec
+	viewBuildStatus *prometheus.GaugeVec
+}
+
+func NewOne2OneRestoreMetrics() One2OneRestoreMetrics {
+	g := gaugeVecCreator("one2onerestore")
+
+	return One2OneRestoreMetrics{
+		remainingBytes: g("Remaining bytes of backup to be restored yet.", "download_remaining_bytes",
+			"source_cluster", "cluster", "snapshot_tag", "location", "dc", "node", "keyspace", "table"),
+		state: g("Defines current state of the 1-1-restore process (downloading/loading/error/done).",
+			"state", "source_cluster", "cluster", "location", "snapshot_tag", "host"),
+		viewBuildStatus: g("Defines build status of recreated view.", "view_build_status", "cluster", "keyspace", "view"),
+	}
+}
+
+// MustRegister shall be called to make the metrics visible by prometheus client.
+func (m One2OneRestoreMetrics) MustRegister() One2OneRestoreMetrics {
+	prometheus.MustRegister(m.all()...)
+	return m
+}
+
+func (m One2OneRestoreMetrics) all() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.remainingBytes,
+		m.state,
+		m.viewBuildStatus,
+	}
+}
+
+// ResetClusterMetrics resets all 1-1-restore metrics labeled with the cluster.
+func (m One2OneRestoreMetrics) ResetClusterMetrics(clusterID uuid.UUID) {
+	for _, c := range m.all() {
+		setGaugeVecMatching(c.(*prometheus.GaugeVec), unspecifiedValue, clusterMatcher(clusterID))
+	}
+}
+
+// One2OneRestoreBytesLabels is a set of labels for restore metrics.
+type One2OneRestoreBytesLabels struct {
+	SourceClusterID, ClusterID string
+	SnapshotTag                string
+	Location                   string
+	DC                         string
+	Node                       string
+	Keyspace                   string
+	Table                      string
+}
+
+// SetDownloadRemainingBytes sets download_remaining_bytes metrics.
+func (m One2OneRestoreMetrics) SetDownloadRemainingBytes(labels One2OneRestoreBytesLabels, remainingBytes float64) {
+	l := prometheus.Labels{
+		"source_cluster": labels.SourceClusterID,
+		"cluster":        labels.ClusterID,
+		"snapshot_tag":   labels.SnapshotTag,
+		"location":       labels.Location,
+		"dc":             labels.DC,
+		"node":           labels.Node,
+		"keyspace":       labels.Keyspace,
+		"table":          labels.Table,
+	}
+	m.remainingBytes.With(l).Set(remainingBytes)
+}
+
+// One2OneRestoreState is the enum that defines how node is used during the 1-1-restore.
+type One2OneRestoreState int
+
+const (
+	// One2OneRestoreStateDownloading means that node is downloading data from backup location.
+	One2OneRestoreStateDownloading = iota
+	// One2OneRestoreStateLoading means that node is calling load sstables (nodetool refresh).
+	One2OneRestoreStateLoading
+	// One2OneRestoreStateDone means that node ended downloading and loading data.
+	One2OneRestoreStateDone
+	// One2OneRestoreStateError means that node ended up with error.
+	One2OneRestoreStateError
+)
+
+// SetOne2OneRestoreState sets 1-1-restore "state" metric.
+func (m One2OneRestoreMetrics) SetOne2OneRestoreState(sourceClusterID, clusterID uuid.UUID, location backupspec.Location, snapshotTag, host string, state One2OneRestoreState) {
+	l := prometheus.Labels{
+		"source_cluster": sourceClusterID.String(),
+		"cluster":        clusterID.String(),
+		"location":       location.String(),
+		"snapshot_tag":   snapshotTag,
+		"host":           host,
+	}
+	m.state.With(l).Set(float64(state))
+}
+
+// SetViewBuildStatus sets 1-1-restore "view_build_status" metric.
+func (m One2OneRestoreMetrics) SetViewBuildStatus(clusterID uuid.UUID, keyspace, view string, status ViewBuildStatus) {
+	l := prometheus.Labels{
+		"cluster":  clusterID.String(),
+		"keyspace": keyspace,
+		"view":     view,
+	}
+	m.viewBuildStatus.With(l).Set(float64(status))
+}

--- a/pkg/service/one2onerestore/helpers_integration_test.go
+++ b/pkg/service/one2onerestore/helpers_integration_test.go
@@ -152,6 +152,7 @@ func newRestoreSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient
 		},
 		configCacheSvc,
 		log.NewDevelopmentWithLevel(zapcore.InfoLevel).Named("1-1-restore"),
+		metrics.NewOne2OneRestoreMetrics(),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/service/one2onerestore/progress_integration_test.go
+++ b/pkg/service/one2onerestore/progress_integration_test.go
@@ -71,7 +71,7 @@ func TestGetProgressIntegration(t *testing.T) {
 		t.Fatalf("Expected empty progress, but got: %v", pr)
 	}
 
-	w.initProgress(context.Background(), workload)
+	w.initProgressAndMetrics(context.Background(), workload)
 
 	pr, err = w.getProgress(context.Background())
 	if err != nil {

--- a/pkg/service/one2onerestore/service.go
+++ b/pkg/service/one2onerestore/service.go
@@ -100,8 +100,8 @@ func (s *Service) One2OneRestore(ctx context.Context, clusterID, taskID, runID u
 		return errors.Wrap(err, "prepare hosts workload")
 	}
 
-	if err := w.initProgress(ctx, workload); err != nil {
-		return errors.Wrap(err, "init progress")
+	if err := w.initProgressAndMetrics(ctx, workload); err != nil {
+		return errors.Wrap(err, "init progress and metrics")
 	}
 
 	start := timeutc.Now()

--- a/pkg/service/one2onerestore/worker.go
+++ b/pkg/service/one2onerestore/worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/scylla-manager/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/inexlist/ksfilter"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
@@ -30,7 +31,8 @@ type worker struct {
 	client         *scyllaclient.Client
 	clusterSession gocqlx.Session
 
-	logger log.Logger
+	logger  log.Logger
+	metrics metrics.One2OneRestoreMetrics
 
 	runInfo struct {
 		ClusterID, TaskID, RunID uuid.UUID

--- a/pkg/service/one2onerestore/worker_tables.go
+++ b/pkg/service/one2onerestore/worker_tables.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-manager/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
 )
@@ -18,29 +19,34 @@ func (w *worker) restoreTables(ctx context.Context, workload []hostWorkload, key
 	}
 	return parallel.Run(len(workload), len(workload), func(i int) error {
 		hostTask := workload[i]
+		manifestInfo, host := hostTask.manifestInfo, hostTask.host
 		const (
 			repeatInterval  = 10 * time.Second
 			pollIntervalSec = 10
 		)
-
-		return hostTask.manifestContent.ForEachIndexIterWithError(keyspaces, func(table backupspec.FilesMeta) error {
+		if err := hostTask.manifestContent.ForEachIndexIterWithError(keyspaces, func(table backupspec.FilesMeta) error {
 			w.logger.Info(ctx, "Restoring data", "ks", table.Keyspace, "table", table.Table, "size", table.Size)
 
-			jobID, err := w.createDownloadJob(ctx, table, hostTask.manifestInfo, hostTask.host)
+			jobID, err := w.createDownloadJob(ctx, table, manifestInfo, host)
 			if err != nil {
 				return errors.Wrapf(err, "create download job: %s.%s", table.Keyspace, table.Table)
 			}
 			pr := w.downloadProgress(ctx, hostTask.host.Addr, table)
 
-			if err := w.waitJob(ctx, jobID, hostTask.host, pr, pollIntervalSec); err != nil {
+			if err := w.waitJob(ctx, jobID, manifestInfo, host, pr, pollIntervalSec); err != nil {
 				return errors.Wrapf(err, "wait job: %s.%s", table.Keyspace, table.Table)
 			}
 
-			if err := w.refreshNode(ctx, table, hostTask.host, pr); err != nil {
+			if err := w.refreshNode(ctx, table, manifestInfo, host, pr); err != nil {
 				return errors.Wrapf(err, "refresh node: %s.%s", table.Keyspace, table.Table)
 			}
 			return nil
-		})
+		}); err != nil {
+			w.metrics.SetOne2OneRestoreState(manifestInfo.ClusterID, w.runInfo.ClusterID, manifestInfo.Location, manifestInfo.SnapshotTag, host.Addr, metrics.One2OneRestoreStateError)
+			return err
+		}
+		w.metrics.SetOne2OneRestoreState(manifestInfo.ClusterID, w.runInfo.ClusterID, manifestInfo.Location, manifestInfo.SnapshotTag, host.Addr, metrics.One2OneRestoreStateDone)
+		return nil
 	}, logError)
 }
 
@@ -51,16 +57,28 @@ func (w *worker) createDownloadJob(ctx context.Context, table backupspec.FilesMe
 	if err != nil {
 		return 0, errors.Wrapf(err, "copy dir: %s", m.LocationSSTableVersionDir(table.Keyspace, table.Table, table.Version))
 	}
+	w.metrics.SetOne2OneRestoreState(m.ClusterID, w.runInfo.ClusterID, m.Location, m.SnapshotTag, h.Addr, metrics.One2OneRestoreStateDownloading)
+	w.metrics.SetDownloadRemainingBytes(metrics.One2OneRestoreBytesLabels{
+		SourceClusterID: m.ClusterID.String(),
+		ClusterID:       w.runInfo.ClusterID.String(),
+		SnapshotTag:     m.SnapshotTag,
+		Location:        m.Location.String(),
+		DC:              h.DC,
+		Node:            h.Addr,
+		Keyspace:        table.Keyspace,
+		Table:           table.Table,
+	}, float64(table.Size))
 	return jobID, nil
 }
 
-func (w *worker) refreshNode(ctx context.Context, table backupspec.FilesMeta, h Host, pr *RunTableProgress) error {
+func (w *worker) refreshNode(ctx context.Context, table backupspec.FilesMeta, m *backupspec.ManifestInfo, h Host, pr *RunTableProgress) error {
+	w.metrics.SetOne2OneRestoreState(m.ClusterID, w.runInfo.ClusterID, m.Location, m.SnapshotTag, h.Addr, metrics.One2OneRestoreStateLoading)
 	err := w.client.AwaitLoadSSTables(ctx, h.Addr, table.Keyspace, table.Table, false, false)
 	w.finishDownloadProgress(ctx, pr, err)
 	return err
 }
 
-func (w *worker) waitJob(ctx context.Context, jobID int64, h Host, pr *RunTableProgress, pollIntervalSec int) (err error) {
+func (w *worker) waitJob(ctx context.Context, jobID int64, m *backupspec.ManifestInfo, h Host, pr *RunTableProgress, pollIntervalSec int) (err error) {
 	defer func() {
 		cleanCtx := context.Background()
 		// On error stop job
@@ -81,6 +99,16 @@ func (w *worker) waitJob(ctx context.Context, jobID int64, h Host, pr *RunTableP
 			return errors.Wrap(err, "fetch job info")
 		}
 		w.updateDownloadProgress(ctx, pr, job)
+		w.metrics.SetDownloadRemainingBytes(metrics.One2OneRestoreBytesLabels{
+			SourceClusterID: m.ClusterID.String(),
+			ClusterID:       w.runInfo.ClusterID.String(),
+			SnapshotTag:     m.SnapshotTag,
+			Location:        m.Location.String(),
+			DC:              h.DC,
+			Node:            h.Addr,
+			Keyspace:        pr.Keyspace,
+			Table:           pr.Table,
+		}, float64(pr.TableSize-job.Uploaded))
 
 		switch scyllaclient.RcloneJobStatus(job.Status) {
 		case scyllaclient.JobError:

--- a/pkg/service/one2onerestore/worker_tables.go
+++ b/pkg/service/one2onerestore/worker_tables.go
@@ -58,15 +58,6 @@ func (w *worker) createDownloadJob(ctx context.Context, table backupspec.FilesMe
 		return 0, errors.Wrapf(err, "copy dir: %s", m.LocationSSTableVersionDir(table.Keyspace, table.Table, table.Version))
 	}
 	w.metrics.SetOne2OneRestoreState(w.runInfo.ClusterID, m.Location, m.SnapshotTag, h.Addr, metrics.One2OneRestoreStateDownloading)
-	w.metrics.SetDownloadRemainingBytes(metrics.One2OneRestoreBytesLabels{
-		ClusterID:   w.runInfo.ClusterID.String(),
-		SnapshotTag: m.SnapshotTag,
-		Location:    m.Location.String(),
-		DC:          h.DC,
-		Node:        h.Addr,
-		Keyspace:    table.Keyspace,
-		Table:       table.Table,
-	}, float64(table.Size))
 	return jobID, nil
 }
 

--- a/pkg/service/one2onerestore/worker_validate_integration_test.go
+++ b/pkg/service/one2onerestore/worker_validate_integration_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/scylla-manager/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/testutils"
 	"github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
@@ -254,6 +255,7 @@ func newTestWorker(t *testing.T, hosts []string) (*worker, *testutils.HackableRo
 		client:         sc,
 		clusterSession: clusterSession,
 		logger:         log.NopLogger,
+		metrics:        metrics.NewOne2OneRestoreMetrics(),
 	}
 	return w, hrt
 }

--- a/pkg/service/one2onerestore/worker_views_test.go
+++ b/pkg/service/one2onerestore/worker_views_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient/scyllaclienttest"
 )
 
@@ -195,7 +196,8 @@ func TestWaitForViewBuilding(t *testing.T) {
 				t.Fatalf("Unexpected err: %v", err)
 			}
 			w := &worker{
-				client: scyllaclienttest.MakeClient(t, tsAddr.Hostname(), tsAddr.Port()),
+				client:  scyllaclienttest.MakeClient(t, tsAddr.Hostname(), tsAddr.Port()),
+				metrics: metrics.NewOne2OneRestoreMetrics(),
 			}
 			err = w.waitForViewBuilding(tc.contextProvider(), tc.view, &RunViewProgress{})
 			if err != nil && !tc.expectedErr {


### PR DESCRIPTION
This adds following metrics to 1-1-restore:
    - download_remaining_bytes
    - state: downloading (0), loading (1), done (2), error (3) 
    - view_build_status: unknown (0), started (1), success (2), error (3)

Refs: #4204

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
