### PR TITLE
feat(1-1-restore): disable auto compaction during download&refresh

### DIFF
--- a/pkg/service/one2onerestore/worker.go
+++ b/pkg/service/one2onerestore/worker.go
@@ -59,14 +59,14 @@ func (w *worker) parseTarget(ctx context.Context, properties json.RawMessage) (T
 
 // restore is an actual 1-1-restore stages.
 func (w *worker) restore(ctx context.Context, workload []hostWorkload, target Target) (err error) {
-	if err := w.setAutoCompaction(ctx, workload, false); err != nil {
-		return errors.Wrap(err, "disable auto compaction")
-	}
 	defer func() {
 		if err := w.setAutoCompaction(context.Background(), workload, true); err != nil {
 			w.logger.Error(ctx, "Can't enable auto compaction", "err", err)
 		}
 	}()
+	if err := w.setAutoCompaction(ctx, workload, false); err != nil {
+		return errors.Wrap(err, "disable auto compaction")
+	}
 
 	if err := w.setTombstoneGCModeRepair(ctx, workload); err != nil {
 		return errors.Wrap(err, "tombstone_gc mode")

--- a/pkg/service/one2onerestore/worker_tables.go
+++ b/pkg/service/one2onerestore/worker_tables.go
@@ -22,6 +22,16 @@ func (w *worker) restoreTables(ctx context.Context, workload []hostWorkload, key
 			repeatInterval  = 10 * time.Second
 			pollIntervalSec = 10
 		)
+
+		if err := w.setAutoCompaction(ctx, hostTask, false); err != nil {
+			return errors.Wrap(err, "disable auto compaction")
+		}
+		defer func() {
+			if err := w.setAutoCompaction(ctx, hostTask, true); err != nil {
+				w.logger.Error(ctx, "Can't enable auto compaction", "err", err)
+			}
+		}()
+
 		return hostTask.manifestContent.ForEachIndexIterWithError(keyspaces, func(table backupspec.FilesMeta) error {
 			w.logger.Info(ctx, "Restoring data", "ks", table.Keyspace, "table", table.Table, "size", table.Size)
 
@@ -117,4 +127,17 @@ func (w *worker) stopJob(ctx context.Context, jobID int64, host string) {
 			"error", err,
 		)
 	}
+}
+
+func (w *worker) setAutoCompaction(ctx context.Context, workload hostWorkload, enabled bool) error {
+	setAutoCompactionFunc := w.client.EnableAutoCompaction
+	if !enabled {
+		setAutoCompactionFunc = w.client.DisableAutoCompaction
+	}
+	for _, table := range workload.tablesToRestore {
+		if err := setAutoCompactionFunc(ctx, workload.host.Addr, table.keyspace, table.table); err != nil {
+			return errors.Wrapf(err, "set auto compaction on %s", workload.host.Addr)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This disables auto compaction during 1-1-restore for the download and refresh period and then re-enables it afterwards.

Refs: #4369

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
