### PR TITLE
Use Scylla read barrier API for Scylla 2025.1

### DIFF
--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -253,6 +253,7 @@ func (ni *NodeInfo) SupportsSafeDescribeSchemaWithInternals() (SafeDescribeMetho
 	}
 
 	for _, fv := range []featureByVersion{
+		{Constraint: ">= 2025.1", Method: SafeDescribeMethodReadBarrierAPI},
 		{Constraint: ">= 6.1, < 2000", Method: SafeDescribeMethodReadBarrierAPI},
 		{Constraint: ">= 2024.2, > 1000", Method: SafeDescribeMethodReadBarrierCQL},
 		{Constraint: ">= 6.0, < 2000", Method: SafeDescribeMethodReadBarrierCQL},

--- a/pkg/scyllaclient/client_agent_test.go
+++ b/pkg/scyllaclient/client_agent_test.go
@@ -367,6 +367,12 @@ func TestSupportsSafeDescribeSchemaWithInternals(t *testing.T) {
 		expectedError  error
 	}{
 		{
+			name:           "when scylla >= 2025.1, then it is expected to support read barrier api",
+			scyllaVersion:  "2025.1.0-candidate-20241106103631",
+			expectedMethod: scyllaclient.SafeDescribeMethodReadBarrierAPI,
+			expectedError:  nil,
+		},
+		{
 			name:           "when scylla >= 6.1, then it is expected to support read barrier api",
 			scyllaVersion:  "6.2.1-candidate-20241106103631",
 			expectedMethod: scyllaclient.SafeDescribeMethodReadBarrierAPI,


### PR DESCRIPTION
When writing this check, there was no enterprise release which exposed read barrier API. It needs to be updated.
