### PR TITLE
[1-1-restore] Next batch of commits to master (4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/scylladb/scylla-manager/backupspec v1.0.2
 	github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250626145254-64b5a3b94aaf
 	github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250530081649-30bcf253e6a6
-	github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250625104743-5452b87d6aab
+	github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250630112249-bb1265859a3e
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stoewer/go-strcase v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1076,6 +1076,8 @@ github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250603122541-18564a0413d8
 github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250603122541-18564a0413d8/go.mod h1:nCN5P0jiWL0W7jbcZ9p0ndtZAPoyEWXefddx/nbyFes=
 github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250625104743-5452b87d6aab h1:sbxovkPAEP4BDnAF5Kgy7Ib2ytgXzsgiH5kiUrEQ8A0=
 github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250625104743-5452b87d6aab/go.mod h1:nCN5P0jiWL0W7jbcZ9p0ndtZAPoyEWXefddx/nbyFes=
+github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250630112249-bb1265859a3e h1:RgI5Il/WRcXtI9E8WhgoxdSO5OwaZoF9orabIeprbh4=
+github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250630112249-bb1265859a3e/go.mod h1:nCN5P0jiWL0W7jbcZ9p0ndtZAPoyEWXefddx/nbyFes=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4 h1:8qmTC5ByIXO3GP/IzBkxcZ/99VITvnIETDhdFz/om7A=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=

--- a/pkg/service/one2onerestore/worker_tables.go
+++ b/pkg/service/one2onerestore/worker_tables.go
@@ -123,7 +123,7 @@ func (w *worker) refreshNodeWorker(ctx context.Context, hostTask hostWorkload, q
 func (w *worker) refreshNode(ctx context.Context, table backupspec.FilesMeta, m *backupspec.ManifestInfo, h Host, pr *RunTableProgress) error {
 	start := timeutc.Now()
 	w.metrics.SetOne2OneRestoreState(w.runInfo.ClusterID, m.Location, m.SnapshotTag, h.Addr, refreshWorkerName, metrics.One2OneRestoreStateLoading)
-	err := w.client.AwaitLoadSSTables(ctx, h.Addr, table.Keyspace, table.Table, false, false)
+	err := w.client.AwaitLoadSSTables(ctx, h.Addr, table.Keyspace, table.Table, false, false, true, true)
 	w.finishRestoreTableProgress(ctx, pr, err)
 	if err == nil {
 		w.logger.Info(ctx, "Refresh node done",

--- a/pkg/service/restore/schema_worker.go
+++ b/pkg/service/restore/schema_worker.go
@@ -109,7 +109,7 @@ func (w *schemaWorker) stageRestoreData(ctx context.Context) error {
 		host := status[i]
 		for _, ks := range w.run.Units {
 			for _, t := range ks.Tables {
-				if err := w.client.AwaitLoadSSTables(ctx, host.Addr, ks.Keyspace, t.Table, false, false); err != nil {
+				if err := w.client.AwaitLoadSSTables(ctx, host.Addr, ks.Keyspace, t.Table, false, false, false, false); err != nil {
 					return errors.Wrap(err, "restore schema")
 				}
 			}

--- a/pkg/service/restore/tablesdir_worker.go
+++ b/pkg/service/restore/tablesdir_worker.go
@@ -81,7 +81,7 @@ func (w *tablesWorker) waitJob(ctx context.Context, b batch, pr *RunProgress) (e
 
 func (w *tablesWorker) restoreSSTables(ctx context.Context, b batch, pr *RunProgress) error {
 	w.onLasStart(ctx, b, pr)
-	err := w.worker.client.AwaitLoadSSTables(ctx, pr.Host, pr.Keyspace, pr.Table, true, true)
+	err := w.worker.client.AwaitLoadSSTables(ctx, pr.Host, pr.Keyspace, pr.Table, true, true, false, false)
 	if err == nil {
 		w.onLasEnd(ctx, b, pr)
 	}

--- a/v3/pkg/managerclient/client.go
+++ b/v3/pkg/managerclient/client.go
@@ -701,3 +701,21 @@ func (c *Client) Resume(ctx context.Context, clusterID string, startTasks bool) 
 	_, err := c.operations.PutClusterClusterIDSuspended(p) // nolint: errcheck
 	return err
 }
+
+// SuspendDetails returns details about the cluster suspend state.
+func (c *Client) SuspendDetails(ctx context.Context, clusterID string) (ClusterSuspendDetails, error) {
+	p := &operations.GetClusterClusterIDSuspendedDetailsParams{
+		Context:   ctx,
+		ClusterID: clusterID,
+	}
+
+	resp, err := c.operations.GetClusterClusterIDSuspendedDetails(p)
+	if err != nil {
+		return ClusterSuspendDetails{}, err
+	}
+
+	return ClusterSuspendDetails{
+		SuspendDetails: resp.Payload,
+		ClusterID:      clusterID,
+	}, nil
+}

--- a/v3/pkg/managerclient/model.go
+++ b/v3/pkg/managerclient/model.go
@@ -1601,3 +1601,24 @@ func formatLabels(labels map[string]string) string {
 	}
 	return strings.Join(out, ", ")
 }
+
+// ClusterSuspendDetails renders cluster suspend details.
+type ClusterSuspendDetails struct {
+	*models.SuspendDetails
+
+	ClusterID string
+}
+
+// Render implements Renderer interface.
+func (csd ClusterSuspendDetails) Render(w io.Writer) error {
+	t := table.New("Cluster ID", "Suspended", "Allowed Task")
+	t.AddRow(
+		csd.ClusterID,
+		csd.Suspended,
+		csd.AllowTaskType,
+	)
+	if _, err := w.Write([]byte(t.String())); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/client/operations/storage_service_sstables_by_keyspace_post_parameters.go
+++ b/vendor/github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/client/operations/storage_service_sstables_by_keyspace_post_parameters.go
@@ -91,12 +91,12 @@ type StorageServiceSstablesByKeyspacePostParams struct {
 	  Don't cleanup keys from loaded sstables. Invalid if load_and_stream is true
 
 	*/
-	SkipCleanup *string
+	SkipCleanup *bool
 	/*SkipReshape
 	  Don't reshape loaded sstables. Invalid if load_and_stream is true
 
 	*/
-	SkipReshape *string
+	SkipReshape *bool
 
 	timeout    time.Duration
 	Context    context.Context
@@ -192,24 +192,24 @@ func (o *StorageServiceSstablesByKeyspacePostParams) SetScope(scope *string) {
 }
 
 // WithSkipCleanup adds the skipCleanup to the storage service sstables by keyspace post params
-func (o *StorageServiceSstablesByKeyspacePostParams) WithSkipCleanup(skipCleanup *string) *StorageServiceSstablesByKeyspacePostParams {
+func (o *StorageServiceSstablesByKeyspacePostParams) WithSkipCleanup(skipCleanup *bool) *StorageServiceSstablesByKeyspacePostParams {
 	o.SetSkipCleanup(skipCleanup)
 	return o
 }
 
 // SetSkipCleanup adds the skipCleanup to the storage service sstables by keyspace post params
-func (o *StorageServiceSstablesByKeyspacePostParams) SetSkipCleanup(skipCleanup *string) {
+func (o *StorageServiceSstablesByKeyspacePostParams) SetSkipCleanup(skipCleanup *bool) {
 	o.SkipCleanup = skipCleanup
 }
 
 // WithSkipReshape adds the skipReshape to the storage service sstables by keyspace post params
-func (o *StorageServiceSstablesByKeyspacePostParams) WithSkipReshape(skipReshape *string) *StorageServiceSstablesByKeyspacePostParams {
+func (o *StorageServiceSstablesByKeyspacePostParams) WithSkipReshape(skipReshape *bool) *StorageServiceSstablesByKeyspacePostParams {
 	o.SetSkipReshape(skipReshape)
 	return o
 }
 
 // SetSkipReshape adds the skipReshape to the storage service sstables by keyspace post params
-func (o *StorageServiceSstablesByKeyspacePostParams) SetSkipReshape(skipReshape *string) {
+func (o *StorageServiceSstablesByKeyspacePostParams) SetSkipReshape(skipReshape *bool) {
 	o.SkipReshape = skipReshape
 }
 
@@ -286,11 +286,11 @@ func (o *StorageServiceSstablesByKeyspacePostParams) WriteToRequest(r runtime.Cl
 	if o.SkipCleanup != nil {
 
 		// query param skip_cleanup
-		var qrSkipCleanup string
+		var qrSkipCleanup bool
 		if o.SkipCleanup != nil {
 			qrSkipCleanup = *o.SkipCleanup
 		}
-		qSkipCleanup := qrSkipCleanup
+		qSkipCleanup := swag.FormatBool(qrSkipCleanup)
 		if qSkipCleanup != "" {
 			if err := r.SetQueryParam("skip_cleanup", qSkipCleanup); err != nil {
 				return err
@@ -302,11 +302,11 @@ func (o *StorageServiceSstablesByKeyspacePostParams) WriteToRequest(r runtime.Cl
 	if o.SkipReshape != nil {
 
 		// query param skip_reshape
-		var qrSkipReshape string
+		var qrSkipReshape bool
 		if o.SkipReshape != nil {
 			qrSkipReshape = *o.SkipReshape
 		}
-		qSkipReshape := qrSkipReshape
+		qSkipReshape := swag.FormatBool(qrSkipReshape)
 		if qSkipReshape != "" {
 			if err := r.SetQueryParam("skip_reshape", qSkipReshape); err != nil {
 				return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -441,7 +441,7 @@ github.com/scylladb/scylla-manager/v3/pkg/util/timeutc
 github.com/scylladb/scylla-manager/v3/pkg/util/uuid
 github.com/scylladb/scylla-manager/v3/pkg/util/version
 github.com/scylladb/scylla-manager/v3/pkg/util/workerpool
-# github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250625104743-5452b87d6aab
+# github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250630112249-bb1265859a3e
 ## explicit; go 1.23.2
 github.com/scylladb/scylla-manager/v3/swagger/gen/agent/client
 github.com/scylladb/scylla-manager/v3/swagger/gen/agent/client/operations


### PR DESCRIPTION
This adds following features/commits from the 1-1-restore-feature-branch to master:
* updates main module to use the laster swagger module 
* expose and use skip_cleanup && skip_reshape parameters
* managerclient: render cluster suspend details


There will be one more PR (final) with just two commits: 
* update main module with the latest managerclient module 
* sctool: render cluster suspend details


---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
