### PR TITLE
docs: link to new scylla docs

### DIFF
--- a/docs/source/backup/index.rst
+++ b/docs/source/backup/index.rst
@@ -47,8 +47,8 @@ Selecting tables and nodes to back up
 | All currently down nodes are ignored for the backup procedure.
 | In case table should be backed up, but some of its token ranges are not replicated on any currently live node in the cluster, the backup will fail.
 
-| Moreover, `Materialized Views <https://opensource.docs.scylladb.com/stable/using-scylla/materialized-views.html>`_ and `Secondary Indexes <https://opensource.docs.scylladb.com/stable/using-scylla/secondary-indexes.html>`_
-  won't be backed up, as they should be restored by recreating them on the restored base table (see `ScyllaDB docs <https://opensource.docs.scylladb.com/stable/operating-scylla/procedures/backup-restore/restore.html#repeat-the-following-steps-for-each-node-in-the-cluster>`_).
+| Moreover, `Materialized Views <https://docs.scylladb.com/manual/stable/features/materialized-views.html>`_ and `Secondary Indexes <https://docs.scylladb.com/manual/stable/features/secondary-indexes.html>`_
+  won't be backed up, as they should be restored by recreating them on the restored base table (see `ScyllaDB docs <https://docs.scylladb.com/manual/stable/operating-scylla/procedures/backup-restore/restore.html#repeat-the-following-steps-for-each-node-in-the-cluster>`_).
 | In order to ensure that data residing in View table is preserved, make sure to backup its base table.
 
 Process
@@ -58,7 +58,7 @@ The backup procedure consists of multiple steps executed sequentially.
 
 #. **Snapshot** - Take a snapshot of data on each node (according to backup configuration settings).
 
-   Note that ScyllaDB Manager halts `tablets <https://opensource.docs.scylladb.com/stable/architecture/tablets.html>`_  migration for the duration of this step.
+   Note that ScyllaDB Manager halts `tablets <https://docs.scylladb.com/manual/stable/architecture/tablets.html>`_  migration for the duration of this step.
 #. **Schema** - Upload the schema in CQL text format to the backup storage destination,
    this requires that you added the cluster with CQL username and password.
    If you didn't you can :ref:`update the cluster using sctool <cluster-update>` at any point in time.

--- a/docs/source/backup/specification.rst
+++ b/docs/source/backup/specification.rst
@@ -161,7 +161,7 @@ Some files may be used in more than one backup.
 
 You may also find that some of those files have the snapshot tag suffix (e.g. ``.sm_20210809095541UTC``).
 Even though sstables (data files) are immutable by nature, using non UUID sstable identifiers alongside
-`replacing a running node <https://opensource.docs.scylladb.com/stable/operating-scylla/procedures/cluster-management/replace-running-node.html#replace-a-running-node-by-taking-its-place-in-the-cluster>`_
+`replacing a running node <https://docs.scylladb.com/manual/stable/operating-scylla/procedures/cluster-management/replace-running-node.html#replace-a-running-node-by-taking-its-place-in-the-cluster>`_
 makes it possible to have two different sstables originating
 from the same table and with the same node ID. In this case, older versions of sstable are appended with the snapshot tag
 indicating the backup that introduced newer version of given sstable. The most current version of sstable does not have the snapshot tag suffix.

--- a/docs/source/repair/index.rst
+++ b/docs/source/repair/index.rst
@@ -25,7 +25,7 @@ ScyllaDB Manager automates the repair process and allows you to configure how an
 chosen (by ScyllaDB Manager) token ranges of a given table owned by a specific replica set. All nodes from this replica set take part in
 the repair job and any node can take part only in a single repair job at any given time.
 
-Note that ScyllaDB Manager stops `tablets <https://opensource.docs.scylladb.com/stable/architecture/tablets.html>`_  migration for the duration of repair.
+Note that ScyllaDB Manager stops `tablets <https://docs.scylladb.com/manual/stable/architecture/tablets.html>`_  migration for the duration of repair.
 
 When you create a cluster a repair task is automatically scheduled.
 This task is set to occur each week by default, but you can change it to another time, change its parameters or add additional repair tasks if needed.
@@ -125,7 +125,7 @@ Scylla Manager repairs keyspace by keyspace and table by table in order to achie
 Keyspaces and tables are ordered according to the following rules:
 
 * repair internal (with ``system`` prefix) tables before user tables
-* repair base tables before `Materialized Views <https://opensource.docs.scylladb.com/stable/using-scylla/materialized-views.html>`_ and `Secondary Indexes <https://opensource.docs.scylladb.com/stable/using-scylla/secondary-indexes.html>`_
+* repair base tables before `Materialized Views <https://docs.scylladb.com/manual/stable/features/materialized-views.html>`_ and `Secondary Indexes <https://docs.scylladb.com/manual/stable/features/secondary-indexes.html>`_
 * repair smaller keyspaces and tables first
 
 .. note:: Ensuring that base tables are repaired before views is possible only when Scylla Manager has `CQL credentials <https://manager.docs.scylladb.com/stable/sctool/cluster.html#cluster-add>`_ to repaired cluster.

--- a/docs/source/restore/examples.rst
+++ b/docs/source/restore/examples.rst
@@ -66,13 +66,13 @@ Complete the restore procedure - restore both the schema and the content of the 
      │ system_schema │ 100% | 100% │ 557.728k │ 557.728k │   557.728k │            0 │      0 │
      ╰───────────────┴─────────────┴──────────┴──────────┴────────────┴──────────────┴────────╯
 
-#. Perform restore schema follow-up action (only for ScyllaDB **5.4**/**2024.1** or older) - `rolling restart <https://docs.scylladb.com/stable/operating-scylla/procedures/config-change/rolling-restart.html>`_.
+#. Perform restore schema follow-up action (only for ScyllaDB **5.4**/**2024.1** or older) - `rolling restart <https://docs.scylladb.com/manual/stable/operating-scylla/procedures/config-change/rolling-restart.html>`_.
 
 #. Ensure that all prerequisites of restoring the content of the tables are met.
 
    The easiest way to achieve that is to restore schema with :doc:`sctool restore <restore-schema>` (so that's what has already been done in this example).
    You don't need to follow this step if you are sure that the destination cluster has the correct schema of restored tables and
-   that those tables are `truncated <https://docs.scylladb.com/stable/cql/ddl.html#truncate-statement>`_.
+   that those tables are `truncated <https://docs.scylladb.com/manual/stable/cql/ddl.html#truncate-statement>`_.
 
 #. Restore the content of the tables using :ref:`sctool restore <sctool-restore>`.
 

--- a/docs/source/restore/old-restore-schema.rst
+++ b/docs/source/restore/old-restore-schema.rst
@@ -20,7 +20,7 @@ Prerequisites
 * It is strongly advised to restore schema only into an empty cluster with no schema change history of the keyspace that is going to be restored.
    Otherwise, the restored schema might be overwritten by the already existing one and cause unexpected errors.
 
-* All nodes in restore destination cluster should be in the ``UN`` state (See `nodetool status <https://docs.scylladb.com/stable/operating-scylla/nodetool-commands/status.html>`_ for details).
+* All nodes in restore destination cluster should be in the ``UN`` state (See `nodetool status <https://docs.scylladb.com/manual/stable/operating-scylla/nodetool-commands/status.html>`_ for details).
 
 Procedure
 =========
@@ -46,13 +46,13 @@ However, the small size of schema files makes this overhead negligible.
             * Download all SSTables
     * For all nodes in restore destination cluster:
 
-        * `nodetool refresh <https://docs.scylladb.com/stable/operating-scylla/nodetool-commands/refresh.html#nodetool-refresh>`_ on all downloaded schema tables (full parallel)
+        * `nodetool refresh <https://docs.scylladb.com/manual/stable/operating-scylla/nodetool-commands/refresh.html>`_ on all downloaded schema tables (full parallel)
 
 Follow-up action
 ================
 
 After successful restore it is important to perform necessary follow-up action. In case of restoring schema,
-you should make a `rolling restart <https://docs.scylladb.com/stable/operating-scylla/procedures/config-change/rolling-restart.html>`_ of an entire cluster.
+you should make a `rolling restart <https://docs.scylladb.com/manual/stable/operating-scylla/procedures/config-change/rolling-restart.html>`_ of an entire cluster.
 Without the restart, the restored schema might not be visible, and querying it can return various errors.
 
 .. _restore-schema-workaround:
@@ -65,5 +65,5 @@ is not supported. In such case, you should perform the following workaround:
 
     * Create a fresh cluster with ``consistent_cluster_management: false`` configured in ``scylla.yaml`` and a desired ScyllaDB version.
     * Restore schema via :ref:`sctool restore <sctool-restore>` with ``--restore-schema`` flag.
-    * Perform `rolling restart <https://docs.scylladb.com/stable/operating-scylla/procedures/config-change/rolling-restart.html>`_ of an entire cluster.
-    * Follow the steps of the `Enable Raft procedure <https://opensource.docs.scylladb.com/stable/architecture/raft.html#enabling-raft>`_.
+    * Perform `rolling restart <https://docs.scylladb.com/manual/stable/operating-scylla/procedures/config-change/rolling-restart.html>`_ of an entire cluster.
+    * Follow the steps of the `Enable Raft procedure <https://docs.scylladb.com/manual/stable/architecture/raft.html>`_.

--- a/docs/source/restore/restore-schema.rst
+++ b/docs/source/restore/restore-schema.rst
@@ -4,7 +4,7 @@ Restore schema for ScyllaDB 6.0/2024.2 or newer
 
 .. note:: Currently, ScyllaDB Manager supports only entire schema restoration, so ``--keyspace`` flag is not allowed.
 
-.. note:: Currently, restoring schema containing `alternator tables <https://opensource.docs.scylladb.com/stable/using-scylla/alternator/>`_ is not supported.
+.. note:: Currently, restoring schema containing `alternator tables <https://docs.scylladb.com/manual/stable/using-scylla/alternator/>`_ is not supported.
 
 | In order to restore ScyllaDB cluster schema use :ref:`sctool restore <sctool-restore>` with ``--restore-schema`` flag.
 | Please note that the term *schema* specifically refers to the data residing in the ``system_schema keyspace``, such as keyspace and table definitions. All other data stored in keyspaces managed by ScyllaDB is restored as part of the :doc:`restore tables procedure <restore-tables>`.
@@ -15,7 +15,7 @@ Prerequisites
 
 * ScyllaDB Manager requires CQL credentials with
 
-    * `permission to create <https://opensource.docs.scylladb.com/stable/operating-scylla/security/authorization.html#permissions>`_ restored keyspaces.
+    * `permission to create <https://docs.scylladb.com/manual/stable/operating-scylla/security/authorization.html#permissions>`_ restored keyspaces.
 
 * No overlapping schema in restore destination cluster (see the procedure below for more details)
 

--- a/docs/source/restore/restore-tables.rst
+++ b/docs/source/restore/restore-tables.rst
@@ -2,7 +2,7 @@
 Restore tables
 ==============
 
-.. note:: Currently, Scylla Manager does not support restoring content of `CDC log tables <https://docs.scylladb.com/stable/using-scylla/cdc/cdc-log-table.html>`_.
+.. note:: Currently, Scylla Manager does not support restoring content of `CDC log tables <https://docs.scylladb.com/manual/stable/features/cdc/cdc-log-table.html>`_.
 
 .. warning:: Restoring data related to *authentication* (``system_auth``) and *service levels* (``system_distributed.service_levels``) is not supported in ScyllaDB 6.0.
 
@@ -16,8 +16,8 @@ Prerequisites
 
 * Scylla Manager requires CQL credentials with:
 
-    * `permission to alter <https://opensource.docs.scylladb.com/stable/operating-scylla/security/authorization.html#permissions>`_ restored tables.
-    * `permission to drop and create <https://opensource.docs.scylladb.com/stable/operating-scylla/security/authorization.html#permissions>`_ Materialized Views and Secondary Indexes of restored tables.
+    * `permission to alter <https://docs.scylladb.com/manual/stable/operating-scylla/security/authorization.html#permissions>`_ restored tables.
+    * `permission to drop and create <https://docs.scylladb.com/manual/stable/operating-scylla/security/authorization.html#permissions>`_ Materialized Views and Secondary Indexes of restored tables.
 
 * Restoring the content of the tables assumes that the correct schema (identical as in the backup) is already present in the destination cluster.
 
@@ -28,14 +28,14 @@ Prerequisites
 
    Note that this requirement also applies to the keyspace schema.
    Keyspace (where restored tables live) should have the correct schema, including the replication strategy.
-   It can be changed after successful restore according to: `How to Safely Increase the Replication Factor <https://opensource.docs.scylladb.com/stable/kb/rf-increase.html>`_.
+   It can be changed after successful restore according to: `How to Safely Increase the Replication Factor <https://docs.scylladb.com/manual/stable/kb/rf-increase.html>`_.
 
-* It is strongly advised to restore the contents of the tables only into `truncated <https://docs.scylladb.com/stable/cql/ddl.html#truncate-statement>`_ tables.
+* It is strongly advised to restore the contents of the tables only into `truncated <https://docs.scylladb.com/manual/stable/cql/ddl.html#truncate-statement>`_ tables.
 
    Otherwise, restored tables' contents might be overwritten by the already existing ones.
    Note that an empty table is not necessarily truncated!
 
-* All nodes in restore destination cluster should be in the ``UN`` state (See `nodetool status <https://docs.scylladb.com/stable/operating-scylla/nodetool-commands/status.html>`_ for details).
+* All nodes in restore destination cluster should be in the ``UN`` state (See `nodetool status <https://docs.scylladb.com/manual/stable/operating-scylla/nodetool-commands/status.html>`_ for details).
 
 Procedure
 =========
@@ -63,7 +63,7 @@ This section contains a description of the restore-tables procedure performed by
 
             * Select *node* with enough free space to restore given batch
             * Download batch to *node's* upload directory
-            * Call `load and stream <https://docs.scylladb.com/stable/operating-scylla/nodetool-commands/refresh.html#load-and-stream>`_ with ``primary_replica_only``
+            * Call `load and stream <https://docs.scylladb.com/manual/stable/operating-scylla/nodetool-commands/refresh.html#load-and-stream>`_ with ``primary_replica_only``
     * :ref:`Repair <sctool-repair>` restored tables
     * Reset all restored tables ``tombstone_gc`` to its original mode
     * Recreate restored views


### PR DESCRIPTION
Scylla license change also resulted in a new place for Source Available Scylla docs. We should link to its docs instead of the older Open Source or Enterprise docs.

Fixes #4416
