### PR TITLE
feat(1-1-restore): add one2onerestore_progress metric

### DIFF
--- a/pkg/metrics/one2onerestore.go
+++ b/pkg/metrics/one2onerestore.go
@@ -25,7 +25,7 @@ func NewOne2OneRestoreMetrics() One2OneRestoreMetrics {
 			"cluster", "location", "snapshot_tag", "host", "worker"),
 		viewBuildStatus: g("Defines build status of recreated view.", "view_build_status",
 			"cluster", "keyspace", "view"),
-		progress: g("Defines current progress of the 1-1-restore process.", "progress",
+		progress: g("Defines current progress of the 1-1-restore process in percents from 0 to 100%", "progress",
 			"cluster", "snapshot_tag"),
 	}
 }

--- a/pkg/metrics/one2onerestore.go
+++ b/pkg/metrics/one2onerestore.go
@@ -12,6 +12,7 @@ type One2OneRestoreMetrics struct {
 	remainingBytes  *prometheus.GaugeVec
 	state           *prometheus.GaugeVec
 	viewBuildStatus *prometheus.GaugeVec
+	progress        *prometheus.GaugeVec
 }
 
 func NewOne2OneRestoreMetrics() One2OneRestoreMetrics {
@@ -24,6 +25,8 @@ func NewOne2OneRestoreMetrics() One2OneRestoreMetrics {
 			"cluster", "location", "snapshot_tag", "host", "worker"),
 		viewBuildStatus: g("Defines build status of recreated view.", "view_build_status",
 			"cluster", "keyspace", "view"),
+		progress: g("Defines current progress of the 1-1-restore process.", "progress",
+			"cluster", "snapshot_tag"),
 	}
 }
 
@@ -38,6 +41,7 @@ func (m One2OneRestoreMetrics) all() []prometheus.Collector {
 		m.remainingBytes,
 		m.state,
 		m.viewBuildStatus,
+		m.progress,
 	}
 }
 
@@ -109,4 +113,14 @@ func (m One2OneRestoreMetrics) SetViewBuildStatus(clusterID uuid.UUID, keyspace,
 		"view":     view,
 	}
 	m.viewBuildStatus.With(l).Set(float64(status))
+}
+
+// SetProgress sets 1-1-restore "progress" metric,
+// progress should be a value between 0 and 100, that indicates global restore progress.
+func (m One2OneRestoreMetrics) SetProgress(clusterID uuid.UUID, snapshotTag string, progress float64) {
+	l := prometheus.Labels{
+		"cluster":      clusterID.String(),
+		"snapshot_tag": snapshotTag,
+	}
+	m.progress.With(l).Set(progress)
 }

--- a/pkg/service/one2onerestore/progress.go
+++ b/pkg/service/one2onerestore/progress.go
@@ -72,6 +72,8 @@ func (w *worker) initProgressAndMetrics(ctx context.Context, workload []hostWork
 		}
 	}
 
+	w.metrics.SetProgress(w.runInfo.ClusterID, workload[0].manifestInfo.SnapshotTag, 0)
+
 	return nil
 }
 

--- a/pkg/service/one2onerestore/stats.go
+++ b/pkg/service/one2onerestore/stats.go
@@ -11,35 +11,53 @@ import (
 // restoreStats is used to collect some run statistics.
 type restoreStats struct {
 	totalShards         int64
-	totalDownloadTimeMS int64
-	totalDownloadBytes  int64
+	totalBytesToRestore int64
+
+	totalDownloadTimeMS atomic.Int64
+	totalDownloadBytes  atomic.Int64
 }
 
 func newRestoreStats(workload []hostWorkload) *restoreStats {
-	var sumShards int
+	var sumShards, sumBytesToRestore int64
 	for _, w := range workload {
-		sumShards += w.host.ShardCount
+		sumShards += int64(w.host.ShardCount)
+		for _, table := range w.tablesToRestore {
+			sumBytesToRestore += table.size
+		}
 	}
 	return &restoreStats{
-		totalShards: int64(sumShards),
+		totalShards:         sumShards,
+		totalBytesToRestore: sumBytesToRestore,
 	}
 }
 
 // incrementDownloadStats atomically increment downloaded bytes and duration in milliseconds.
 func (rs *restoreStats) incrementDownloadStats(downloadedBytes, tookMS int64) {
-	atomic.AddInt64(&rs.totalDownloadBytes, downloadedBytes)
-	atomic.AddInt64(&rs.totalDownloadTimeMS, tookMS)
+	rs.totalDownloadBytes.Add(downloadedBytes)
+	rs.totalDownloadTimeMS.Add(tookMS)
 }
 
 // averageBandwidthPerShard provides download bandwidth in the same
 // format as `sctool progress` for regular restore task.
 func (rs *restoreStats) averageBandwidthPerShard() string {
-	if rs.totalDownloadTimeMS <= 0 {
+	if rs.totalDownloadTimeMS.Load() <= 0 {
 		return "unknown"
 	}
-	bs := rs.totalDownloadBytes * 1000 / rs.totalDownloadTimeMS
+	bs := rs.totalDownloadBytes.Load() * 1000 / rs.totalDownloadTimeMS.Load()
 	if rs.totalShards <= 0 {
 		return sizesuffix.SizeSuffix(bs).String() + "/s"
 	}
 	return sizesuffix.SizeSuffix(bs/rs.totalShards).String() + "/s/shard"
+}
+
+// progress returns the percentage of restored bytes so far.
+func (rs *restoreStats) progress() float64 {
+	if rs.totalBytesToRestore == 0 {
+		return 100
+	}
+	restoredBytes := rs.totalDownloadBytes.Load()
+	if restoredBytes == 0 {
+		return 0
+	}
+	return float64(restoredBytes) / float64(rs.totalBytesToRestore) * 100.0
 }

--- a/pkg/service/one2onerestore/stats_test.go
+++ b/pkg/service/one2onerestore/stats_test.go
@@ -9,38 +9,123 @@ import (
 
 func TestAverageBandwidthPerShard(t *testing.T) {
 	testCases := []struct {
-		name     string
-		stats    *restoreStats
-		expected string
+		name                string
+		workload            []hostWorkload
+		totalDownloadBytes  int64
+		totalDownloadTimeMS int64
+		expected            string
 	}{
 		{
 			name:     "no data",
-			stats:    &restoreStats{},
+			workload: nil,
 			expected: "unknown",
 		},
 		{
 			name: "no shards",
-			stats: &restoreStats{
-				totalDownloadTimeMS: 1000,
-				totalDownloadBytes:  1024,
+
+			workload: []hostWorkload{
+				{host: Host{ShardCount: 0}},
+				{host: Host{ShardCount: 0}},
 			},
-			expected: "1KiB/s",
+			totalDownloadBytes:  1024,
+			totalDownloadTimeMS: 1000,
+			expected:            "1KiB/s",
 		},
 		{
 			name: "shards",
-			stats: &restoreStats{
-				totalDownloadTimeMS: 1000,
-				totalDownloadBytes:  1024,
-				totalShards:         2,
+			workload: []hostWorkload{
+				{host: Host{ShardCount: 1}},
+				{host: Host{ShardCount: 1}},
 			},
-			expected: "512B/s/shard",
+			totalDownloadBytes:  1024,
+			totalDownloadTimeMS: 1000,
+			expected:            "512B/s/shard",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := tc.stats.averageBandwidthPerShard(); got != tc.expected {
+			stats := newRestoreStats(tc.workload)
+			stats.incrementDownloadStats(tc.totalDownloadBytes, tc.totalDownloadTimeMS)
+			if got := stats.averageBandwidthPerShard(); got != tc.expected {
 				t.Fatalf("Expected bandwidth %s, but got %s", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestProgress(t *testing.T) {
+	testCases := []struct {
+		name                string
+		workload            []hostWorkload
+		totalDownloadBytes  int64
+		totalDownloadTimeMS int64
+		expected            float64
+	}{
+		{
+			name:     "no data",
+			workload: nil,
+			expected: 100.0,
+		},
+		{
+			name: "no tables",
+			workload: []hostWorkload{
+				{host: Host{ShardCount: 0}},
+				{host: Host{ShardCount: 0}},
+			},
+			totalDownloadBytes:  1024,
+			totalDownloadTimeMS: 1000,
+			expected:            100.0,
+		},
+		{
+			name: "everything is restored",
+			workload: []hostWorkload{
+				{host: Host{ShardCount: 1}, tablesToRestore: []scyllaTableWithSize{
+					{scyllaTable: scyllaTable{keyspace: "ks1", table: "table1"}, size: 512},
+				}},
+				{host: Host{ShardCount: 1}, tablesToRestore: []scyllaTableWithSize{
+					{scyllaTable: scyllaTable{keyspace: "ks1", table: "table1"}, size: 512},
+				}},
+			},
+			totalDownloadBytes:  1024,
+			totalDownloadTimeMS: 1000,
+			expected:            100,
+		},
+		{
+			name: "half is restored",
+			workload: []hostWorkload{
+				{host: Host{ShardCount: 1}, tablesToRestore: []scyllaTableWithSize{
+					{scyllaTable: scyllaTable{keyspace: "ks1", table: "table1"}, size: 512},
+				}},
+				{host: Host{ShardCount: 1}, tablesToRestore: []scyllaTableWithSize{
+					{scyllaTable: scyllaTable{keyspace: "ks1", table: "table1"}, size: 512},
+				}},
+			},
+			totalDownloadBytes:  512,
+			totalDownloadTimeMS: 1000,
+			expected:            50,
+		},
+		{
+			name: "nothing is restored",
+			workload: []hostWorkload{
+				{host: Host{ShardCount: 1}, tablesToRestore: []scyllaTableWithSize{
+					{scyllaTable: scyllaTable{keyspace: "ks1", table: "table1"}, size: 512},
+				}},
+				{host: Host{ShardCount: 1}, tablesToRestore: []scyllaTableWithSize{
+					{scyllaTable: scyllaTable{keyspace: "ks1", table: "table1"}, size: 512},
+				}},
+			},
+			totalDownloadBytes:  0,
+			totalDownloadTimeMS: 0,
+			expected:            0,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			stats := newRestoreStats(tc.workload)
+			stats.incrementDownloadStats(tc.totalDownloadBytes, tc.totalDownloadTimeMS)
+			if got := stats.progress(); got != tc.expected {
+				t.Fatalf("Expected progress %.2f, but got %.2f", tc.expected, got)
 			}
 		})
 	}
@@ -48,9 +133,17 @@ func TestAverageBandwidthPerShard(t *testing.T) {
 
 func TestIncrementDownloadStats(t *testing.T) {
 	stats := newRestoreStats([]hostWorkload{
-		{host: Host{ShardCount: 2}},
-		{host: Host{ShardCount: 2}},
+		{host: Host{ShardCount: 2}, tablesToRestore: []scyllaTableWithSize{
+			{scyllaTable: scyllaTable{keyspace: "ks1", table: "table1"}, size: 5 * 1024},
+		}},
+		{host: Host{ShardCount: 2}, tablesToRestore: []scyllaTableWithSize{
+			{scyllaTable: scyllaTable{keyspace: "ks2", table: "table1"}, size: 5 * 1024},
+		}},
 	})
+
+	if stats.totalBytesToRestore != 10*1024 {
+		t.Fatalf("Expected totalBytesToRestore 10*1024, but got %d", stats.totalBytesToRestore)
+	}
 
 	var (
 		wg              sync.WaitGroup
@@ -71,10 +164,10 @@ func TestIncrementDownloadStats(t *testing.T) {
 	if stats.totalShards != 4 {
 		t.Fatalf("Expected totalShards 4, but got %d", stats.totalShards)
 	}
-	if stats.totalDownloadBytes != int64(numberOfWorkers*bytesPerWorker) {
-		t.Fatalf("Expected totalDownloadBytes %d, but got %d", int64(numberOfWorkers*bytesPerWorker), stats.totalDownloadBytes)
+	if stats.totalDownloadBytes.Load() != int64(numberOfWorkers*bytesPerWorker) {
+		t.Fatalf("Expected totalDownloadBytes %d, but got %d", int64(numberOfWorkers*bytesPerWorker), stats.totalDownloadBytes.Load())
 	}
-	if stats.totalDownloadTimeMS != int64(numberOfWorkers*timePerWorker) {
-		t.Fatalf("Expected totalDownloadTimeMS %d, but got %d", int64(numberOfWorkers*timePerWorker), stats.totalDownloadTimeMS)
+	if stats.totalDownloadTimeMS.Load() != int64(numberOfWorkers*timePerWorker) {
+		t.Fatalf("Expected totalDownloadTimeMS %d, but got %d", int64(numberOfWorkers*timePerWorker), stats.totalDownloadTimeMS.Load())
 	}
 }

--- a/pkg/service/one2onerestore/worker_tables.go
+++ b/pkg/service/one2onerestore/worker_tables.go
@@ -186,6 +186,7 @@ func (w *worker) waitJob(ctx context.Context, jobID int64, m *backupspec.Manifes
 			)
 			stats.incrementDownloadStats(job.Uploaded, took.Milliseconds())
 			w.metrics.SetOne2OneRestoreState(w.runInfo.ClusterID, m.Location, m.SnapshotTag, h.Addr, downloadWorkerName, metrics.One2OneRestoreStateIdle)
+			w.metrics.SetProgress(w.runInfo.ClusterID, m.SnapshotTag, stats.progress())
 			return nil
 		case scyllaclient.JobRunning:
 			continue

--- a/pkg/service/one2onerestore/worker_tables.go
+++ b/pkg/service/one2onerestore/worker_tables.go
@@ -189,6 +189,9 @@ func (w *worker) waitJob(ctx context.Context, jobID int64, m *backupspec.Manifes
 			w.metrics.SetProgress(w.runInfo.ClusterID, m.SnapshotTag, stats.progress())
 			return nil
 		case scyllaclient.JobRunning:
+			took := timeutc.Since(time.Time(job.StartedAt))
+			stats.incrementDownloadStats(job.Uploaded, took.Milliseconds())
+			w.metrics.SetProgress(w.runInfo.ClusterID, m.SnapshotTag, stats.progress())
 			continue
 		case scyllaclient.JobNotFound:
 			return errors.New("job not found")


### PR DESCRIPTION
This adds one2onerestore_progress metric that will show percent of downloaded bytes from 0 to 100%.
Considering that loadSSTables calls should be quick and the most amount of time 1-1-restore will spend downloading files from s3 it's fair to say that this metric indicates global 1-1-restore process progress. 

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
