### PR TITLE
feat(1-1-restore): add unpin-agent-cpu flag 

### DIFF
--- a/docs/source/sctool/partials/sctool_restore_1-1-restore.yaml
+++ b/docs/source/sctool/partials/sctool_restore_1-1-restore.yaml
@@ -119,7 +119,8 @@ options:
         The default value is taken from this system, namely 'TZ' envvar or '/etc/localtime' file.
     - name: unpin-agent-cpu
       default_value: "false"
-      usage: "Defines if ScyllaDB Manager Agent should be unpinned from CPUs during restore.\nThis might significantly improve download speed at the cost of decreasing streaming speed. "
+      usage: |
+        Defines if ScyllaDB Manager Agent should be unpinned from CPUs during restore.
     - name: window
       default_value: '[]'
       usage: |

--- a/docs/source/sctool/partials/sctool_restore_1-1-restore.yaml
+++ b/docs/source/sctool/partials/sctool_restore_1-1-restore.yaml
@@ -117,6 +117,9 @@ options:
       usage: |
         Timezone of --cron and --window flag values.
         The default value is taken from this system, namely 'TZ' envvar or '/etc/localtime' file.
+    - name: unpin-agent-cpu
+      default_value: "false"
+      usage: "Defines if ScyllaDB Manager Agent should be unpinned from CPUs during restore.\nThis might significantly improve download speed at the cost of decreasing streaming speed. "
     - name: window
       default_value: '[]'
       usage: |

--- a/docs/source/sctool/partials/sctool_restore_1-1-restore_update.yaml
+++ b/docs/source/sctool/partials/sctool_restore_1-1-restore_update.yaml
@@ -118,6 +118,9 @@ options:
       usage: |
         Timezone of --cron and --window flag values.
         The default value is taken from this system, namely 'TZ' envvar or '/etc/localtime' file.
+    - name: unpin-agent-cpu
+      default_value: "false"
+      usage: "Defines if ScyllaDB Manager Agent should be unpinned from CPUs during restore.\nThis might significantly improve download speed at the cost of decreasing streaming speed. "
     - name: window
       default_value: '[]'
       usage: |

--- a/docs/source/sctool/partials/sctool_restore_1-1-restore_update.yaml
+++ b/docs/source/sctool/partials/sctool_restore_1-1-restore_update.yaml
@@ -120,7 +120,8 @@ options:
         The default value is taken from this system, namely 'TZ' envvar or '/etc/localtime' file.
     - name: unpin-agent-cpu
       default_value: "false"
-      usage: "Defines if ScyllaDB Manager Agent should be unpinned from CPUs during restore.\nThis might significantly improve download speed at the cost of decreasing streaming speed. "
+      usage: |
+        Defines if ScyllaDB Manager Agent should be unpinned from CPUs during restore.
     - name: window
       default_value: '[]'
       usage: |

--- a/pkg/command/one2onerestore/cmd.go
+++ b/pkg/command/one2onerestore/cmd.go
@@ -32,6 +32,7 @@ type command struct {
 	keyspace      []string
 	snapshotTag   string
 	nodesMapping  nodesMapping
+	unpinAgentCPU bool
 	dryRun        bool
 }
 
@@ -83,6 +84,7 @@ func (cmd *command) init() {
 
 	// Common configuration for restore procedures
 	w.Unwrap().BoolVar(&cmd.dryRun, "dry-run", false, "")
+	w.Unwrap().BoolVar(&cmd.unpinAgentCPU, "unpin-agent-cpu", false, "")
 }
 
 func (cmd *command) run(args []string) error {
@@ -204,6 +206,11 @@ func flagsToTaskProperties(cmd *command, task *models.Task) (updated bool, err e
 		{
 			flagName: "nodes-mapping",
 			value:    cmd.nodesMapping,
+		},
+		{
+			flagName:     "unpin-agent-cpu",
+			value:        cmd.unpinAgentCPU,
+			canBeUpdated: true,
 		},
 	}
 

--- a/pkg/command/one2onerestore/res.yaml
+++ b/pkg/command/one2onerestore/res.yaml
@@ -31,4 +31,3 @@ dry-run: |
 
 unpin-agent-cpu: |
   Defines if ScyllaDB Manager Agent should be unpinned from CPUs during restore.
-  This might significantly improve download speed at the cost of decreasing streaming speed. 

--- a/pkg/command/one2onerestore/res.yaml
+++ b/pkg/command/one2onerestore/res.yaml
@@ -28,3 +28,7 @@ nodes-mapping:
 dry-run: |
   Validates and displays restore information without actually running the restore.
   This allows you to display what will happen should the restore run with the parameters you set.
+
+unpin-agent-cpu: |
+  Defines if ScyllaDB Manager Agent should be unpinned from CPUs during restore.
+  This might significantly improve download speed at the cost of decreasing streaming speed. 

--- a/pkg/service/one2onerestore/model.go
+++ b/pkg/service/one2onerestore/model.go
@@ -19,6 +19,7 @@ type Target struct {
 	SourceClusterID uuid.UUID             `json:"source_cluster_id"`
 	SnapshotTag     string                `json:"snapshot_tag"`
 	NodesMapping    []nodeMapping         `json:"nodes_mapping"`
+	UnpinAgentCPU   bool                  `json:"unpin_agent_cpu"`
 }
 
 func defaultTarget() Target {


### PR DESCRIPTION
This adds support of unpin-agent-cpu flag to 1-1-restore command.
Unpinning agent CPU should help with agent download speed.

Refs: https://github.com/scylladb/scylla-manager/issues/4375

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
