### PR TITLE
fix(1-1-restore): fix how restore duration is rendered

### DIFF
--- a/v3/pkg/managerclient/model.go
+++ b/v3/pkg/managerclient/model.go
@@ -1464,7 +1464,7 @@ func (p One2OneRestoreProgress) RenderDetailedTableProgress() string {
 		"Status",
 	)
 	for _, table := range p.Progress.Tables {
-		startedAt, completedAt := strfmt.NewDateTime(), strfmt.NewDateTime()
+		startedAt, completedAt := strfmt.DateTime{}, strfmt.DateTime{}
 		if table.StartedAt != nil {
 			startedAt = *table.StartedAt
 		}
@@ -1493,7 +1493,7 @@ func (p One2OneRestoreProgress) RenderDetailedViewProgress() string {
 		"Status",
 	)
 	for _, view := range p.Progress.Views {
-		startedAt, completedAt := strfmt.NewDateTime(), strfmt.NewDateTime()
+		startedAt, completedAt := strfmt.DateTime{}, strfmt.DateTime{}
 		if view.StartedAt != nil {
 			startedAt = *view.StartedAt
 		}


### PR DESCRIPTION
This fixes how restore duration is rendered. The issue was that managerclient.FormatDuration checks if input date is zero then uses current time, but strfmt.NewDateTime() returns unix epoch (not zero), so FormatDuration returns negative result.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
