### PR TITLE
feat(1-1-restore): use 2*shard count transfers for downloading tables

### DIFF
--- a/pkg/service/one2onerestore/worker_tables.go
+++ b/pkg/service/one2onerestore/worker_tables.go
@@ -57,7 +57,8 @@ func (w *worker) restoreTables(ctx context.Context, workload []hostWorkload, key
 func (w *worker) createDownloadJob(ctx context.Context, table backupspec.FilesMeta, m *backupspec.ManifestInfo, h Host) (int64, error) {
 	uploadDir := backupspec.UploadTableDir(table.Keyspace, table.Table, table.Version)
 	remoteDir := m.LocationSSTableVersionDir(table.Keyspace, table.Table, table.Version)
-	jobID, err := w.client.RcloneCopyPaths(ctx, h.Addr, scyllaclient.TransfersFromConfig, scyllaclient.NoRateLimit, uploadDir, remoteDir, table.Files)
+	transfers := 2 * h.ShardCount // 2 * shard count showed to be the most optimal value in tests
+	jobID, err := w.client.RcloneCopyPaths(ctx, h.Addr, transfers, scyllaclient.NoRateLimit, uploadDir, remoteDir, table.Files)
 	if err != nil {
 		return 0, errors.Wrapf(err, "copy dir: %s", m.LocationSSTableVersionDir(table.Keyspace, table.Table, table.Version))
 	}


### PR DESCRIPTION
The usage of transfer values from the config is replaced with `2 * shard count`. This is necessary because the default config value of 2 is too slow in most cases, and tests have indicated that `2 * shard count` yields the most optimal performance. Also regular restore uses this formula by default.

Refs: #4402

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
