### PR TITLE
feat(1-1-restore): add queue for a refreshNode calls

### DIFF
--- a/pkg/service/one2onerestore/worker_tables.go
+++ b/pkg/service/one2onerestore/worker_tables.go
@@ -11,6 +11,8 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
+	"golang.org/x/sync/errgroup"
 )
 
 func (w *worker) restoreTables(ctx context.Context, workload []hostWorkload, keyspaces []string) error {
@@ -20,34 +22,54 @@ func (w *worker) restoreTables(ctx context.Context, workload []hostWorkload, key
 	return parallel.Run(len(workload), len(workload), func(i int) error {
 		hostTask := workload[i]
 		manifestInfo, host := hostTask.manifestInfo, hostTask.host
-		const (
-			repeatInterval  = 10 * time.Second
-			pollIntervalSec = 10
+		var (
+			refreshQueueSize = max(100, len(hostTask.manifestContent.Index))
+			refreshQueue     = make(chan refreshNodeInput, refreshQueueSize)
+			refreshGroup     errgroup.Group
 		)
-		if err := hostTask.manifestContent.ForEachIndexIterWithError(keyspaces, func(table backupspec.FilesMeta) error {
-			w.logger.Info(ctx, "Restoring data", "ks", table.Keyspace, "table", table.Table, "size", table.Size)
-
-			jobID, err := w.createDownloadJob(ctx, table, manifestInfo, host)
-			if err != nil {
-				return errors.Wrapf(err, "create download job: %s.%s", table.Keyspace, table.Table)
-			}
-			pr := w.downloadProgress(ctx, hostTask.host.Addr, table)
-
-			if err := w.waitJob(ctx, jobID, manifestInfo, host, pr, pollIntervalSec); err != nil {
-				return errors.Wrapf(err, "wait job: %s.%s", table.Keyspace, table.Table)
-			}
-
-			if err := w.refreshNode(ctx, table, manifestInfo, host, pr); err != nil {
-				return errors.Wrapf(err, "refresh node: %s.%s", table.Keyspace, table.Table)
-			}
-			return nil
-		}); err != nil {
+		// Start refresh node worker to avoid blocking on refreshNode call.
+		refreshGroup.Go(w.refreshNodeWorker(ctx, refreshQueue))
+		if err := w.downloadTablesByHost(ctx, hostTask, keyspaces, refreshQueue); err != nil {
+			w.metrics.SetOne2OneRestoreState(w.runInfo.ClusterID, manifestInfo.Location, manifestInfo.SnapshotTag, host.Addr, metrics.One2OneRestoreStateError)
+			return err
+		}
+		if err := refreshGroup.Wait(); err != nil {
 			w.metrics.SetOne2OneRestoreState(w.runInfo.ClusterID, manifestInfo.Location, manifestInfo.SnapshotTag, host.Addr, metrics.One2OneRestoreStateError)
 			return err
 		}
 		w.metrics.SetOne2OneRestoreState(w.runInfo.ClusterID, manifestInfo.Location, manifestInfo.SnapshotTag, host.Addr, metrics.One2OneRestoreStateDone)
 		return nil
 	}, logError)
+}
+
+func (w *worker) downloadTablesByHost(ctx context.Context, hostTask hostWorkload, keyspaces []string, refreshQueue chan<- refreshNodeInput) error {
+	manifestInfo, host := hostTask.manifestInfo, hostTask.host
+	const (
+		repeatInterval  = 10 * time.Second
+		pollIntervalSec = 10
+	)
+	defer close(refreshQueue)
+	return hostTask.manifestContent.ForEachIndexIterWithError(keyspaces, func(table backupspec.FilesMeta) error {
+		w.logger.Info(ctx, "Restoring data", "ks", table.Keyspace, "table", table.Table, "size", table.Size)
+
+		jobID, err := w.createDownloadJob(ctx, table, manifestInfo, host)
+		if err != nil {
+			return errors.Wrapf(err, "create download job: %s.%s", table.Keyspace, table.Table)
+		}
+		pr := w.downloadProgress(ctx, hostTask.host.Addr, table)
+
+		if err := w.waitJob(ctx, jobID, manifestInfo, host, pr, pollIntervalSec); err != nil {
+			return errors.Wrapf(err, "wait job: %s.%s", table.Keyspace, table.Table)
+		}
+
+		refreshQueue <- refreshNodeInput{
+			Table:        table,
+			Host:         host,
+			ManfiestInfo: manifestInfo,
+			Progress:     pr,
+		}
+		return nil
+	})
 }
 
 func (w *worker) createDownloadJob(ctx context.Context, table backupspec.FilesMeta, m *backupspec.ManifestInfo, h Host) (int64, error) {
@@ -61,10 +83,43 @@ func (w *worker) createDownloadJob(ctx context.Context, table backupspec.FilesMe
 	return jobID, nil
 }
 
+type refreshNodeInput struct {
+	Table        backupspec.FilesMeta
+	Host         Host
+	ManfiestInfo *backupspec.ManifestInfo
+	Progress     *RunTableProgress
+}
+
+func (w *worker) refreshNodeWorker(ctx context.Context, queue <-chan refreshNodeInput) func() error {
+	return func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case input, ok := <-queue:
+				if !ok {
+					return nil // Channel closed
+				}
+				if err := w.refreshNode(ctx, input.Table, input.ManfiestInfo, input.Host, input.Progress); err != nil {
+					return errors.Wrapf(err, "refresh node: %s.%s", input.Table.Keyspace, input.Table.Table)
+				}
+			}
+		}
+	}
+}
+
 func (w *worker) refreshNode(ctx context.Context, table backupspec.FilesMeta, m *backupspec.ManifestInfo, h Host, pr *RunTableProgress) error {
+	start := timeutc.Now()
 	w.metrics.SetOne2OneRestoreState(w.runInfo.ClusterID, m.Location, m.SnapshotTag, h.Addr, metrics.One2OneRestoreStateLoading)
 	err := w.client.AwaitLoadSSTables(ctx, h.Addr, table.Keyspace, table.Table, false, false)
 	w.finishDownloadProgress(ctx, pr, err)
+	w.logger.Info(ctx, "Refresh node done",
+		"host", h.Addr,
+		"keyspace", table.Keyspace,
+		"table", table.Table,
+		"size", table.Size,
+		"took", timeutc.Since(start),
+	)
 	return err
 }
 

--- a/pkg/service/one2onerestore/worker_tables_test.go
+++ b/pkg/service/one2onerestore/worker_tables_test.go
@@ -1,0 +1,81 @@
+// Copyright (C) 2025 ScyllaDB
+
+package one2onerestore
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/scylladb/scylla-manager/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient/scyllaclienttest"
+)
+
+func TestRefreshNodeWorker(t *testing.T) {
+	testCases := []struct {
+		name          string
+		inputCh       chan refreshNodeInput
+		input         []refreshNodeInput
+		handler       http.HandlerFunc
+		expectedCalls int32
+		expectedError bool
+	}{
+		{
+			name:    "Happy path",
+			inputCh: make(chan refreshNodeInput, 3),
+			input: []refreshNodeInput{
+				{
+					ManfiestInfo: &backupspec.ManifestInfo{},
+					Progress:     &RunTableProgress{},
+				},
+				{
+					ManfiestInfo: &backupspec.ManifestInfo{},
+					Progress:     &RunTableProgress{},
+				},
+				{
+					ManfiestInfo: &backupspec.ManifestInfo{},
+					Progress:     &RunTableProgress{},
+				},
+			},
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			expectedCalls: 3,
+			expectedError: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			handler := &testHandler{Handler: tc.handler}
+			ts := httptest.NewServer(handler)
+			defer ts.Close()
+
+			tsAddr, err := url.Parse(ts.URL)
+			if err != nil {
+				t.Fatalf("Unexpected err: %v", err)
+			}
+			w := &worker{
+				client:  scyllaclienttest.MakeClient(t, tsAddr.Hostname(), tsAddr.Port()),
+				metrics: metrics.NewOne2OneRestoreMetrics(),
+			}
+
+			for _, input := range tc.input {
+				tc.inputCh <- input
+			}
+			close(tc.inputCh)
+			// Start the refresh node worker
+			err = w.refreshNodeWorker(context.Background(), tc.inputCh)()
+			// Check the result
+			if (err != nil) != tc.expectedError {
+				t.Errorf("Expected error: %v, got: %v", tc.expectedError, err)
+			}
+			if tc.expectedCalls != handler.calls.Load() {
+				t.Errorf("Expected %d calls, got: %d", tc.expectedCalls, handler.calls.Load())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a queue for refreshNode calls to avoid blocking download operation.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
