### PR TITLE
[1-1-restore] Final batch of commits to master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/scylladb/go-set v1.0.2
 	github.com/scylladb/gocqlx/v2 v2.8.0
 	github.com/scylladb/scylla-manager/backupspec v1.0.2
-	github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250626145254-64b5a3b94aaf
+	github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250630160519-24627a91850a
 	github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250530081649-30bcf253e6a6
 	github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250630112249-bb1265859a3e
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1070,6 +1070,8 @@ github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250625104256-6b
 github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250625104256-6b6c8bc7650b/go.mod h1:fyQQ05QGlWFRqpP2GVI1k56x/De+KeCUu2iPmxSZ0M0=
 github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250626145254-64b5a3b94aaf h1:D1OuJles7+GCvSiizTU+mlkL9llH+JXJ5EACpwscT0g=
 github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250626145254-64b5a3b94aaf/go.mod h1:RmtRlpZS+Ox8xI19NFPzPdDK1MlZoF+WDzPqceW7EQE=
+github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250630160519-24627a91850a h1:9TEBNt22TSt6s/UW3w27PuZl2nxFMr4TiFDfWmI6iC0=
+github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250630160519-24627a91850a/go.mod h1:RmtRlpZS+Ox8xI19NFPzPdDK1MlZoF+WDzPqceW7EQE=
 github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250530081649-30bcf253e6a6 h1:Tjt1RNnyWP+7Z32BUn2Q31gYrYCz2QszmNy6GnXhM2c=
 github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250530081649-30bcf253e6a6/go.mod h1:VKqHSrDj9zfgCKilpbdpmqV1TjmSglt/df79eIg6wuI=
 github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250603122541-18564a0413d8 h1:lH0C9dPw5rROvIWbS7f2X74loSugu0Xw3uarPGdXYU0=

--- a/pkg/command/status/cmd.go
+++ b/pkg/command/status/cmd.go
@@ -55,6 +55,15 @@ func (cmd *command) run() error {
 
 	w := cmd.OutOrStdout()
 	h := func(clusterID string) error {
+		suspendDetails, err := cmd.client.SuspendDetails(cmd.Context(), clusterID)
+		if err != nil {
+			return err
+		}
+		if suspendDetails.Suspended {
+			if err := suspendDetails.Render(w); err != nil {
+				return err
+			}
+		}
 		status, err := cmd.client.ClusterStatus(cmd.Context(), clusterID)
 		if err != nil {
 			return err

--- a/vendor/github.com/scylladb/scylla-manager/v3/pkg/managerclient/client.go
+++ b/vendor/github.com/scylladb/scylla-manager/v3/pkg/managerclient/client.go
@@ -701,3 +701,21 @@ func (c *Client) Resume(ctx context.Context, clusterID string, startTasks bool) 
 	_, err := c.operations.PutClusterClusterIDSuspended(p) // nolint: errcheck
 	return err
 }
+
+// SuspendDetails returns details about the cluster suspend state.
+func (c *Client) SuspendDetails(ctx context.Context, clusterID string) (ClusterSuspendDetails, error) {
+	p := &operations.GetClusterClusterIDSuspendedDetailsParams{
+		Context:   ctx,
+		ClusterID: clusterID,
+	}
+
+	resp, err := c.operations.GetClusterClusterIDSuspendedDetails(p)
+	if err != nil {
+		return ClusterSuspendDetails{}, err
+	}
+
+	return ClusterSuspendDetails{
+		SuspendDetails: resp.Payload,
+		ClusterID:      clusterID,
+	}, nil
+}

--- a/vendor/github.com/scylladb/scylla-manager/v3/pkg/managerclient/model.go
+++ b/vendor/github.com/scylladb/scylla-manager/v3/pkg/managerclient/model.go
@@ -1601,3 +1601,24 @@ func formatLabels(labels map[string]string) string {
 	}
 	return strings.Join(out, ", ")
 }
+
+// ClusterSuspendDetails renders cluster suspend details.
+type ClusterSuspendDetails struct {
+	*models.SuspendDetails
+
+	ClusterID string
+}
+
+// Render implements Renderer interface.
+func (csd ClusterSuspendDetails) Render(w io.Writer) error {
+	t := table.New("Cluster ID", "Suspended", "Allowed Task")
+	t.AddRow(
+		csd.ClusterID,
+		csd.Suspended,
+		csd.AllowTaskType,
+	)
+	if _, err := w.Write([]byte(t.String())); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -404,7 +404,7 @@ github.com/scylladb/gocqlx/v2/table
 # github.com/scylladb/scylla-manager/backupspec v1.0.2
 ## explicit; go 1.23.2
 github.com/scylladb/scylla-manager/backupspec
-# github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250626145254-64b5a3b94aaf
+# github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250630160519-24627a91850a
 ## explicit; go 1.23.2
 github.com/scylladb/scylla-manager/v3/pkg/managerclient
 github.com/scylladb/scylla-manager/v3/pkg/managerclient/table


### PR DESCRIPTION
This adds final batch of commits from 1-1-restore-feature-branch to master: 

* update managerclient dependency to the latest version
* sctool: render suspend details table 

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
