### PR TITLE
Repair: don't long poll tablet repair task status

### DIFF
--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -1341,7 +1341,8 @@ func scyllaWaitTaskShouldRetryHandler(err error) *bool {
 	return nil
 }
 
-// ScyllaWaitTask long polls Scylla task status.
+// ScyllaWaitTask waits for Scylla task to finish and returns its status.
+// If longPollingSeconds is greater than 0, it will long poll instead of waiting for the task to finish.
 func (c *Client) ScyllaWaitTask(ctx context.Context, host, id string, longPollingSeconds int64) (*models.TaskStatus, error) {
 	ctx = withShouldRetryHandler(ctx, scyllaWaitTaskShouldRetryHandler)
 	ctx = forceHost(ctx, host)


### PR DESCRIPTION
Tablet repair task status is always immediately removed from Scylla after the task finishes. This means that we can't long poll it, because the task might finish in between long polling calls.

Fixes #4434
Fixes #4433
