### PR TITLE
feat(1-1-restore): add progress and rendering to v3/managerclient module

### DIFF
--- a/v3/pkg/managerclient/client.go
+++ b/v3/pkg/managerclient/client.go
@@ -543,6 +543,23 @@ func (c *Client) ValidateBackupProgress(ctx context.Context, clusterID, taskID, 
 	}, nil
 }
 
+// One2OneRestoreProgress returns 1-1-restore progress.
+func (c *Client) One2OneRestoreProgress(ctx context.Context, clusterID, taskID, runID string) (One2OneRestoreProgress, error) {
+	resp, err := c.operations.GetClusterClusterIDTask11RestoreTaskIDRunID(&operations.GetClusterClusterIDTask11RestoreTaskIDRunIDParams{
+		Context:   ctx,
+		ClusterID: clusterID,
+		TaskID:    taskID,
+		RunID:     runID,
+	})
+	if err != nil {
+		return One2OneRestoreProgress{}, err
+	}
+
+	return One2OneRestoreProgress{
+		TaskRunOne2OneRestoreProgress: resp.Payload,
+	}, nil
+}
+
 // ListBackups returns listing of available backups.
 func (c *Client) ListBackups(ctx context.Context, clusterID string,
 	locations []string, allClusters bool, keyspace []string, minDate, maxDate time.Time,

--- a/v3/pkg/managerclient/go.mod
+++ b/v3/pkg/managerclient/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/scylladb/go-set v1.0.2
 	github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250310104639-18257b71bb48
-	github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250310104639-18257b71bb48
+	github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250502123045-ee6af14e22db
 	github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4
 )
 

--- a/v3/pkg/managerclient/go.sum
+++ b/v3/pkg/managerclient/go.sum
@@ -86,8 +86,8 @@ github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250310104639-18257b71bb48 h1:2iJMWV073twoCG2L/F5DBzQApxVX8kKEEeke3qvSitM=
 github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250310104639-18257b71bb48/go.mod h1:VKqHSrDj9zfgCKilpbdpmqV1TjmSglt/df79eIg6wuI=
-github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250310104639-18257b71bb48 h1:bAQTWuQ8tkbUuHvaMOQBTJaLaTMpXMsBi1znv+yIpLo=
-github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250310104639-18257b71bb48/go.mod h1:nCN5P0jiWL0W7jbcZ9p0ndtZAPoyEWXefddx/nbyFes=
+github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250502123045-ee6af14e22db h1:Ij7Zw/AqHpTDH5sELQOBC1uE1Fh1fmSJEqdy7D+yyAs=
+github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250502123045-ee6af14e22db/go.mod h1:nCN5P0jiWL0W7jbcZ9p0ndtZAPoyEWXefddx/nbyFes=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4 h1:8qmTC5ByIXO3GP/IzBkxcZ/99VITvnIETDhdFz/om7A=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/v3/pkg/managerclient/model_test.go
+++ b/v3/pkg/managerclient/model_test.go
@@ -1,0 +1,96 @@
+package managerclient
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestOne2OneRestoreProgressRender(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		one2oneRestoreProgress string
+	}{
+		{
+			name:                   "Only tables",
+			one2oneRestoreProgress: "testdata/1.1_1_restore_run_progress.json",
+		},
+		{
+			name:                   "Only views",
+			one2oneRestoreProgress: "testdata/2.1_1_restore_run_progress.json",
+		},
+		{
+			name:                   "Empty",
+			one2oneRestoreProgress: "testdata/3.1_1_restore_run_progress.json",
+		},
+		{
+			name:                   "Table and views",
+			one2oneRestoreProgress: "testdata/4.1_1_restore_run_progress.json",
+		},
+		{
+			name:                   "Table and views, in progress",
+			one2oneRestoreProgress: "testdata/5.1_1_restore_run_progress.json",
+		},
+		{
+			name:                   "Table and views, not detailed",
+			one2oneRestoreProgress: "testdata/6.1_1_restore_run_progress.json",
+		},
+		{
+			name:                   "Table and views, not detailed, in progress",
+			one2oneRestoreProgress: "testdata/7.1_1_restore_run_progress.json",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			progress := loadOne2OneRestoreProgress(t, tc.one2oneRestoreProgress)
+			var b bytes.Buffer
+			if err := progress.Render(&b); err != nil {
+				t.Fatalf("Unexpected err: %v", err)
+			}
+			saveGoldenFile(t, tc.one2oneRestoreProgress, b.Bytes(), false)
+			expected := loadGoldenFile(t, tc.one2oneRestoreProgress)
+			if diff := cmp.Diff(b.String(), expected); diff != "" {
+				t.Fatalf("Actual != Expected\n%s", diff)
+			}
+		})
+	}
+}
+
+func loadOne2OneRestoreProgress(t *testing.T, filePath string) One2OneRestoreProgress {
+	t.Helper()
+	var progress One2OneRestoreProgress
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Read file: %v", err)
+	}
+	err = json.Unmarshal(data, &progress)
+	if err != nil {
+		t.Fatalf("JSON unmarshal: %v", err)
+	}
+	return progress
+}
+
+func saveGoldenFile(t *testing.T, prefix string, content []byte, update bool) {
+	t.Helper()
+	if !update {
+		return
+	}
+	fileName := prefix + ".golden"
+	if err := os.WriteFile(fileName, content, 0o666); err != nil {
+		t.Fatalf("can't save golden file: %v", err)
+	}
+}
+
+func loadGoldenFile(t *testing.T, prefix string) string {
+	t.Helper()
+	fileName := prefix + ".golden"
+	b, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatalf("can't read golden file: %v", err)
+	}
+	return string(b)
+}

--- a/v3/pkg/managerclient/testdata/1.1_1_restore_run_progress.json
+++ b/v3/pkg/managerclient/testdata/1.1_1_restore_run_progress.json
@@ -1,0 +1,32 @@
+{
+  "progress": {
+    "tables": [
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "restored": 1000,
+        "size": 1000,
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1"
+      },
+      {
+        "completed_at": "2025-01-01T10:00:00.000Z",
+        "keyspace": "keyspace1",
+        "restored": 1000,
+        "size": 1000,
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table2"
+      }
+    ]
+  },
+  "run": {
+    "end_time": "2025-01-01T10:00:00.000Z",
+    "id": "task_run_id",
+    "start_time": "2025-01-01T09:00:00.000Z",
+    "status": "DONE"
+  },
+  "Task": null,
+  "Detailed": true
+}

--- a/v3/pkg/managerclient/testdata/1.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/1.1_1_restore_run_progress.json.golden
@@ -3,15 +3,10 @@ Status:		DONE
 Start time:	01 Jan 25 10:00:00 CET
 End time:	01 Jan 25 11:00:00 CET
 Duration:	1h0m0s
-Progress: 	
-- Name: keyspace1.table1: 
-  Size: 1000B
-  Restored: 1000B
-  Duration: 30m0s
-  Status: done
-	
-- Name: keyspace1.table2: 
-  Size: 1000B
-  Restored: 1000B
-  Duration: 1h0m0s
-  Status: done
+Progress: 
+╭───────────┬────────┬───────┬──────────┬──────────┬────────╮
+│ Keyspace  │ Table  │ Size  │ Restored │ Duration │ Status │
+├───────────┼────────┼───────┼──────────┼──────────┼────────┤
+│ keyspace1 │ table1 │ 1000B │ 1000B    │ 30m0s    │ done   │
+│ keyspace1 │ table2 │ 1000B │ 1000B    │ 1h0m0s   │ done   │
+╰───────────┴────────┴───────┴──────────┴──────────┴────────╯

--- a/v3/pkg/managerclient/testdata/1.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/1.1_1_restore_run_progress.json.golden
@@ -1,0 +1,17 @@
+Run:		task_run_id
+Status:		DONE
+Start time:	01 Jan 25 10:00:00 CET
+End time:	01 Jan 25 11:00:00 CET
+Duration:	1h0m0s
+Progress: 	
+- Name: keyspace1.table1: 
+  Size: 1000B
+  Restored: 1000B
+  Duration: 30m0s
+  Status: done
+	
+- Name: keyspace1.table2: 
+  Size: 1000B
+  Restored: 1000B
+  Duration: 1h0m0s
+  Status: done

--- a/v3/pkg/managerclient/testdata/2.1_1_restore_run_progress.json
+++ b/v3/pkg/managerclient/testdata/2.1_1_restore_run_progress.json
@@ -1,0 +1,31 @@
+{
+  "progress": {
+    "views": [
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1",
+        "view": "view1",
+        "view_type": "MaterializedView"
+      },
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1",
+        "view": "index1",
+        "view_type": "SecondaryIndex"
+      }
+    ]
+  },
+  "run": {
+    "end_time": "2025-01-01T10:00:00.000Z",
+    "id": "task_run_id",
+    "start_time": "2025-01-01T09:00:00.000Z",
+    "status": "DONE"
+  },
+  "Detailed": true
+}

--- a/v3/pkg/managerclient/testdata/2.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/2.1_1_restore_run_progress.json.golden
@@ -4,10 +4,9 @@ Start time:	01 Jan 25 10:00:00 CET
 End time:	01 Jan 25 11:00:00 CET
 Duration:	1h0m0s
 Progress: 
-- Name: keyspace1.view1: 
-  Duration: 30m0s
-  Status: done
-
-- Name: keyspace1.index1: 
-  Duration: 30m0s
-  Status: done
+╭───────────┬────────┬──────────────────┬──────────┬────────╮
+│ Keyspace  │ View   │ Type             │ Duration │ Status │
+├───────────┼────────┼──────────────────┼──────────┼────────┤
+│ keyspace1 │ view1  │ MaterializedView │ 30m0s    │ done   │
+│ keyspace1 │ index1 │ SecondaryIndex   │ 30m0s    │ done   │
+╰───────────┴────────┴──────────────────┴──────────┴────────╯

--- a/v3/pkg/managerclient/testdata/2.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/2.1_1_restore_run_progress.json.golden
@@ -1,0 +1,13 @@
+Run:		task_run_id
+Status:		DONE
+Start time:	01 Jan 25 10:00:00 CET
+End time:	01 Jan 25 11:00:00 CET
+Duration:	1h0m0s
+Progress: 
+- Name: keyspace1.view1: 
+  Duration: 30m0s
+  Status: done
+
+- Name: keyspace1.index1: 
+  Duration: 30m0s
+  Status: done

--- a/v3/pkg/managerclient/testdata/3.1_1_restore_run_progress.json
+++ b/v3/pkg/managerclient/testdata/3.1_1_restore_run_progress.json
@@ -1,0 +1,10 @@
+{
+  "run": {
+    "end_time": "2025-01-01T10:00:00.000Z",
+    "id": "task_run_id",
+    "start_time": "2025-01-01T09:00:00.000Z",
+    "status": "DONE"
+  },
+  "Task": null,
+  "Detailed": true
+}

--- a/v3/pkg/managerclient/testdata/3.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/3.1_1_restore_run_progress.json.golden
@@ -1,0 +1,6 @@
+Run:		task_run_id
+Status:		DONE
+Start time:	01 Jan 25 10:00:00 CET
+End time:	01 Jan 25 11:00:00 CET
+Duration:	1h0m0s
+Progress: 0%

--- a/v3/pkg/managerclient/testdata/4.1_1_restore_run_progress.json
+++ b/v3/pkg/managerclient/testdata/4.1_1_restore_run_progress.json
@@ -1,0 +1,52 @@
+{
+  "progress": {
+    "tables": [
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "restored": 1000,
+        "size": 1000,
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1"
+      },
+      {
+        "completed_at": "2025-01-01T10:00:00.000Z",
+        "keyspace": "keyspace1",
+        "restored": 1000,
+        "size": 1000,
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table2"
+      }
+    ],
+    "views": [
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1",
+        "view": "view1",
+        "view_type": "MaterializedView"
+      },
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1",
+        "view": "index1",
+        "view_type": "SecondaryIndex"
+      }
+    ]
+  },
+  "run": {
+    "end_time": "2025-01-01T10:00:00.000Z",
+    "id": "task_run_id",
+    "start_time": "2025-01-01T09:00:00.000Z",
+    "status": "DONE"
+  },
+  "Task": null,
+  "Detailed": true
+}

--- a/v3/pkg/managerclient/testdata/4.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/4.1_1_restore_run_progress.json.golden
@@ -1,0 +1,25 @@
+Run:		task_run_id
+Status:		DONE
+Start time:	01 Jan 25 10:00:00 CET
+End time:	01 Jan 25 11:00:00 CET
+Duration:	1h0m0s
+Progress: 	
+- Name: keyspace1.table1: 
+  Size: 1000B
+  Restored: 1000B
+  Duration: 30m0s
+  Status: done
+	
+- Name: keyspace1.table2: 
+  Size: 1000B
+  Restored: 1000B
+  Duration: 1h0m0s
+  Status: done
+
+- Name: keyspace1.view1: 
+  Duration: 30m0s
+  Status: done
+
+- Name: keyspace1.index1: 
+  Duration: 30m0s
+  Status: done

--- a/v3/pkg/managerclient/testdata/4.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/4.1_1_restore_run_progress.json.golden
@@ -3,23 +3,17 @@ Status:		DONE
 Start time:	01 Jan 25 10:00:00 CET
 End time:	01 Jan 25 11:00:00 CET
 Duration:	1h0m0s
-Progress: 	
-- Name: keyspace1.table1: 
-  Size: 1000B
-  Restored: 1000B
-  Duration: 30m0s
-  Status: done
-	
-- Name: keyspace1.table2: 
-  Size: 1000B
-  Restored: 1000B
-  Duration: 1h0m0s
-  Status: done
+Progress: 
+╭───────────┬────────┬───────┬──────────┬──────────┬────────╮
+│ Keyspace  │ Table  │ Size  │ Restored │ Duration │ Status │
+├───────────┼────────┼───────┼──────────┼──────────┼────────┤
+│ keyspace1 │ table1 │ 1000B │ 1000B    │ 30m0s    │ done   │
+│ keyspace1 │ table2 │ 1000B │ 1000B    │ 1h0m0s   │ done   │
+╰───────────┴────────┴───────┴──────────┴──────────┴────────╯
 
-- Name: keyspace1.view1: 
-  Duration: 30m0s
-  Status: done
-
-- Name: keyspace1.index1: 
-  Duration: 30m0s
-  Status: done
+╭───────────┬────────┬──────────────────┬──────────┬────────╮
+│ Keyspace  │ View   │ Type             │ Duration │ Status │
+├───────────┼────────┼──────────────────┼──────────┼────────┤
+│ keyspace1 │ view1  │ MaterializedView │ 30m0s    │ done   │
+│ keyspace1 │ index1 │ SecondaryIndex   │ 30m0s    │ done   │
+╰───────────┴────────┴──────────────────┴──────────┴────────╯

--- a/v3/pkg/managerclient/testdata/5.1_1_restore_run_progress.json
+++ b/v3/pkg/managerclient/testdata/5.1_1_restore_run_progress.json
@@ -1,0 +1,52 @@
+{
+  "progress": {
+    "tables": [
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "restored": 1000,
+        "size": 1000,
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1"
+      },
+      {
+        "completed_at": "2025-01-01T10:00:00.000Z",
+        "keyspace": "keyspace1",
+        "restored": 500,
+        "size": 1000,
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "in_progress",
+        "table": "table2"
+      }
+    ],
+    "views": [
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1",
+        "view": "view1",
+        "view_type": "MaterializedView"
+      },
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "in_progress",
+        "table": "table1",
+        "view": "index1",
+        "view_type": "SecondaryIndex"
+      }
+    ]
+  },
+  "run": {
+    "end_time": "2025-01-01T10:00:00.000Z",
+    "id": "task_run_id",
+    "start_time": "2025-01-01T09:00:00.000Z",
+    "status": "DONE"
+  },
+  "Task": null,
+  "Detailed": true
+}

--- a/v3/pkg/managerclient/testdata/5.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/5.1_1_restore_run_progress.json.golden
@@ -3,23 +3,17 @@ Status:		DONE
 Start time:	01 Jan 25 10:00:00 CET
 End time:	01 Jan 25 11:00:00 CET
 Duration:	1h0m0s
-Progress: 	
-- Name: keyspace1.table1: 
-  Size: 1000B
-  Restored: 1000B
-  Duration: 30m0s
-  Status: done
-	
-- Name: keyspace1.table2: 
-  Size: 1000B
-  Restored: 500B
-  Duration: 1h0m0s
-  Status: in_progress
+Progress: 
+╭───────────┬────────┬───────┬──────────┬──────────┬─────────────╮
+│ Keyspace  │ Table  │ Size  │ Restored │ Duration │ Status      │
+├───────────┼────────┼───────┼──────────┼──────────┼─────────────┤
+│ keyspace1 │ table1 │ 1000B │ 1000B    │ 30m0s    │ done        │
+│ keyspace1 │ table2 │ 1000B │ 500B     │ 1h0m0s   │ in_progress │
+╰───────────┴────────┴───────┴──────────┴──────────┴─────────────╯
 
-- Name: keyspace1.view1: 
-  Duration: 30m0s
-  Status: done
-
-- Name: keyspace1.index1: 
-  Duration: 30m0s
-  Status: in_progress
+╭───────────┬────────┬──────────────────┬──────────┬─────────────╮
+│ Keyspace  │ View   │ Type             │ Duration │ Status      │
+├───────────┼────────┼──────────────────┼──────────┼─────────────┤
+│ keyspace1 │ view1  │ MaterializedView │ 30m0s    │ done        │
+│ keyspace1 │ index1 │ SecondaryIndex   │ 30m0s    │ in_progress │
+╰───────────┴────────┴──────────────────┴──────────┴─────────────╯

--- a/v3/pkg/managerclient/testdata/5.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/5.1_1_restore_run_progress.json.golden
@@ -1,0 +1,25 @@
+Run:		task_run_id
+Status:		DONE
+Start time:	01 Jan 25 10:00:00 CET
+End time:	01 Jan 25 11:00:00 CET
+Duration:	1h0m0s
+Progress: 	
+- Name: keyspace1.table1: 
+  Size: 1000B
+  Restored: 1000B
+  Duration: 30m0s
+  Status: done
+	
+- Name: keyspace1.table2: 
+  Size: 1000B
+  Restored: 500B
+  Duration: 1h0m0s
+  Status: in_progress
+
+- Name: keyspace1.view1: 
+  Duration: 30m0s
+  Status: done
+
+- Name: keyspace1.index1: 
+  Duration: 30m0s
+  Status: in_progress

--- a/v3/pkg/managerclient/testdata/6.1_1_restore_run_progress.json
+++ b/v3/pkg/managerclient/testdata/6.1_1_restore_run_progress.json
@@ -1,0 +1,52 @@
+{
+  "progress": {
+    "tables": [
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "restored": 1000,
+        "size": 1000,
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1"
+      },
+      {
+        "completed_at": "2025-01-01T10:00:00.000Z",
+        "keyspace": "keyspace1",
+        "restored": 1000,
+        "size": 1000,
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table2"
+      }
+    ],
+    "views": [
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1",
+        "view": "view1",
+        "view_type": "MaterializedView"
+      },
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1",
+        "view": "index1",
+        "view_type": "SecondaryIndex"
+      }
+    ]
+  },
+  "run": {
+    "end_time": "2025-01-01T10:00:00.000Z",
+    "id": "task_run_id",
+    "start_time": "2025-01-01T09:00:00.000Z",
+    "status": "DONE"
+  },
+  "Task": null,
+  "Detailed": false
+}

--- a/v3/pkg/managerclient/testdata/6.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/6.1_1_restore_run_progress.json.golden
@@ -1,0 +1,8 @@
+Run:		task_run_id
+Status:		DONE
+Start time:	01 Jan 25 10:00:00 CET
+End time:	01 Jan 25 11:00:00 CET
+Duration:	1h0m0s
+Progress: 
+  Tables: 100%
+  Views:  100%

--- a/v3/pkg/managerclient/testdata/7.1_1_restore_run_progress.json
+++ b/v3/pkg/managerclient/testdata/7.1_1_restore_run_progress.json
@@ -1,0 +1,52 @@
+{
+  "progress": {
+    "tables": [
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "restored": 1000,
+        "size": 1000,
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1"
+      },
+      {
+        "completed_at": "2025-01-01T10:00:00.000Z",
+        "keyspace": "keyspace1",
+        "restored": 900,
+        "size": 1000,
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "in_progress",
+        "table": "table2"
+      }
+    ],
+    "views": [
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "done",
+        "table": "table1",
+        "view": "view1",
+        "view_type": "MaterializedView"
+      },
+      {
+        "completed_at": "2025-01-01T09:30:00.000Z",
+        "keyspace": "keyspace1",
+        "started_at": "2025-01-01T09:00:00.000Z",
+        "status": "in_progress",
+        "table": "table1",
+        "view": "index1",
+        "view_type": "SecondaryIndex"
+      }
+    ]
+  },
+  "run": {
+    "end_time": "2025-01-01T10:00:00.000Z",
+    "id": "task_run_id",
+    "start_time": "2025-01-01T09:00:00.000Z",
+    "status": "DONE"
+  },
+  "Task": null,
+  "Detailed": false
+}

--- a/v3/pkg/managerclient/testdata/7.1_1_restore_run_progress.json.golden
+++ b/v3/pkg/managerclient/testdata/7.1_1_restore_run_progress.json.golden
@@ -1,0 +1,8 @@
+Run:		task_run_id
+Status:		DONE
+Start time:	01 Jan 25 10:00:00 CET
+End time:	01 Jan 25 11:00:00 CET
+Duration:	1h0m0s
+Progress: 
+  Tables: 95%
+  Views:  50%

--- a/v3/pkg/managerclient/utils.go
+++ b/v3/pkg/managerclient/utils.go
@@ -283,3 +283,24 @@ func FormatRetentionPolicy(retention, retentionDays int64) string {
 	}
 	return res
 }
+
+// FormatTablesProgress calculates percent of restored table bytes.
+func FormatTablesProgress(tables []*models.One2OneRestoreTableProgress) string {
+	var sumSize, sumRestored int64
+	for _, t := range tables {
+		sumSize += t.Size
+		sumRestored += t.Restored
+	}
+	return fmt.Sprintf("%d%%", sumRestored*100/sumSize)
+}
+
+// FormatViewsProgress calculates percent of restored views.
+func FormatViewsProgress(views []*models.One2OneRestoreViewProgress) string {
+	var done int
+	for _, v := range views {
+		if v.Status == models.One2OneRestoreTableProgressStatusDone {
+			done++
+		}
+	}
+	return fmt.Sprintf("%d%%", done*100/len(views))
+}


### PR DESCRIPTION
This adds 1-1-restore progress to managerclient and also introduces
text rending of the progress model.

Here is a few examples of how rendered progress will look like:
```
Run:		task_run_id
Status:		DONE
Start time:	01 Jan 25 10:00:00 CET
End time:	01 Jan 25 11:00:00 CET
Duration:	1h0m0s
Progress: 
  Tables: 100%
  Views:  100%

```
With details:
```
Run:		task_run_id
Status:		DONE
Start time:	01 Jan 25 10:00:00 CET
End time:	01 Jan 25 11:00:00 CET
Duration:	1h0m0s
Progress: 
╭───────────┬────────┬───────┬──────────┬──────────┬─────────────╮
│ Keyspace  │ Table  │ Size  │ Restored │ Duration │ Status      │
├───────────┼────────┼───────┼──────────┼──────────┼─────────────┤
│ keyspace1 │ table1 │ 1000B │ 1000B    │ 30m0s    │ done        │
│ keyspace1 │ table2 │ 1000B │ 500B     │ 1h0m0s   │ in_progress │
╰───────────┴────────┴───────┴──────────┴──────────┴─────────────╯

╭───────────┬────────┬──────────────────┬──────────┬─────────────╮
│ Keyspace  │ View   │ Type             │ Duration │ Status      │
├───────────┼────────┼──────────────────┼──────────┼─────────────┤
│ keyspace1 │ view1  │ MaterializedView │ 30m0s    │ done        │
│ keyspace1 │ index1 │ SecondaryIndex   │ 30m0s    │ in_progress │
╰───────────┴────────┴──────────────────┴──────────┴─────────────╯

```
More example can be found in testdata/*.golden 

This pr is a prerequisite to #4351 and 99% of it :)   

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
