### PR TITLE
feat(1-1-restore): adds stopping-runner and use it for 1-1-restore task

### DIFF
--- a/docs/source/sctool/partials/sctool_restore_1-1-restore.yaml
+++ b/docs/source/sctool/partials/sctool_restore_1-1-restore.yaml
@@ -112,6 +112,11 @@ options:
 
         If you want the task to start at a specified date use RFC3339 formatted string i.e. '2018-01-02T15:04:05-07:00'.
         If you want the repair to start immediately, use the value 'now' or skip this flag.
+    - name: stop-all
+      default_value: "false"
+      usage: |
+        If true, then before executing 1-1-restore all enabled tasks will be disabled and all running tasks will be stopped. Once 1-1-restore is finished
+        all disabled tasks will be re-enabled.
     - name: timezone
       default_value: UTC
       usage: |

--- a/docs/source/sctool/partials/sctool_restore_1-1-restore_update.yaml
+++ b/docs/source/sctool/partials/sctool_restore_1-1-restore_update.yaml
@@ -113,6 +113,11 @@ options:
 
         If you want the task to start at a specified date use RFC3339 formatted string i.e. '2018-01-02T15:04:05-07:00'.
         If you want the repair to start immediately, use the value 'now' or skip this flag.
+    - name: stop-all
+      default_value: "false"
+      usage: |
+        If true, then before executing 1-1-restore all enabled tasks will be disabled and all running tasks will be stopped. Once 1-1-restore is finished
+        all disabled tasks will be re-enabled.
     - name: timezone
       default_value: UTC
       usage: |

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -167,9 +167,12 @@ func (s *server) makeServices(ctx context.Context) error {
 		scheduler.PolicyRunner{Policy: restoreExclusiveLock, Runner: s.backupSvc.Runner(), TaskType: scheduler.BackupTask})
 	s.schedSvc.SetRunner(scheduler.RestoreTask,
 		scheduler.PolicyRunner{Policy: restoreExclusiveLock, Runner: s.restoreSvc.Runner(), TaskType: scheduler.RestoreTask})
-	s.schedSvc.SetRunner(scheduler.One2OneRestoreTask,
-		scheduler.PolicyRunner{Policy: restoreExclusiveLock, Runner: s.one2OneRestoreSvc.Runner(), TaskType: scheduler.One2OneRestoreTask},
-	)
+	one2OneRestoreRunner := scheduler.StoppingRunner{
+		Runner:   scheduler.PolicyRunner{Policy: restoreExclusiveLock, Runner: s.one2OneRestoreSvc.Runner(), TaskType: scheduler.One2OneRestoreTask},
+		Service:  s.schedSvc,
+		TaskType: scheduler.One2OneRestoreTask,
+	}
+	s.schedSvc.SetRunner(scheduler.One2OneRestoreTask, one2OneRestoreRunner)
 	s.schedSvc.SetRunner(scheduler.HealthCheckTask, s.healthSvc.Runner())
 	s.schedSvc.SetRunner(scheduler.RepairTask,
 		scheduler.PolicyRunner{Policy: restoreExclusiveLock, Runner: s.repairSvc.Runner(), TaskType: scheduler.RepairTask})

--- a/pkg/command/one2onerestore/cmd.go
+++ b/pkg/command/one2onerestore/cmd.go
@@ -32,6 +32,7 @@ type command struct {
 	keyspace      []string
 	snapshotTag   string
 	nodesMapping  nodesMapping
+	stopAll       bool
 	dryRun        bool
 }
 
@@ -80,6 +81,7 @@ func (cmd *command) init() {
 	w.Unwrap().Var(&cmd.sourceCluster, "source-cluster-id", "")
 	w.Unwrap().StringVarP(&cmd.snapshotTag, "snapshot-tag", "T", "", "")
 	w.Unwrap().Var(&cmd.nodesMapping, "nodes-mapping", "")
+	w.Unwrap().BoolVar(&cmd.stopAll, "stop-all", false, "")
 
 	// Common configuration for restore procedures
 	w.Unwrap().BoolVar(&cmd.dryRun, "dry-run", false, "")
@@ -204,6 +206,10 @@ func flagsToTaskProperties(cmd *command, task *models.Task) (updated bool, err e
 		{
 			flagName: "nodes-mapping",
 			value:    cmd.nodesMapping,
+		},
+		{
+			flagName: "stop-all",
+			value:    cmd.stopAll,
 		},
 	}
 

--- a/pkg/command/one2onerestore/res.yaml
+++ b/pkg/command/one2onerestore/res.yaml
@@ -28,3 +28,7 @@ nodes-mapping:
 dry-run: |
   Validates and displays restore information without actually running the restore.
   This allows you to display what will happen should the restore run with the parameters you set.
+
+stop-all: |
+  If true, then before executing 1-1-restore all enabled tasks will be disabled and all running tasks will be stopped. Once 1-1-restore is finished
+  all disabled tasks will be re-enabled.

--- a/pkg/service/scheduler/policy_test.go
+++ b/pkg/service/scheduler/policy_test.go
@@ -189,7 +189,7 @@ func TestExclusiveTaskLockPolicy(t *testing.T) {
 			t.Fatalf("t.running[clusterID] should be deleted")
 		}
 
-		// Lock can be acquried again.
+		// Lock can be acquired again.
 		err = restoreExclusiveTask.PreRun(clusterID, taskID, runID, RestoreTask)
 		if err != nil {
 			t.Fatalf("PreRun: unexpected err: %v", err)

--- a/pkg/service/scheduler/stopping_runner.go
+++ b/pkg/service/scheduler/stopping_runner.go
@@ -1,0 +1,112 @@
+// Copyright (C) 2015 ScyllaDB
+
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+
+	stderr "errors"
+
+	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+)
+
+const (
+	disabledByLabel = "disabled-by"
+	disabledByValue = "stopping-runner"
+)
+
+// StoppingRunner wraps Runner and before executing it will fetch all tasks disable and stop them.
+// Once wrapped Runner execution is finished all disabled tasks will be re-enabled.
+type StoppingRunner struct {
+	Runner  Runner
+	Service *Service
+	// TaskType of a task this runner is executing.
+	TaskType TaskType
+}
+
+type taskOptions struct {
+	StopAll bool `json:"stop_all"`
+}
+
+// Run implements Runner interface.
+func (sr StoppingRunner) Run(ctx context.Context, clusterID, taskID, runID uuid.UUID, properties json.RawMessage) (err error) {
+	var opt taskOptions
+	if err := json.Unmarshal(properties, &opt); err != nil {
+		return errors.Wrap(err, "unmarshal task properties")
+	}
+	defer func() {
+		if dErr := sr.enableAllTasks(ctx, clusterID, opt.StopAll); dErr != nil {
+			err = stderr.Join(err, errors.Wrap(err, "enable all tasks"))
+		}
+	}()
+	if err := sr.disableAndStopAllTasks(ctx, clusterID, opt.StopAll); err != nil {
+		return errors.Wrap(err, "disable and stop all tasks")
+	}
+	return sr.Runner.Run(ctx, clusterID, taskID, runID, properties)
+}
+
+func (sr StoppingRunner) disableAndStopAllTasks(ctx context.Context, clusterID uuid.UUID, stopAll bool) error {
+	if !stopAll {
+		return nil
+	}
+	tasks, err := sr.Service.ListTasks(ctx, clusterID, ListFilter{})
+	if err != nil {
+		return errors.Wrap(err, "list tasks")
+	}
+	for _, task := range tasks {
+		// Prevent from stopping itself or tasks of the same type.
+		if task.Type == sr.TaskType {
+			sr.Service.logger.Debug(ctx, "Ignoring task", "task", task.Task)
+			continue
+		}
+
+		// Mark all disabled tasks with special label, so we can easily find them and re-enable.
+		if task.Labels == nil {
+			task.Labels = map[string]string{}
+		}
+		task.Labels[disabledByLabel] = disabledByValue
+		if task.Enabled {
+			task.Enabled = false
+		}
+		if err := sr.Service.PutTask(ctx, &task.Task); err != nil {
+			return errors.Wrap(err, "disable task")
+		}
+		if err := sr.Service.StopTask(ctx, &task.Task); err != nil {
+			return errors.Wrap(err, "stop task")
+		}
+	}
+	return nil
+}
+
+func (sr StoppingRunner) enableAllTasks(ctx context.Context, clusterID uuid.UUID, stopAll bool) error {
+	if !stopAll {
+		return nil
+	}
+	tasks, err := sr.Service.ListTasks(ctx, clusterID, ListFilter{
+		Disabled: true,
+	})
+	if err != nil {
+		return errors.Wrap(err, "list tasks")
+	}
+
+	for _, task := range tasks {
+		if task.Enabled {
+			continue
+		}
+		if task.Type == sr.TaskType {
+			continue
+		}
+		// Enabling only tasks that were disabled by StoppingRunner.
+		if val := task.Labels[disabledByLabel]; val != disabledByValue {
+			continue
+		}
+		task.Enabled = true
+		delete(task.Labels, disabledByLabel)
+		if err := sr.Service.PutTask(ctx, &task.Task); err != nil {
+			return errors.Wrap(err, "enable task")
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This introduces StoppingRunner that wraps any other Runner and when
executed:
1. Disables & Stops all tasks (only if task has `stop-all` property)
2. Then invokes wrapped Runner
3. Re-enables tasks from step 1 (only if task has `stop-all` property)

Refs: https://github.com/scylladb/scylla-manager/issues/4367

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
