### PR TITLE
Set backup method in CI

### DIFF
--- a/.github/cfg/integration-test-cfg.yaml
+++ b/.github/cfg/integration-test-cfg.yaml
@@ -39,9 +39,11 @@
   raft-schema: none
   tablets: disabled
   ssl-enabled: true
+  backup-method: native
 
 - scylla-version: scylla-nightly:latest
   ip-family: IPV6
   raft-schema: none
   tablets: enabled
   ssl-enabled: false
+  backup-method: rclone

--- a/.github/cfg/integration-test-core.yaml
+++ b/.github/cfg/integration-test-core.yaml
@@ -30,7 +30,7 @@ jobs:
           ssl-enabled: ${{ env.ssl-enabled }}
 
       - name: Run tests
-        run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
+        run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
 
   restore-schema:
     name: Test restore schema
@@ -50,7 +50,7 @@ jobs:
         # Go does not support negative lookahead in regex expressions, so it has to be done manually.
         # This regex ensures that all restore tests that didn't match restore-tables job will be run here.
       - name: Run tests
-        run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+        run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
 
   backup:
     name: Test backup
@@ -69,7 +69,7 @@ jobs:
           ssl-enabled: ${{ env.ssl-enabled }}
 
       - name: Run tests
-        run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/backup
+        run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/backup
 
   repair:
     name: Test repair

--- a/.github/cfg/main.go
+++ b/.github/cfg/main.go
@@ -15,6 +15,7 @@ type integrationTestCfg struct {
 	RaftSchema    string `yaml:"raft-schema"`
 	Tablets       string `yaml:"tablets"`
 	SSLEnabled    string `yaml:"ssl-enabled,omitempty"`
+	BackupMethod  string `yaml:"backup-method,omitempty"`
 }
 
 func (cfg integrationTestCfg) name() string {
@@ -32,7 +33,9 @@ func (cfg integrationTestCfg) name() string {
 	}
 	if cfg.SSLEnabled == "false" {
 		parts = append(parts, "nossl")
-
+	}
+	if cfg.BackupMethod != "" {
+		parts = append(parts, cfg.BackupMethod)
 	}
 	return strings.Join(parts, "-")
 }

--- a/.github/workflows/integration-tests-2024.1.15-IPV4.yaml
+++ b/.github/workflows/integration-tests-2024.1.15-IPV4.yaml
@@ -23,7 +23,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/backup
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/backup
     repair:
         name: Test repair
         runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
     restore-tables:
         name: Test restore tables
         runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
     small-pkg:
         name: Test other, smaller packages
         runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests-2024.1.15-IPV6-raftschema-nossl.yaml
+++ b/.github/workflows/integration-tests-2024.1.15-IPV6-raftschema-nossl.yaml
@@ -23,7 +23,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/backup
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/backup
     repair:
         name: Test repair
         runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
     restore-tables:
         name: Test restore tables
         runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
     small-pkg:
         name: Test other, smaller packages
         runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests-2024.2.7-IPV4-nossl.yaml
+++ b/.github/workflows/integration-tests-2024.2.7-IPV4-nossl.yaml
@@ -23,7 +23,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/backup
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/backup
     repair:
         name: Test repair
         runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
     restore-tables:
         name: Test restore tables
         runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
     small-pkg:
         name: Test other, smaller packages
         runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests-2024.2.7-IPV6.yaml
+++ b/.github/workflows/integration-tests-2024.2.7-IPV6.yaml
@@ -23,7 +23,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/backup
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/backup
     repair:
         name: Test repair
         runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
     restore-tables:
         name: Test restore tables
         runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
     small-pkg:
         name: Test other, smaller packages
         runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests-2025.1.0-IPV4.yaml
+++ b/.github/workflows/integration-tests-2025.1.0-IPV4.yaml
@@ -23,7 +23,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/backup
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/backup
     repair:
         name: Test repair
         runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
     restore-tables:
         name: Test restore tables
         runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
     small-pkg:
         name: Test other, smaller packages
         runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests-2025.1.0-IPV6-tablets-nossl.yaml
+++ b/.github/workflows/integration-tests-2025.1.0-IPV6-tablets-nossl.yaml
@@ -23,7 +23,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/backup
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/backup
     repair:
         name: Test repair
         runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
     restore-tables:
         name: Test restore tables
         runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
     small-pkg:
         name: Test other, smaller packages
         runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests-latest-IPV4-native.yaml
+++ b/.github/workflows/integration-tests-latest-IPV4-native.yaml
@@ -7,6 +7,7 @@ env:
     raft-schema: none
     tablets: disabled
     ssl-enabled: "true"
+    backup-method: native
 jobs:
     backup:
         name: Test backup
@@ -23,7 +24,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/backup
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/backup
     repair:
         name: Test repair
         runs-on: ubuntu-latest
@@ -55,7 +56,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
     restore-tables:
         name: Test restore tables
         runs-on: ubuntu-latest
@@ -71,7 +72,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
     small-pkg:
         name: Test other, smaller packages
         runs-on: ubuntu-latest
@@ -106,7 +107,7 @@ jobs:
               run: make pkg-integration-test PKG=./pkg/store
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
-name: integration-tests-latest-IPV4
+name: integration-tests-latest-IPV4-native
 "on":
     pull_request:
         types:

--- a/.github/workflows/integration-tests-latest-IPV6-tablets-nossl-rclone.yaml
+++ b/.github/workflows/integration-tests-latest-IPV6-tablets-nossl-rclone.yaml
@@ -7,6 +7,7 @@ env:
     raft-schema: none
     tablets: enabled
     ssl-enabled: "false"
+    backup-method: rclone
 jobs:
     backup:
         name: Test backup
@@ -23,7 +24,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/backup
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/backup
     repair:
         name: Test repair
         runs-on: ubuntu-latest
@@ -55,7 +56,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestore([^T]|.{1}[^a]|.{2}[^b]|.{3}[^l]|.{4}[^e]|.{5}[^s]).*Integration"'
     restore-tables:
         name: Test restore tables
         runs-on: ubuntu-latest
@@ -71,7 +72,7 @@ jobs:
                 ssl-enabled: ${{ env.ssl-enabled }}
                 tablets: ${{ env.tablets }}
             - name: Run tests
-              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
+              run: make pkg-integration-test IP_FAMILY=${{ env.ip-family }} SSL_ENABLED=${{ env.ssl-enabled}} BACKUP_METHOD=${{ env.backup-method }} PKG=./pkg/service/restore RUN='"TestRestoreTables.*Integration"'
     small-pkg:
         name: Test other, smaller packages
         runs-on: ubuntu-latest
@@ -106,7 +107,7 @@ jobs:
               run: make pkg-integration-test PKG=./pkg/store
             - name: Run migrate tests
               run: make pkg-integration-test PKG=./pkg/schema/migrate
-name: integration-tests-latest-IPV6-tablets-nossl
+name: integration-tests-latest-IPV6-tablets-nossl-rclone
 "on":
     pull_request:
         types:

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,10 @@ INTEGRATION_TEST_ARGS := -cluster $(PUBLIC_NET)100 \
 -agent-auth-token token \
 -s3-data-dir ./testing/minio/data -s3-provider Minio -s3-endpoint $(MINIO_ENDPOINT) -s3-access-key-id $(MINIO_USER_ACCESS_KEY) -s3-secret-access-key $(MINIO_USER_SECRET_KEY)
 
+ifdef BACKUP_METHOD
+INTEGRATION_TEST_ARGS += -backup-method $(BACKUP_METHOD)
+endif
+
 SSL_FLAGS := -ssl-ca-file ./testing/$(SSL_AUTHORITY_CRT) -ssl-key-file ./testing/$(SSL_CLIENT_KEY) -ssl-cert-file ./testing/$(SSL_CLIENT_CRT) -gocql.port $(SSL_PORT)
 
 CURRENT_UID = $(shell id -u)

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Scylla Manager consists of tree components:
 
 ## Scylla integration status
 
-| ScyllaDB version | Workflows                                                                                    | Limitations                                                                                                                                           |
-|------------------|----------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **2024.1.15**    | ![integration-tests-2024.1.15-IPV4]<br/>![integration-tests-2024.1.15-IPV6-raftschema-nossl] | Restoration of schema into cluster with `consistant_cluster_management: true` is not supported                                                        |
-| **2024.2.7**     | ![integration-tests-2024.2.7-IPV4-nossl]<br/>![integration-tests-2024.2.7-IPV6]              | Restoration of **Authentication** and **Service Levels** is not supported<br/>Restoration of schema containing **Alternator** tables is not supported |
-| **2025.1.0**     | ![integration-tests-2025.1.0-IPV4]<br/>![integration-tests-2025.1.0-IPV6-tablets-nossl]      | Restoration of **Authentication** and **Service Levels** is not supported<br/>Restoration of schema containing **Alternator** tables is not supported |
-| **latest**       | ![integration-tests-latest-IPV4]<br/>![integration-tests-latest-IPV6-tablets-nossl]          | Restoration of **Authentication** and **Service Levels** is not supported<br/>Restoration of schema containing **Alternator** tables is not supported |
+| ScyllaDB version | Workflows                                                                                         | Limitations                                                                                                                                           |
+|------------------|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **2024.1.15**    | ![integration-tests-2024.1.15-IPV4]<br/>![integration-tests-2024.1.15-IPV6-raftschema-nossl]      | Restoration of schema into cluster with `consistant_cluster_management: true` is not supported                                                        |
+| **2024.2.7**     | ![integration-tests-2024.2.7-IPV4-nossl]<br/>![integration-tests-2024.2.7-IPV6]                   | Restoration of **Authentication** and **Service Levels** is not supported<br/>Restoration of schema containing **Alternator** tables is not supported |
+| **2025.1.0**     | ![integration-tests-2025.1.0-IPV4]<br/>![integration-tests-2025.1.0-IPV6-tablets-nossl]           | Restoration of **Authentication** and **Service Levels** is not supported<br/>Restoration of schema containing **Alternator** tables is not supported |
+| **latest**       | ![integration-tests-latest-IPV4-native]<br/>![integration-tests-latest-IPV6-tablets-nossl-rclone] | Restoration of **Authentication** and **Service Levels** is not supported<br/>Restoration of schema containing **Alternator** tables is not supported |
 
 [integration-tests-2024.1.15-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2024.1.15-IPV4.yaml/badge.svg?branch=master
 [integration-tests-2024.1.15-IPV6-raftschema-nossl]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2024.1.15-IPV6-raftschema-nossl.yaml/badge.svg?branch=master
@@ -28,8 +28,8 @@ Scylla Manager consists of tree components:
 [integration-tests-2024.2.7-IPV6]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2024.2.7-IPV6.yaml/badge.svg?branch=master
 [integration-tests-2025.1.0-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2025.1.0-IPV4.yaml/badge.svg?branch=master
 [integration-tests-2025.1.0-IPV6-tablets-nossl]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2025.1.0-IPV6-tablets-nossl.yaml/badge.svg?branch=master
-[integration-tests-latest-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-latest-IPV4.yaml/badge.svg?branch=master
-[integration-tests-latest-IPV6-tablets-nossl]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-latest-IPV6-tablets-nossl.yaml/badge.svg?branch=master
+[integration-tests-latest-IPV4-native]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-latest-IPV4-native.yaml/badge.svg?branch=master
+[integration-tests-latest-IPV6-tablets-nossl-rclone]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-latest-IPV6-tablets-nossl-rclone.yaml/badge.svg?branch=master
 
 ## Installing and updating Go
 

--- a/pkg/service/backup/model.go
+++ b/pkg/service/backup/model.go
@@ -58,7 +58,7 @@ type Target struct {
 	Continue         bool                  `json:"continue,omitempty"`
 	PurgeOnly        bool                  `json:"purge_only,omitempty"`
 	SkipSchema       bool                  `json:"skip_schema,omitempty"`
-	Method           method                `json:"method,omitempty"`
+	Method           Method                `json:"method,omitempty"`
 
 	// LiveNodes caches node status for GetTarget GetTargetSize calls.
 	liveNodes scyllaclient.NodeStatusInfoSlice `json:"-"`
@@ -95,16 +95,16 @@ func (u *Unit) UnmarshalUDT(name string, info gocql.TypeInfo, data []byte) error
 // This happens when working with runs coming from versions prior to adding stage.
 const stageNone Stage = ""
 
-// method describes which API should be used by SM during backup.
-type method string
+// Method describes which API should be used by SM during backup.
+type Method string
 
 const (
-	// methodAuto means that SM will use native backup API when possible, and rclone API otherwise.
-	methodAuto method = "auto"
-	// methodRclone means that SM will only use rclone API.
-	methodRclone method = "rclone"
-	// methodNative means that SM will only use native scylla backup API (whether it's configured or not).
-	methodNative method = "native"
+	// MethodAuto means that SM will use native backup API when possible, and rclone API otherwise.
+	MethodAuto Method = "auto"
+	// MethodRclone means that SM will only use rclone API.
+	MethodRclone Method = "rclone"
+	// MethodNative means that SM will only use native scylla backup API (whether it's configured or not).
+	MethodNative Method = "native"
 )
 
 // Run tracks backup progress, shares ID with scheduler.Run that initiated it.
@@ -231,7 +231,7 @@ type taskProperties struct {
 	Continue         bool                  `json:"continue"`
 	PurgeOnly        bool                  `json:"purge_only"`
 	SkipSchema       bool                  `json:"skip_schema"`
-	Method           method                `json:"method,omitempty"`
+	Method           Method                `json:"method,omitempty"`
 }
 
 func (p taskProperties) validate(dcs []string, dcMap map[string][]string) error {
@@ -245,8 +245,8 @@ func (p taskProperties) validate(dcs []string, dcMap map[string][]string) error 
 		return errors.New("transfers param has to be equal to -1 (set transfers to the value from scylla-manager-agent.yaml config) " +
 			"or greater than zero")
 	}
-	if !slices.Contains([]method{methodAuto, methodRclone, methodNative}, p.Method) {
-		return errors.New("unknown method: " + string(p.Method))
+	if !slices.Contains([]Method{MethodAuto, MethodRclone, MethodNative}, p.Method) {
+		return errors.New("unknown Method: " + string(p.Method))
 	}
 
 	// Validate location DCs
@@ -404,7 +404,7 @@ func (p taskProperties) extractRetention() RetentionPolicy {
 func defaultTaskProperties() taskProperties {
 	return taskProperties{
 		Transfers: scyllaclient.TransfersFromConfig,
-		Method:    methodAuto,
+		Method:    MethodAuto,
 		Continue:  true,
 	}
 }

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -167,7 +167,7 @@ func (s *Service) targetFromProperties(ctx context.Context, clusterID uuid.UUID,
 		return Target{}, errors.Wrap(err, "location is not accessible")
 	}
 
-	if p.Method == methodNative {
+	if p.Method == MethodNative {
 		if err := s.validateHostNativeBackupSupport(clusterID, liveNodes, p); err != nil {
 			return Target{}, err
 		}

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -2624,7 +2624,7 @@ func TestBackupMethodIntegration(t *testing.T) {
 	}
 
 	type testCase struct {
-		method           string
+		method           backup.Method
 		blockedPath      string
 		ensuredPath      string
 		getTargetSuccess bool
@@ -2635,21 +2635,21 @@ func TestBackupMethodIntegration(t *testing.T) {
 	switch {
 	case support && !IsIPV6Network():
 		testCases = []testCase{
-			{method: "auto", ensuredPath: nativeAPIPath, blockedPath: rcloneAPIPath, getTargetSuccess: true},
-			{method: "native", ensuredPath: nativeAPIPath, blockedPath: rcloneAPIPath, getTargetSuccess: true},
-			{method: "rclone", ensuredPath: rcloneAPIPath, blockedPath: nativeAPIPath, getTargetSuccess: true},
+			{method: backup.MethodAuto, ensuredPath: nativeAPIPath, blockedPath: rcloneAPIPath, getTargetSuccess: true},
+			{method: backup.MethodNative, ensuredPath: nativeAPIPath, blockedPath: rcloneAPIPath, getTargetSuccess: true},
+			{method: backup.MethodRclone, ensuredPath: rcloneAPIPath, blockedPath: nativeAPIPath, getTargetSuccess: true},
 		}
 	case support && IsIPV6Network():
 		testCases = []testCase{
-			{method: "auto", ensuredPath: rcloneAPIPath, blockedPath: nativeAPIPath, getTargetSuccess: true},
-			{method: "native", getTargetSuccess: false},
-			{method: "rclone", ensuredPath: rcloneAPIPath, blockedPath: nativeAPIPath, getTargetSuccess: true},
+			{method: backup.MethodAuto, ensuredPath: rcloneAPIPath, blockedPath: nativeAPIPath, getTargetSuccess: true},
+			{method: backup.MethodNative, getTargetSuccess: false},
+			{method: backup.MethodRclone, ensuredPath: rcloneAPIPath, blockedPath: nativeAPIPath, getTargetSuccess: true},
 		}
 	default:
 		testCases = []testCase{
-			{method: "auto", ensuredPath: rcloneAPIPath, blockedPath: nativeAPIPath, getTargetSuccess: true},
-			{method: "native", getTargetSuccess: false},
-			{method: "rclone", ensuredPath: rcloneAPIPath, blockedPath: nativeAPIPath, getTargetSuccess: true},
+			{method: backup.MethodAuto, ensuredPath: rcloneAPIPath, blockedPath: nativeAPIPath, getTargetSuccess: true},
+			{method: backup.MethodNative, getTargetSuccess: false},
+			{method: backup.MethodRclone, ensuredPath: rcloneAPIPath, blockedPath: nativeAPIPath, getTargetSuccess: true},
 		}
 	}
 

--- a/pkg/service/backup/worker.go
+++ b/pkg/service/backup/worker.go
@@ -62,7 +62,7 @@ type workerTools struct {
 	TaskID      uuid.UUID
 	RunID       uuid.UUID
 	SnapshotTag string
-	Method      method
+	Method      Method
 	Config      Config
 	Client      *scyllaclient.Client
 	Logger      log.Logger

--- a/pkg/service/backup/worker_upload.go
+++ b/pkg/service/backup/worker_upload.go
@@ -53,19 +53,19 @@ func (w *worker) uploadHost(ctx context.Context, h hostInfo) error {
 func (w *worker) hostSnapshotDirsByMethod(ctx context.Context, h hostInfo) (rclone, native []snapshotDir, err error) {
 	dirs := w.hostSnapshotDirs(h)
 
-	if w.Method == methodRclone {
+	if w.Method == MethodRclone {
 		return dirs, nil, nil
 	}
 
 	// Handle lack of native backup support on the host level
 	if err := w.hostNativeBackupSupport(ctx, h.IP, h.NodeConfig.NodeInfo, h.Location); err != nil {
-		if w.Method == methodNative {
+		if w.Method == MethodNative {
 			return nil, nil, err
 		}
 		return dirs, nil, nil
 	}
 
-	if w.Method == methodNative {
+	if w.Method == MethodNative {
 		for _, d := range dirs {
 			if err := w.snapshotDirNativeBackupSupport(ctx, h.IP, d); err != nil {
 				return nil, nil, errors.Wrapf(err, "%s.%s: ensure native backup support", d.Keyspace, d.Table)
@@ -74,7 +74,7 @@ func (w *worker) hostSnapshotDirsByMethod(ctx context.Context, h hostInfo) (rclo
 		return nil, dirs, nil
 	}
 
-	if w.Method == methodAuto {
+	if w.Method == MethodAuto {
 		for _, d := range dirs {
 			if err := w.snapshotDirNativeBackupSupport(ctx, h.IP, d); err != nil {
 				rclone = append(rclone, d)

--- a/pkg/service/restore/helper_integration_test.go
+++ b/pkg/service/restore/helper_integration_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/gocqlx/v2/qb"
+	"github.com/scylladb/scylla-manager/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
@@ -183,6 +185,19 @@ func newRestoreSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient
 	}
 
 	return svc
+}
+
+func defaultTestBackupProperties(loc backupspec.Location, ks string) map[string]any {
+	properties := map[string]any{
+		"location": []backupspec.Location{loc},
+	}
+	if ks != "" {
+		properties["keyspace"] = []string{ks}
+	}
+	if testconfig.BackupMethod() != nil && *testconfig.BackupMethod() != "" {
+		properties["method"] = *testconfig.BackupMethod()
+	}
+	return properties
 }
 
 func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {

--- a/pkg/testutils/testconfig/testconfig.go
+++ b/pkg/testutils/testconfig/testconfig.go
@@ -27,6 +27,7 @@ var (
 	flagUserCertFile = flag.String("ssl-cert-file", "", "User SSL certificate file")
 	flagUserKeyFile  = flag.String("ssl-key-file", "", "User SSL key file")
 	flagValidate     = flag.Bool("ssl-validate", false, "Enable host verification")
+	flagBackupMethod = flag.String("backup-method", "", "Default backup --method to use")
 
 	flagManagedCluster       = flag.String("managed-cluster", "127.0.0.1", "a comma-separated list of host:port tuples of data cluster hosts")
 	flagManagedSecondCluster = flag.String("managed-second-cluster", "127.0.0.1", "a comma-separated list of host:port tuples of data second cluster hosts")
@@ -204,4 +205,13 @@ func TLSConfig(sslOpts *gocql.SslOptions) (*tls.Config, error) {
 	}
 
 	return tlsConfig, nil
+}
+
+// BackupMethod returns default backup --method to use.
+// Returns nil if not set.
+func BackupMethod() *string {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	return flagBackupMethod
 }


### PR DESCRIPTION
This PR adds `-backup-method` to test flags and uses it in backup and restore integration tests to choose the default backup `--method`. This allows us to test both native and rclone backups without relying on the native backup incompatibility with IPV6 env and the default `--method=auto`.

Refs #4437
Fixes #4393