### PR TITLE
Don't timeout on long API calls

### DIFF
--- a/dist/etc/scylla-manager.yaml
+++ b/dist/etc/scylla-manager.yaml
@@ -123,6 +123,10 @@ http: 127.0.0.1:5080
 
 # Repair service configuration.
 #repair:
+# Timeout on querying repair status of vnode replicated table. Zero means no timeout.
+# Use only if you observe that Scylla Manager hangs indefinitely when querying vnode repair status.
+#  status_timeout: 0
+#
 # Maximal time a paused repair is considered fresh and can be continued,
 # if exceeded repair will start from the beginning. Zero means no limit.
 #  age_max: 0

--- a/dist/etc/scylla-manager.yaml
+++ b/dist/etc/scylla-manager.yaml
@@ -123,9 +123,6 @@ http: 127.0.0.1:5080
 
 # Repair service configuration.
 #repair:
-# Frequency Scylla Manager poll Scylla node for repair command status.
-#  poll_interval: 50ms
-#
 # Maximal time a paused repair is considered fresh and can be continued,
 # if exceeded repair will start from the beginning. Zero means no limit.
 #  age_max: 0
@@ -133,16 +130,6 @@ http: 127.0.0.1:5080
 # Specifies how long repair will wait until all ongoing repair requests finish
 # when repair task is stopped. After this time, task will be interrupted.
 #  graceful_stop_timeout: 30s
-#
-# Force usage of certain type of repair algorithm. Allowed values are row_level, legacy, and auto.
-# row_level means that Scylla Manager will use row level repair optimised algorithm.
-# legacy means that Scylla Manager will be splitting ranges to shards when making repair requests.
-# Default value is auto which means that repair type will be auto detected based on Scylla versions in the managed cluster.
-#  force_repair_type: auto
-#
-# Distribution of data among cores (shards) within a node.
-# Copy value from Scylla configuration file.
-#  murmur3_partitioner_ignore_msb_bits: 12
 
 # Connection configuration to Scylla Agent.
 #  agent_client:

--- a/pkg/config/server/server_test.go
+++ b/pkg/config/server/server_test.go
@@ -87,6 +87,7 @@ func TestConfigModification(t *testing.T) {
 			LongPollingTimeoutSeconds: 5,
 		},
 		Repair: repair.Config{
+			StatusTimeout:                   time.Hour,
 			PollInterval:                    500 * time.Millisecond,
 			LongPollingTimeoutSeconds:       5,
 			AgeMax:                          12 * time.Hour,

--- a/pkg/config/server/testdata/scylla-manager.yaml
+++ b/pkg/config/server/testdata/scylla-manager.yaml
@@ -46,6 +46,7 @@ restore:
   long_polling_timeout_seconds: 5
 
 repair:
+  status_timeout: 1h
   poll_interval: 500ms
   long_polling_timeout_seconds: 5
   age_max: 12h

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -682,12 +682,14 @@ func repairStatusShouldRetryHandler(err error) *bool {
 	return nil
 }
 
-const repairStatusTimeout = 30 * time.Minute
-
 // RepairStatus waits for repair job to finish and returns its status.
-func (c *Client) RepairStatus(ctx context.Context, host string, id int32) (CommandStatus, error) {
+func (c *Client) RepairStatus(ctx context.Context, host string, id int32, timeout time.Duration) (CommandStatus, error) {
 	ctx = forceHost(ctx, host)
-	ctx = customTimeout(ctx, repairStatusTimeout)
+	if timeout > 0 {
+		ctx = customTimeout(ctx, timeout)
+	} else {
+		ctx = noTimeout(ctx)
+	}
 	ctx = withShouldRetryHandler(ctx, repairStatusShouldRetryHandler)
 	var (
 		resp interface {

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -1093,14 +1093,13 @@ func (c *Client) AwaitLoadSSTables(ctx context.Context, host, keyspace, table st
 		return err != nil && strings.Contains(err.Error(), alreadyLoadingSSTablesErrMsg)
 	}
 
-	// The first call is synchronous and might time out.
+	// The first call is synchronous.
 	// We also need to handle situation where SM task
 	// was interrupted and retried immediately.
 	// Then it might also happen, that we get the
 	// already loading error, and we should await its completion.
-	const firstCallTimeout = time.Hour
 	firstCallCtx := ctx
-	firstCallCtx = customTimeout(firstCallCtx, firstCallTimeout)
+	firstCallCtx = noTimeout(firstCallCtx)
 	firstCallCtx = noRetry(firstCallCtx)
 	err := c.loadSSTables(firstCallCtx, host, keyspace, table, loadAndStream, primaryReplicaOnly)
 	if err == nil {

--- a/pkg/service/repair/config.go
+++ b/pkg/service/repair/config.go
@@ -24,6 +24,7 @@ const (
 
 // Config specifies the repair service configuration.
 type Config struct {
+	StatusTimeout                   time.Duration `yaml:"status_timeout"`
 	PollInterval                    time.Duration `yaml:"poll_interval"`
 	LongPollingTimeoutSeconds       int           `yaml:"long_polling_timeout_seconds"`
 	AgeMax                          time.Duration `yaml:"age_max"`
@@ -48,6 +49,9 @@ func (c *Config) Validate() error {
 	}
 
 	var err error
+	if c.StatusTimeout < 0 {
+		err = multierr.Append(err, errors.New("invalid status_timeout, must be >= 0"))
+	}
 	if c.PollInterval <= 0 {
 		err = multierr.Append(err, errors.New("invalid poll_interval, must be > 0"))
 	}

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1032,11 +1032,7 @@ func TestServiceRepairResumeAllRangesIntegration(t *testing.T) {
 }
 
 func TestServiceRepairIntegration(t *testing.T) {
-	defaultConfig := func() repair.Config {
-		c := repair.DefaultConfig()
-		c.PollInterval = 10 * time.Millisecond
-		return c
-	}
+	defaultConfig := repair.DefaultConfig
 	session := CreateScyllaManagerDBSession(t)
 	h := newRepairTestHelper(t, session, defaultConfig())
 	clusterSession := CreateSessionAndDropAllKeyspaces(t, h.Client)

--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -93,7 +93,7 @@ func (w *worker) runRepair(ctx context.Context, j job) (out error) {
 		"job_id", jobID,
 	)
 
-	status, err := w.client.RepairStatus(ctx, j.master.String(), jobID)
+	status, err := w.client.RepairStatus(ctx, j.master.String(), jobID, w.config.StatusTimeout)
 	if err != nil {
 		return errors.Wrap(err, "get repair status")
 	}


### PR DESCRIPTION
This PR removes SM side timeouts on long API calls such as:
- repair status for vnodes (still possible to configure via `scylla-manager.yaml`)
- load&stream

It also removes unused repair config fields from `scylla-manager.yaml`.

Fixes #4419 