### PR TITLE
feat(1-1-restore): set tombstone_gc mode to 'repair' for views

### DIFF
--- a/pkg/service/one2onerestore/worker_tgc.go
+++ b/pkg/service/one2onerestore/worker_tgc.go
@@ -25,37 +25,73 @@ const (
 
 // setTombstoneGCModeRepair sets tombstone gc mode to repair to avoid data resurrection issues during restore.
 func (w *worker) setTombstoneGCModeRepair(ctx context.Context, workload []hostWorkload) error {
-	for table := range getTablesToRestore(workload) {
-		mode, err := w.getTableTombstoneGCMode(table.keyspace, table.table)
+	type alterTGCTarget struct {
+		keyspace string
+		name     string
+		isView   bool
+	}
+	tablesToRestore := getTablesToRestore(workload)
+	var targets []alterTGCTarget
+	for table := range tablesToRestore {
+		targets = append(targets, alterTGCTarget{
+			keyspace: table.keyspace,
+			name:     table.table,
+			isView:   false,
+		})
+	}
+	views, err := w.getViews(ctx, tablesToRestore)
+	if err != nil {
+		return errors.Wrap(err, "get views")
+	}
+	for _, view := range views {
+		viewName := view.View
+		if view.Type == SecondaryIndex {
+			viewName += "_index"
+		}
+		targets = append(targets, alterTGCTarget{
+			keyspace: view.Keyspace,
+			name:     viewName,
+			isView:   true,
+		})
+	}
+
+	for _, target := range targets {
+		mode, err := w.getTombstoneGCMode(target.keyspace, target.name, target.isView)
 		if err != nil {
-			return errors.Wrap(err, "get tombstone_gc mode")
+			return errors.Wrapf(err, "get tombstone_gc mode: %s.%s", target.keyspace, target.name)
 		}
 		// No need to change tombstone gc mode.
 		if mode == modeDisabled || mode == modeImmediate || mode == modeRepair {
-			w.logger.Info(ctx, "Skipping set tombstone_gc mode", "table", table, "mode", mode)
+			w.logger.Info(ctx, "Skipping set tombstone_gc mode", "name", target.keyspace+"."+target.name, "mode", mode)
 			continue
 		}
-		if err := w.setTableTombstoneGCMode(ctx, table.keyspace, table.table, modeRepair); err != nil {
-			return errors.Wrap(err, "set tombstone_gc mode repair")
+		if err := w.setTombstoneGCMode(ctx, target.keyspace, target.name, target.isView, modeRepair); err != nil {
+			return errors.Wrapf(err, "set tombstone_gc mode repair: %s.%s", target.keyspace, target.name)
 		}
 	}
 
 	return nil
 }
 
-// getTableTombstoneGCMode returns table's tombstone_gc mode.
-func (w *worker) getTableTombstoneGCMode(keyspace, table string) (tombstoneGCMode, error) {
+// getTombstoneGCMode returns table's tombstone_gc mode.
+func (w *worker) getTombstoneGCMode(keyspace, name string, isView bool) (tombstoneGCMode, error) {
+	systemSchemaTable := "system_schema.tables"
+	columnName := "table_name"
+	if isView {
+		systemSchemaTable = "system_schema.views"
+		columnName = "view_name"
+	}
 	var ext map[string]string
-	q := qb.Select("system_schema.tables").
+	q := qb.Select(systemSchemaTable).
 		Columns("extensions").
-		Where(qb.Eq("keyspace_name"), qb.Eq("table_name")).
+		Where(qb.Eq("keyspace_name"), qb.Eq(columnName)).
 		Query(w.clusterSession).
-		Bind(keyspace, table)
+		Bind(keyspace, name)
 
 	defer q.Release()
 	err := q.Scan(&ext)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "scan")
 	}
 
 	// Timeout (just using gc_grace_seconds) is the default mode
@@ -73,21 +109,22 @@ func (w *worker) getTableTombstoneGCMode(keyspace, table string) (tombstoneGCMod
 	return "", errors.Errorf("unrecognized tombstone_gc mode: %s", mode)
 }
 
-// setTableTombstoneGCMode alters 'tombstone_gc' mode.
-func (w *worker) setTableTombstoneGCMode(ctx context.Context, keyspace, table string, mode tombstoneGCMode) error {
-	w.logger.Info(ctx, "Alter table's tombstone_gc mode",
-		"keyspace", keyspace,
-		"table", table,
-	)
+// setTombstoneGCMode alters 'tombstone_gc' mode.
+func (w *worker) setTombstoneGCMode(ctx context.Context, keyspace, name string, isView bool, mode tombstoneGCMode) error {
+	logger := w.logger.With("keyspace", keyspace, "name", name, "is_view", isView)
+
+	logger.Info(ctx, "Alter tombstone_gc mode")
 
 	op := func() error {
-		return w.clusterSession.ExecStmt(alterTableTombstoneGCStmt(keyspace, table, mode))
+		stmt := alterTableTombstoneGCStmt(keyspace, name, mode)
+		if isView {
+			stmt = alterViewTombstoneGCStmt(keyspace, name, mode)
+		}
+		return w.clusterSession.ExecStmt(stmt)
 	}
 
 	notify := func(err error, wait time.Duration) {
-		w.logger.Info(ctx, "Altering table's tombstone_gc mode failed",
-			"keyspace", keyspace,
-			"table", table,
+		logger.Info(ctx, "Altering tombstone_gc mode failed",
 			"error", err,
 			"wait", wait,
 		)
@@ -98,4 +135,8 @@ func (w *worker) setTableTombstoneGCMode(ctx context.Context, keyspace, table st
 
 func alterTableTombstoneGCStmt(keyspace, table string, mode tombstoneGCMode) string {
 	return fmt.Sprintf(`ALTER TABLE %q.%q WITH tombstone_gc = {'mode': '%s'}`, keyspace, table, mode)
+}
+
+func alterViewTombstoneGCStmt(keyspace, view string, mode tombstoneGCMode) string {
+	return fmt.Sprintf(`ALTER MATERIALIZED VIEW %q.%q WITH tombstone_gc = {'mode': '%s'}`, keyspace, view, mode)
 }

--- a/pkg/service/one2onerestore/worker_views.go
+++ b/pkg/service/one2onerestore/worker_views.go
@@ -6,12 +6,12 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
+	"slices"
 	"time"
 
-	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/query"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 )
 
@@ -72,7 +72,12 @@ func (w *worker) dropView(ctx context.Context, view View) error {
 func (w *worker) getViews(ctx context.Context, tablesToRestore map[scyllaTable]struct{}) ([]View, error) {
 	keyspaces, err := w.client.Keyspaces(ctx)
 	if err != nil {
-		return nil, errors.Wrapf(err, "get keyspaces")
+		return nil, errors.Wrap(err, "get keyspaces")
+	}
+
+	describedViews, err := w.viewsSchemaByName()
+	if err != nil {
+		return nil, err
 	}
 
 	var views []View
@@ -86,17 +91,10 @@ func (w *worker) getViews(ctx context.Context, tablesToRestore map[scyllaTable]s
 			if _, ok := tablesToRestore[scyllaTable{keyspace: index.KeyspaceName, table: index.TableName}]; !ok {
 				continue
 			}
-			dummyMeta := gocql.KeyspaceMetadata{
-				Indexes: map[string]*gocql.IndexMetadata{index.Name: index},
+			stmt, ok := describedViews[scyllaTable{keyspace: index.KeyspaceName, table: index.Name + "_index"}]
+			if !ok {
+				continue
 			}
-
-			schema, err := dummyMeta.ToCQL()
-			if err != nil {
-				return nil, errors.Wrapf(err, "get index %s.%s create statement", ks, index.Name)
-			}
-
-			// DummyMeta schema consists of create keyspace and create view statements
-			stmt := strings.Split(schema, ";")[1]
 			stmt, err = addIfNotExists(stmt, SecondaryIndex)
 			if err != nil {
 				return nil, err
@@ -115,17 +113,10 @@ func (w *worker) getViews(ctx context.Context, tablesToRestore map[scyllaTable]s
 			if _, ok := tablesToRestore[scyllaTable{keyspace: view.KeyspaceName, table: view.BaseTableName}]; !ok {
 				continue
 			}
-			dummyMeta := gocql.KeyspaceMetadata{
-				Views: map[string]*gocql.ViewMetadata{view.ViewName: view},
+			stmt, ok := describedViews[scyllaTable{keyspace: view.KeyspaceName, table: view.ViewName}]
+			if !ok {
+				continue
 			}
-
-			schema, err := dummyMeta.ToCQL()
-			if err != nil {
-				return nil, errors.Wrapf(err, "get view %s.%s create statement", ks, view.ViewName)
-			}
-
-			// DummyMeta schema consists of create keyspace and create view statements
-			stmt := strings.Split(schema, ";")[1]
 			stmt, err = addIfNotExists(stmt, MaterializedView)
 			if err != nil {
 				return nil, err
@@ -240,4 +231,23 @@ func (w *worker) waitForViewBuilding(ctx context.Context, view View, pr *RunView
 	}
 
 	return nil
+}
+
+func (w *worker) viewsSchemaByName() (map[scyllaTable]string, error) {
+	describedSchema, err := query.DescribeSchemaWithInternals(w.clusterSession)
+	if err != nil {
+		return nil, errors.Wrap(err, "describe schema")
+	}
+	result := map[scyllaTable]string{}
+	for _, stmt := range describedSchema {
+		if stmt.Keyspace == "" {
+			continue
+		}
+		if !slices.Contains([]string{"view", "index"}, stmt.Type) {
+			continue
+		}
+
+		result[scyllaTable{keyspace: stmt.Keyspace, table: stmt.Name}] = stmt.CQLStmt
+	}
+	return result, nil
 }


### PR DESCRIPTION
This includes views into alterTGC stage as view is a normal table under the hood.

Refs: #4261


**P.S.** For now it's not clear what the behavior of Secondary Indexes: 
1) we don't know if the tombstone_gc mode is inherited from base table. DESC statement doesn't show options for indexes, see https://github.com/scylladb/scylladb/issues/22849
 2) It looks like there is no way to provide tombstone_gc mode during index creation 


---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
