### PR TITLE
fix(1-1-restore): fix 1-1-restore progress aggregation

### DIFF
--- a/pkg/service/one2onerestore/model.go
+++ b/pkg/service/one2onerestore/model.go
@@ -262,7 +262,7 @@ type ViewProgress struct {
 	Keyspace string `json:"keyspace"`
 	Table    string `json:"table"`
 	View     string `json:"view"`
-	ViewType string `json:"type"`
+	ViewType string `json:"view_type"`
 }
 
 // progress describes general properties of Table or View progress.

--- a/pkg/service/one2onerestore/progress.go
+++ b/pkg/service/one2onerestore/progress.go
@@ -236,7 +236,7 @@ func (w *worker) aggregateProgress(tableIter, viewIter dbIterator) Progress {
 	}
 
 	for viewIter.StructScan(&rvp) {
-		viewKey := scyllaTable{keyspace: rvp.Keyspace, table: rvp.Table}
+		viewKey := scyllaTable{keyspace: rvp.Keyspace, table: rvp.View}
 		vp := viewProgress[viewKey]
 		vp.progress = incrementProgress(vp.progress, progress{
 			StartedAt:   rvp.StartedAt,

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Only_views_progress.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Only_views_progress.golden.json
@@ -10,7 +10,7 @@
       "keyspace": "ks1",
       "table": "t1",
       "view": "v1",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
     },
     {
       "started_at": "2025-01-01T12:01:03Z",
@@ -21,7 +21,7 @@
       "keyspace": "ks1",
       "table": "t2",
       "view": "v2",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
     }
   ]
 }

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Tables_and_views_progress,_status_done.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Tables_and_views_progress,_status_done.golden.json
@@ -21,17 +21,6 @@
   ],
   "views": [
     {
-      "started_at": "2025-01-01T12:01:03Z",
-      "completed_at": "2025-01-01T12:00:04Z",
-      "size": 0,
-      "restored": 0,
-      "status": "done",
-      "keyspace": "ks1",
-      "table": "t2",
-      "view": "v2",
-      "type": "MaterializedView"
-    },
-    {
       "started_at": "2025-01-01T12:00:01Z",
       "completed_at": "2025-01-01T12:00:03Z",
       "size": 0,
@@ -40,7 +29,18 @@
       "keyspace": "ks1",
       "table": "t1",
       "view": "v1",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
+    },
+    {
+      "started_at": "2025-01-01T12:01:03Z",
+      "completed_at": "2025-01-01T12:00:04Z",
+      "size": 0,
+      "restored": 0,
+      "status": "done",
+      "keyspace": "ks1",
+      "table": "t2",
+      "view": "v2",
+      "view_type": "MaterializedView"
     }
   ]
 }

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Tables_and_views_progress,_status_failed.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Tables_and_views_progress,_status_failed.golden.json
@@ -29,7 +29,7 @@
       "keyspace": "ks1",
       "table": "t1",
       "view": "v1",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
     },
     {
       "started_at": "2025-01-01T12:01:03Z",
@@ -40,7 +40,7 @@
       "keyspace": "ks1",
       "table": "t2",
       "view": "v2",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
     }
   ]
 }

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Tables_and_views_progress,_status_in_progress.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Tables_and_views_progress,_status_in_progress.golden.json
@@ -29,7 +29,7 @@
       "keyspace": "ks1",
       "table": "t1",
       "view": "v1",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
     },
     {
       "started_at": "2025-01-01T12:01:03Z",
@@ -40,7 +40,7 @@
       "keyspace": "ks1",
       "table": "t2",
       "view": "v2",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
     }
   ]
 }

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Tables_and_views_progress,_status_mixed.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Tables_and_views_progress,_status_mixed.golden.json
@@ -29,7 +29,7 @@
       "keyspace": "ks1",
       "table": "t1",
       "view": "v1",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
     },
     {
       "started_at": "2025-01-01T12:01:03Z",
@@ -40,7 +40,7 @@
       "keyspace": "ks1",
       "table": "t2",
       "view": "v2",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
     }
   ]
 }

--- a/pkg/service/one2onerestore/testdata/AggregateProgress/Tables_and_views_progress,_status_not_started.golden.json
+++ b/pkg/service/one2onerestore/testdata/AggregateProgress/Tables_and_views_progress,_status_not_started.golden.json
@@ -29,7 +29,7 @@
       "keyspace": "ks1",
       "table": "t1",
       "view": "v1",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
     },
     {
       "started_at": null,
@@ -40,7 +40,7 @@
       "keyspace": "ks1",
       "table": "t2",
       "view": "v2",
-      "type": "MaterializedView"
+      "view_type": "MaterializedView"
     }
   ]
 }


### PR DESCRIPTION
This fixes several small issues in 1-1-restore progress aggregation:
1. Uniqueness of views was checked by keyspace + table name
2. Progress model had the wrong json tag for ViewType

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
