### PR TITLE
Merge native restore support

### DIFF
--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -280,6 +280,16 @@ func (ni *NodeInfo) SupportsNativeBackupAPI() (bool, error) {
 	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2025.2")
 }
 
+// SupportsNativeRestoreAPI returns whether node exposes /storage_service/restore API.
+func (ni *NodeInfo) SupportsNativeRestoreAPI() (bool, error) {
+	// Detect master builds
+	if scyllaversion.MasterVersion(ni.ScyllaVersion) {
+		return true, nil
+	}
+	// Check ENT
+	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2025.3")
+}
+
 // ScyllaObjectStorageEndpoint returns endpoint that should be used when calling /storage_service/<backup|restore> API.
 // It also validates that agent's and Scylla's configurations match.
 func (ni *NodeInfo) ScyllaObjectStorageEndpoint(provider backupspec.Provider) (string, error) {

--- a/pkg/service/restore/helper_integration_test.go
+++ b/pkg/service/restore/helper_integration_test.go
@@ -453,17 +453,17 @@ func grantRestoreSchemaPermissions(t *testing.T, s gocqlx.Session, user string) 
 }
 
 func validateCompleteProgress(t *testing.T, pr Progress, tables []table) {
-	if pr.Size != pr.Restored || pr.Size != pr.Downloaded {
+	if pr.Size != pr.Restored {
 		t.Fatal("Expected complete restore")
 	}
 	encountered := make(map[table]struct{})
 	for _, kpr := range pr.Keyspaces {
-		if kpr.Size != kpr.Restored || kpr.Size != kpr.Downloaded {
+		if kpr.Size != kpr.Restored {
 			t.Fatalf("Expected complete keyspace restore (%s)", kpr.Keyspace)
 		}
 		for _, tpr := range kpr.Tables {
 			encountered[table{ks: kpr.Keyspace, tab: tpr.Table}] = struct{}{}
-			if tpr.Size != tpr.Restored || tpr.Size != tpr.Downloaded {
+			if tpr.Size != tpr.Restored {
 				t.Fatalf("Expected complete table restore (%s)", tpr.Table)
 			}
 		}
@@ -539,4 +539,14 @@ func runPausedRestore(t *testing.T, restore func(ctx context.Context) error, int
 			}()
 		}
 	}
+}
+
+func isDownloadOrRestoreEndpoint(path string) bool {
+	return strings.HasPrefix(path, "/agent/rclone/sync/copypaths") ||
+		strings.HasPrefix(path, "/storage_service/restore")
+}
+
+func isLasOrRestoreEndpoint(path string) bool {
+	return strings.HasPrefix(path, "/storage_service/sstables") ||
+		strings.HasPrefix(path, "/storage_service/restore")
 }

--- a/pkg/service/restore/progress_test.go
+++ b/pkg/service/restore/progress_test.go
@@ -102,6 +102,9 @@ func TestAggregateProgress(t *testing.T) {
 	setRclone := func(rp *RunProgress, d, v int64,
 		downloadStartFromNowInSec, downloadEndFromNowInSec, restoreEndFromNowInSec int) *RunProgress {
 		clone := *rp
+		clone.AgentJobID = 1
+		clone.ScyllaTaskID = ""
+
 		clone.RestoreStartedAt = timePtr(taskStart.Add(time.Duration(downloadStartFromNowInSec) * time.Second))
 		clone.DownloadStartedAt = timePtr(taskStart.Add(time.Duration(downloadStartFromNowInSec) * time.Second))
 		if downloadEndFromNowInSec != unsetCompletedAt {
@@ -118,6 +121,24 @@ func TestAggregateProgress(t *testing.T) {
 		}
 		clone.Downloaded = d
 		clone.VersionedDownloaded = v
+		return &clone
+	}
+	setScylla := func(rp *RunProgress, r int64, restoreStartFromNowInSec, restoreEndFromNowInSec int) *RunProgress {
+		clone := *rp
+		clone.AgentJobID = 0
+		clone.ScyllaTaskID = "1"
+		clone.DownloadStartedAt = nil
+		clone.DownloadCompletedAt = nil
+		clone.Downloaded = 0
+		clone.VersionedDownloaded = 0
+
+		clone.RestoreStartedAt = timePtr(taskStart.Add(time.Duration(restoreStartFromNowInSec) * time.Second))
+		if restoreEndFromNowInSec != unsetCompletedAt {
+			clone.RestoreCompletedAt = timePtr(taskStart.Add(time.Duration(restoreEndFromNowInSec) * time.Second))
+		} else {
+			clone.RestoreCompletedAt = nil
+		}
+		clone.Restored = r
 		return &clone
 	}
 
@@ -164,6 +185,38 @@ func TestAggregateProgress(t *testing.T) {
 				setRclone(fullTab1, tab1size/2, tab1size/2, 5, 7, 10),
 				setRclone(fullTab2, tab2size/3, 0, 1, 2, 3),
 				setRclone(fullTab2, tab2size/3, tab2size/3, 1, 2, unsetCompletedAt),
+			},
+		},
+		{
+			name: "scylla API full tab1 partial tab2",
+			progress: []*RunProgress{
+				setScylla(fullTab1, tab1size, 0, 10),
+				setScylla(fullTab2, tab2size/3, 1, 3),
+				setScylla(fullTab2, tab2size/3, 1, unsetCompletedAt),
+			},
+		},
+		{
+			name: "scylla API partial tab1 partial tab2",
+			progress: []*RunProgress{
+				setScylla(fullTab1, tab1size/2, 0, unsetCompletedAt),
+				setScylla(fullTab2, tab2size/3, 0, 7),
+				setScylla(fullTab2, tab2size/3, 0, unsetCompletedAt),
+			},
+		},
+		{
+			name: "mixed API full tab1 partial tab2",
+			progress: []*RunProgress{
+				fullTab1,
+				setScylla(fullTab2, tab2size/3, 1, 5),
+				setScylla(fullTab2, tab2size/3, 0, unsetCompletedAt),
+			},
+		},
+		{
+			name: "mixed API full tab1 full tab2",
+			progress: []*RunProgress{
+				fullTab1,
+				setScylla(fullTab2, tab2size/3, 1, 3),
+				setRclone(fullTab2, tab2size/3, tab2size/3, 1, 2, 4),
 			},
 		},
 	}

--- a/pkg/service/restore/restore_integration_test.go
+++ b/pkg/service/restore/restore_integration_test.go
@@ -494,6 +494,10 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	nativeRestoreSupport, err := ni.SupportsNativeRestoreAPI()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	Print("Keyspace setup")
 	ksStmt := "CREATE KEYSPACE %q WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': %d}"
@@ -510,10 +514,55 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	Print("Fill setup")
 	fillTable(t, h.srcCluster.rootSession, 100, ks, tab)
 
-	validateState := func(ch clusterHelper, tombstone string, compaction bool, transfers int, rateLimit int, cpus []int64) {
+	// Choose expected API - load&stream or native restore depending on node version
+	ensuredPath := "/storage_service/sstables"
+	blockedPath := "/storage_service/restore"
+	if nativeRestoreSupport {
+		ensuredPath, blockedPath = blockedPath, ensuredPath
+	}
+
+	Printf("Expect that %q API will be used for restore, while %q API won't be used at all", ensuredPath, blockedPath)
+	encounteredEnsured := atomic.Bool{}
+	encounteredBlocked := atomic.Bool{}
+	// Should always be set (also as a part of other interceptors)
+	apiInterceptor := func(req *http.Request) {
+		if strings.HasPrefix(req.URL.Path, ensuredPath) {
+			encounteredEnsured.Store(true)
+		}
+		if strings.HasPrefix(req.URL.Path, blockedPath) {
+			encounteredBlocked.Store(true)
+		}
+	}
+	setDstInterceptor := func(interceptor httpx.RoundTripperFunc) {
+		h.dstCluster.Hrt.SetInterceptor(httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			apiInterceptor(req)
+			if interceptor != nil {
+				return interceptor.RoundTrip(req)
+			}
+			return nil, nil
+		}))
+	}
+	setDstInterceptor(nil)
+
+	validateState := func(ch clusterHelper, tombstone string, compaction bool, transfers int, rateLimit int, cpus []int64, ttl int64) {
 		// Validate tombstone_gc mode
 		if got := tombstoneGCMode(t, ch.rootSession, ks, tab); tombstone != got {
 			t.Errorf("expected tombstone_gc=%s, got %s", tombstone, got)
+		}
+		// Restore with Scylla API does not need to directly control
+		// compaction, transfers, rate limit, cpu pinning.
+		// We only need to check for user task TTL.
+		if nativeRestoreSupport {
+			for _, host := range ch.Client.Config().Hosts {
+				got, err := ch.Client.ScyllaGetUserTaskTTL(context.Background(), host)
+				if err != nil {
+					t.Errorf("check user task ttl on host %s: %s", host, err)
+				}
+				if ttl != got {
+					t.Errorf("Expected user_task_ttl=%d, got=%d on host %s", ttl, got, host)
+				}
+			}
+			return
 		}
 		// Validate compaction
 		for _, host := range ch.Client.Config().Hosts {
@@ -539,7 +588,7 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 		for _, host := range ch.Client.Config().Hosts {
 			got, err := ch.Client.RcloneGetBandwidthLimit(context.Background(), host)
 			if err != nil {
-				t.Fatal(errors.Wrapf(err, "check transfers on host %s", host))
+				t.Fatal(errors.Wrapf(err, "check rate limit on host %s", host))
 			}
 			rawLimit := fmt.Sprintf("%dM", rateLimit)
 			if rateLimit == 0 {
@@ -553,7 +602,7 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 		for _, host := range ch.Client.Config().Hosts {
 			got, err := ch.Client.GetPinnedCPU(context.Background(), host)
 			if err != nil {
-				t.Fatal(errors.Wrapf(err, "check transfers on host %s", host))
+				t.Fatal(errors.Wrapf(err, "check cpus on host %s", host))
 			}
 			slices.Sort(cpus)
 			slices.Sort(got)
@@ -575,8 +624,17 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	}
 	transfers0 := 2 * int(shardCnt)
 
-	setTransfersAndRateLimitAndPinnedCPU := func(ch clusterHelper, transfers int, rateLimit int, pin bool) {
+	setTransfersAndRateLimitAndPinnedCPU := func(ch clusterHelper, transfers int, rateLimit int, pin bool, ttl int64) {
 		for _, host := range ch.Client.Config().Hosts {
+			// Restore with Scylla API does not need to directly control
+			// compaction, transfers, rate limit, cpu pinning.
+			// We only need to set user task TTL.
+			if nativeRestoreSupport {
+				if err := ch.Client.ScyllaSetUserTaskTTL(context.Background(), host, ttl); err != nil {
+					t.Fatalf("Set user task ttl on host %s: %s", host, err)
+				}
+				continue
+			}
 			err := ch.Client.RcloneSetTransfers(context.Background(), host, transfers)
 			if err != nil {
 				t.Fatal(errors.Wrapf(err, "set transfers on host %s", host))
@@ -599,12 +657,12 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 		}
 	}
 
-	Print("Set initial transfers and rate limit")
-	setTransfersAndRateLimitAndPinnedCPU(h.srcCluster, 10, 99, true)
-	setTransfersAndRateLimitAndPinnedCPU(h.dstCluster, 10, 99, true)
+	Print("Set initial config")
+	setTransfersAndRateLimitAndPinnedCPU(h.srcCluster, 10, 99, true, 1)
+	setTransfersAndRateLimitAndPinnedCPU(h.dstCluster, 10, 99, true, 1)
 
 	Print("Validate state before backup")
-	validateState(h.srcCluster, "repair", true, 10, 99, pinnedCPU)
+	validateState(h.srcCluster, "repair", true, 10, 99, pinnedCPU, 1)
 
 	Print("Run backup")
 	loc := []backupspec.Location{testLocation("preparation", "")}
@@ -617,9 +675,9 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 
 	Print("Validate state after backup")
 	if nativeBackupSupport && !IsIPV6Network() {
-		validateState(h.srcCluster, "repair", true, 10, 99, pinnedCPU)
+		validateState(h.srcCluster, "repair", true, 10, 99, pinnedCPU, 1)
 	} else {
-		validateState(h.srcCluster, "repair", true, 3, 88, pinnedCPU)
+		validateState(h.srcCluster, "repair", true, 3, 88, pinnedCPU, 1)
 	}
 
 	runRestore := func(ctx context.Context, finishedRestore chan error) {
@@ -644,8 +702,8 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	makeLASHang := func(reachedDataStageChan, hangLAS chan struct{}) {
 		cnt := atomic.Int64{}
 		cnt.Add(int64(len(h.dstCluster.Client.Config().Hosts)))
-		h.dstCluster.Hrt.SetInterceptor(httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			if strings.HasPrefix(req.URL.Path, "/storage_service/sstables") {
+		setDstInterceptor(func(req *http.Request) (*http.Response, error) {
+			if isLasOrRestoreEndpoint(req.URL.Path) {
 				if curr := cnt.Add(-1); curr == 0 {
 					Print("Reached data stage")
 					close(reachedDataStageChan)
@@ -654,7 +712,7 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 				<-hangLAS
 			}
 			return nil, nil
-		}))
+		})
 	}
 
 	var (
@@ -665,7 +723,7 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	makeLASHang(reachedDataStageChan, hangLAS)
 
 	Print("Validate state before restore")
-	validateState(h.dstCluster, "repair", true, 10, 99, pinnedCPU)
+	validateState(h.dstCluster, "repair", true, 10, 99, pinnedCPU, 1)
 
 	Print("Run restore")
 	finishedRestore := make(chan error)
@@ -680,7 +738,7 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	}
 
 	Print("Validate state during restore data")
-	validateState(h.dstCluster, "disabled", false, transfers0, 0, unpinnedCPU)
+	validateState(h.dstCluster, "disabled", false, transfers0, 0, unpinnedCPU, scyllaclient.ManagerTaskTTLSeconds)
 
 	Print("Pause restore")
 	restoreCancel()
@@ -695,10 +753,10 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	}
 
 	Print("Validate state during pause")
-	validateState(h.dstCluster, "disabled", true, transfers0, 0, pinnedCPU)
+	validateState(h.dstCluster, "disabled", true, transfers0, 0, pinnedCPU, 1)
 
 	Print("Change transfers and rate limit during pause")
-	setTransfersAndRateLimitAndPinnedCPU(h.dstCluster, 9, 55, false)
+	setTransfersAndRateLimitAndPinnedCPU(h.dstCluster, 9, 55, false, 2)
 
 	reachedDataStageChan = make(chan struct{})
 	hangLAS = make(chan struct{})
@@ -717,7 +775,7 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	}
 
 	Print("Validate state during restore data after pause")
-	validateState(h.dstCluster, "disabled", false, transfers0, 0, unpinnedCPU)
+	validateState(h.dstCluster, "disabled", false, transfers0, 0, unpinnedCPU, scyllaclient.ManagerTaskTTLSeconds)
 
 	Print("Release LAS")
 	close(hangLAS)
@@ -729,7 +787,7 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	}
 
 	Print("Validate state after restore success")
-	validateState(h.dstCluster, "repair", true, transfers0, 0, pinnedCPU)
+	validateState(h.dstCluster, "repair", true, transfers0, 0, pinnedCPU, 2)
 
 	Print("Validate table contents")
 	h.validateIdenticalTables(t, []table{{ks: ks, tab: tab}})
@@ -767,8 +825,6 @@ func TestRestoreTablesBatchRetryIntegration(t *testing.T) {
 	backupProps["batch_size"] = 100
 	tag := h.runBackup(t, backupProps)
 
-	downloadErr := errors.New("fake download error")
-	lasErr := errors.New("fake las error")
 	props := map[string]any{
 		"location":       loc,
 		"keyspace":       ksFilter,
@@ -778,30 +834,23 @@ func TestRestoreTablesBatchRetryIntegration(t *testing.T) {
 
 	t.Run("batch retry finished with success", func(t *testing.T) {
 		Print("Inject errors to some download and las calls")
-		downloadCnt := atomic.Int64{}
-		lasCnt := atomic.Int64{}
+		counter := atomic.Int64{}
 		h.dstCluster.Hrt.SetInterceptor(httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 			// For this setup, we have 6 remote sstable dirs and 6 workers.
-			// We inject 2 errors during download and 3 errors during LAS.
+			// We inject 5 errors during LAS or Scylla Restore API.
 			// This means that only a single node will be restoring at the end.
-			// Huge batch size and 3 LAS errors guarantee total 9 calls to LAS.
-			// The last failed call to LAS (cnt=8) waits a bit so that we test
+			// Huge batch size and 5 errors guarantee total 11 calls to LAS or Scylla API.
+			// The last failed call (cnt=10) waits a bit so that we test
 			// that batch dispatcher correctly reuses and releases nodes waiting
 			// for failed sstables to come back to the batch dispatcher.
-			if strings.HasPrefix(req.URL.Path, "/agent/rclone/sync/copypaths") {
-				if cnt := downloadCnt.Add(1); cnt == 1 || cnt == 3 {
-					t.Log("Fake download error ", cnt)
-					return nil, downloadErr
-				}
-			}
-			if strings.HasPrefix(req.URL.Path, "/storage_service/sstables/") {
-				cnt := lasCnt.Add(1)
-				if cnt == 8 {
+			if isLasOrRestoreEndpoint(req.URL.Path) {
+				cnt := counter.Add(1)
+				switch cnt {
+				case 10:
 					time.Sleep(15 * time.Second)
-				}
-				if cnt == 1 || cnt == 5 || cnt == 8 {
-					t.Log("Fake LAS error ", cnt)
-					return nil, lasErr
+					return nil, errors.New("fake error")
+				case 1, 3, 5, 8:
+					return nil, errors.New("fake error")
 				}
 			}
 			return nil, nil
@@ -812,7 +861,7 @@ func TestRestoreTablesBatchRetryIntegration(t *testing.T) {
 		h.runRestore(t, props)
 
 		Print("Validate success")
-		if cnt := lasCnt.Add(0); cnt < 9 {
+		if cnt := counter.Add(0); cnt < 11 {
 			t.Fatalf("Expected at least 9 calls to LAS, got %d", cnt)
 		}
 		validateTableContent[int, int](t, h.srcCluster.rootSession, h.dstCluster.rootSession, ks, tab1, "id", "data")
@@ -825,14 +874,14 @@ func TestRestoreTablesBatchRetryIntegration(t *testing.T) {
 		reachedDataStage := atomic.Bool{}
 		reachedDataStageChan := make(chan struct{})
 		h.dstCluster.Hrt.SetInterceptor(httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			if strings.HasPrefix(req.URL.Path, "/agent/rclone/sync/copypaths") {
+			if isDownloadOrRestoreEndpoint(req.URL.Path) {
 				if reachedDataStage.CompareAndSwap(false, true) {
 					close(reachedDataStageChan)
 				}
-				return nil, downloadErr
+				return nil, errors.New("fake error")
 			}
-			if strings.HasPrefix(req.URL.Path, "/storage_service/sstables/") {
-				return nil, lasErr
+			if isLasOrRestoreEndpoint(req.URL.Path) {
+				return nil, errors.New("fake error")
 			}
 			return nil, nil
 		}))
@@ -873,8 +922,7 @@ func TestRestoreTablesBatchRetryIntegration(t *testing.T) {
 		reachedDataStage := atomic.Bool{}
 		reachedDataStageChan := make(chan struct{})
 		h.dstCluster.Hrt.SetInterceptor(httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			if strings.HasPrefix(req.URL.Path, "/agent/rclone/sync/copypaths") ||
-				strings.HasPrefix(req.URL.Path, "/storage_service/sstables/") {
+			if isDownloadOrRestoreEndpoint(req.URL.Path) || isLasOrRestoreEndpoint(req.URL.Path) {
 				if reachedDataStage.CompareAndSwap(false, true) {
 					close(reachedDataStageChan)
 				}

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -970,9 +970,11 @@ func restoreWithResume(t *testing.T, target Target, keyspace string, loadCnt, lo
 	a := atomic.NewInt64(0)
 	b := atomic.NewInt64(0)
 	dstH.Hrt.SetInterceptor(httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-		if strings.HasPrefix(req.URL.Path, "/storage_service/sstables/") && a.Inc() == 1 {
-			Print("And: context1 is canceled")
-			cancel1()
+		if isLasOrRestoreEndpoint(req.URL.Path) {
+			if a.Inc() == 1 {
+				Print("And: context1 is canceled")
+				cancel1()
+			}
 		}
 		if strings.HasPrefix(req.URL.Path, "/storage_service/repair_async") && b.Inc() == 1 {
 			Print("And: context2 is canceled")
@@ -1762,15 +1764,15 @@ func (h *restoreTestHelper) validateRestoreSuccess(dstSession, srcSession gocqlx
 	for _, kpr := range pr.Keyspaces {
 		for _, tpr := range kpr.Tables {
 			Printf("name %s %v %v %v", tpr.Table, tpr.Downloaded, tpr.Size, tpr.Restored)
-			if tpr.Size != tpr.Restored || tpr.Size != tpr.Downloaded {
+			if tpr.Size != tpr.Restored {
 				h.T.Fatalf("Expected complete table restore (%s)", tpr.Table)
 			}
 		}
-		if kpr.Size != kpr.Restored || kpr.Size != kpr.Downloaded {
+		if kpr.Size != kpr.Restored {
 			h.T.Fatalf("Expected complete keyspace restore (%s)", kpr.Keyspace)
 		}
 	}
-	if pr.Size != pr.Restored || pr.Size != pr.Downloaded {
+	if pr.Size != pr.Restored {
 		h.T.Fatal("Expected complete restore")
 	}
 }

--- a/pkg/service/restore/tables_worker.go
+++ b/pkg/service/restore/tables_worker.go
@@ -225,6 +225,9 @@ func (w *tablesWorker) stageRestoreData(ctx context.Context) error {
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
+			if err := w.checkAvailableDiskSpace(ctx, hi.Host); err != nil {
+				return errors.Wrap(err, "validate free disk space")
+			}
 			// Download and stream in parallel
 			b, ok := bd.DispatchBatch(ctx, hi.Host)
 			if !ok {

--- a/pkg/service/restore/tablesdir_worker.go
+++ b/pkg/service/restore/tablesdir_worker.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/scylladb/scylla-manager/backupspec"
+	. "github.com/scylladb/scylla-manager/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
@@ -90,11 +90,7 @@ func (w *tablesWorker) restoreSSTables(ctx context.Context, b batch, pr *RunProg
 
 // newRunProgress creates RunProgress by starting download to host's upload dir.
 func (w *tablesWorker) newRunProgress(ctx context.Context, hi HostInfo, b batch) (*RunProgress, error) {
-	if err := w.checkAvailableDiskSpace(ctx, hi.Host); err != nil {
-		return nil, errors.Wrap(err, "validate free disk space")
-	}
-
-	uploadDir := backupspec.UploadTableDir(b.Keyspace, b.Table, w.tableVersion[b.TableName])
+	uploadDir := UploadTableDir(b.Keyspace, b.Table, w.tableVersion[b.TableName])
 	if err := w.cleanUploadDir(ctx, hi.Host, uploadDir, nil); err != nil {
 		return nil, errors.Wrapf(err, "clean upload dir of host %s", hi.Host)
 	}
@@ -126,7 +122,7 @@ func (w *tablesWorker) newRunProgress(ctx context.Context, hi HostInfo, b batch)
 // It returns jobID for asynchronous download of the newest versions of files
 // alongside with the size of the already downloaded versioned files.
 func (w *tablesWorker) startDownload(ctx context.Context, hi HostInfo, b batch) (jobID, versionedDownloaded int64, err error) {
-	uploadDir := backupspec.UploadTableDir(b.Keyspace, b.Table, w.tableVersion[b.TableName])
+	uploadDir := UploadTableDir(b.Keyspace, b.Table, w.tableVersion[b.TableName])
 	sstables := b.NotVersionedSSTables()
 	versioned := b.VersionedSSTables()
 	versionedSize := b.VersionedSize()
@@ -195,7 +191,7 @@ func (w *tablesWorker) cleanupRunProgress(ctx context.Context, pr *RunProgress) 
 		Keyspace: pr.Keyspace,
 		Table:    pr.Table,
 	}
-	if cleanErr := w.cleanUploadDir(ctx, pr.Host, backupspec.UploadTableDir(pr.Keyspace, pr.Table, w.tableVersion[tn]), nil); cleanErr != nil {
+	if cleanErr := w.cleanUploadDir(ctx, pr.Host, UploadTableDir(pr.Keyspace, pr.Table, w.tableVersion[tn]), nil); cleanErr != nil {
 		w.logger.Error(ctx, "Couldn't clear destination directory", "host", pr.Host, "error", cleanErr)
 	}
 }

--- a/pkg/service/restore/testdata/AggregateProgress/mixed_API_full_tab1_full_tab2.golden.json
+++ b/pkg/service/restore/testdata/AggregateProgress/mixed_API_full_tab1_full_tab2.golden.json
@@ -1,0 +1,66 @@
+{
+  "size": 180,
+  "restored": 180,
+  "downloaded": 140,
+  "failed": 0,
+  "started_at": "2024-02-23T01:12:00Z",
+  "completed_at": "2024-02-23T01:12:04Z",
+  "repair_progress": null,
+  "snapshot_tag": "sm_20240223011159UTC",
+  "keyspaces": [
+    {
+      "size": 180,
+      "restored": 180,
+      "downloaded": 140,
+      "failed": 0,
+      "started_at": "2024-02-23T01:12:00Z",
+      "completed_at": "2024-02-23T01:12:04Z",
+      "keyspace": "ks",
+      "tables": [
+        {
+          "size": 60,
+          "restored": 60,
+          "downloaded": 60,
+          "failed": 0,
+          "started_at": "2024-02-23T01:12:00Z",
+          "completed_at": "2024-02-23T01:12:02Z",
+          "table": "tab1",
+          "tombstone_gc": "repair"
+        },
+        {
+          "size": 120,
+          "restored": 120,
+          "downloaded": 80,
+          "failed": 0,
+          "started_at": "2024-02-23T01:12:01Z",
+          "completed_at": "2024-02-23T01:12:04Z",
+          "table": "tab2",
+          "tombstone_gc": "timeout"
+        }
+      ]
+    }
+  ],
+  "hosts": [
+    {
+      "host": "h",
+      "shard_cnt": 1,
+      "restored_bytes": 180,
+      "restore_duration": 7000,
+      "downloaded_bytes": 140,
+      "download_duration": 2000,
+      "streamed_bytes": 140,
+      "stream_duration": 3000
+    }
+  ],
+  "views": [
+    {
+      "keyspace": "ks",
+      "view": "mv",
+      "type": "MaterializedView",
+      "base_table": "tab1",
+      "create_stmt": "CREATE",
+      "status": ""
+    }
+  ],
+  "stage": "DATA"
+}

--- a/pkg/service/restore/testdata/AggregateProgress/mixed_API_full_tab1_partial_tab2.golden.json
+++ b/pkg/service/restore/testdata/AggregateProgress/mixed_API_full_tab1_partial_tab2.golden.json
@@ -1,0 +1,66 @@
+{
+  "size": 180,
+  "restored": 140,
+  "downloaded": 60,
+  "failed": 0,
+  "started_at": "2024-02-23T01:12:00Z",
+  "completed_at": null,
+  "repair_progress": null,
+  "snapshot_tag": "sm_20240223011159UTC",
+  "keyspaces": [
+    {
+      "size": 180,
+      "restored": 140,
+      "downloaded": 60,
+      "failed": 0,
+      "started_at": "2024-02-23T01:12:00Z",
+      "completed_at": null,
+      "keyspace": "ks",
+      "tables": [
+        {
+          "size": 60,
+          "restored": 60,
+          "downloaded": 60,
+          "failed": 0,
+          "started_at": "2024-02-23T01:12:00Z",
+          "completed_at": "2024-02-23T01:12:02Z",
+          "table": "tab1",
+          "tombstone_gc": "repair"
+        },
+        {
+          "size": 120,
+          "restored": 80,
+          "downloaded": 0,
+          "failed": 0,
+          "started_at": "2024-02-23T01:12:00Z",
+          "completed_at": null,
+          "table": "tab2",
+          "tombstone_gc": "timeout"
+        }
+      ]
+    }
+  ],
+  "hosts": [
+    {
+      "host": "h",
+      "shard_cnt": 1,
+      "restored_bytes": 140,
+      "restore_duration": 16000,
+      "downloaded_bytes": 60,
+      "download_duration": 1000,
+      "streamed_bytes": 60,
+      "stream_duration": 1000
+    }
+  ],
+  "views": [
+    {
+      "keyspace": "ks",
+      "view": "mv",
+      "type": "MaterializedView",
+      "base_table": "tab1",
+      "create_stmt": "CREATE",
+      "status": ""
+    }
+  ],
+  "stage": "DATA"
+}

--- a/pkg/service/restore/testdata/AggregateProgress/scylla_API_full_tab1_partial_tab2.golden.json
+++ b/pkg/service/restore/testdata/AggregateProgress/scylla_API_full_tab1_partial_tab2.golden.json
@@ -1,0 +1,66 @@
+{
+  "size": 180,
+  "restored": 140,
+  "downloaded": 0,
+  "failed": 0,
+  "started_at": "2024-02-23T01:12:00Z",
+  "completed_at": null,
+  "repair_progress": null,
+  "snapshot_tag": "sm_20240223011159UTC",
+  "keyspaces": [
+    {
+      "size": 180,
+      "restored": 140,
+      "downloaded": 0,
+      "failed": 0,
+      "started_at": "2024-02-23T01:12:00Z",
+      "completed_at": null,
+      "keyspace": "ks",
+      "tables": [
+        {
+          "size": 60,
+          "restored": 60,
+          "downloaded": 0,
+          "failed": 0,
+          "started_at": "2024-02-23T01:12:00Z",
+          "completed_at": "2024-02-23T01:12:10Z",
+          "table": "tab1",
+          "tombstone_gc": "repair"
+        },
+        {
+          "size": 120,
+          "restored": 80,
+          "downloaded": 0,
+          "failed": 0,
+          "started_at": "2024-02-23T01:12:01Z",
+          "completed_at": null,
+          "table": "tab2",
+          "tombstone_gc": "timeout"
+        }
+      ]
+    }
+  ],
+  "hosts": [
+    {
+      "host": "h",
+      "shard_cnt": 1,
+      "restored_bytes": 140,
+      "restore_duration": 21000,
+      "downloaded_bytes": 0,
+      "download_duration": 0,
+      "streamed_bytes": 0,
+      "stream_duration": 0
+    }
+  ],
+  "views": [
+    {
+      "keyspace": "ks",
+      "view": "mv",
+      "type": "MaterializedView",
+      "base_table": "tab1",
+      "create_stmt": "CREATE",
+      "status": ""
+    }
+  ],
+  "stage": "DATA"
+}

--- a/pkg/service/restore/testdata/AggregateProgress/scylla_API_partial_tab1_partial_tab2.golden.json
+++ b/pkg/service/restore/testdata/AggregateProgress/scylla_API_partial_tab1_partial_tab2.golden.json
@@ -1,0 +1,66 @@
+{
+  "size": 180,
+  "restored": 110,
+  "downloaded": 0,
+  "failed": 0,
+  "started_at": "2024-02-23T01:12:00Z",
+  "completed_at": null,
+  "repair_progress": null,
+  "snapshot_tag": "sm_20240223011159UTC",
+  "keyspaces": [
+    {
+      "size": 180,
+      "restored": 110,
+      "downloaded": 0,
+      "failed": 0,
+      "started_at": "2024-02-23T01:12:00Z",
+      "completed_at": null,
+      "keyspace": "ks",
+      "tables": [
+        {
+          "size": 60,
+          "restored": 30,
+          "downloaded": 0,
+          "failed": 0,
+          "started_at": "2024-02-23T01:12:00Z",
+          "completed_at": null,
+          "table": "tab1",
+          "tombstone_gc": "repair"
+        },
+        {
+          "size": 120,
+          "restored": 80,
+          "downloaded": 0,
+          "failed": 0,
+          "started_at": "2024-02-23T01:12:00Z",
+          "completed_at": null,
+          "table": "tab2",
+          "tombstone_gc": "timeout"
+        }
+      ]
+    }
+  ],
+  "hosts": [
+    {
+      "host": "h",
+      "shard_cnt": 1,
+      "restored_bytes": 110,
+      "restore_duration": 27000,
+      "downloaded_bytes": 0,
+      "download_duration": 0,
+      "streamed_bytes": 0,
+      "stream_duration": 0
+    }
+  ],
+  "views": [
+    {
+      "keyspace": "ks",
+      "view": "mv",
+      "type": "MaterializedView",
+      "base_table": "tab1",
+      "create_stmt": "CREATE",
+      "status": ""
+    }
+  ],
+  "stage": "DATA"
+}

--- a/pkg/service/restore/worker.go
+++ b/pkg/service/restore/worker.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net/netip"
 	"path"
 	"regexp"
 	"slices"
@@ -22,6 +23,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/schema/table"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/configcache"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/query"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
 
@@ -30,7 +32,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/util/version"
 )
 
-// restoreWorkerTools consists of utils common for both schemaWorker and tablesWorker.
+// worker consists of utils common for both schemaWorker and tablesWorker.
 type worker struct {
 	run             *Run
 	target          Target
@@ -43,6 +45,7 @@ type worker struct {
 	client         *scyllaclient.Client
 	session        gocqlx.Session
 	clusterSession gocqlx.Session
+	nodeConfig     map[netip.Addr]configcache.NodeConfig
 }
 
 func (w *worker) init(ctx context.Context, properties json.RawMessage) error {

--- a/pkg/service/restore/worker_scylla_restore.go
+++ b/pkg/service/restore/worker_scylla_restore.go
@@ -1,0 +1,206 @@
+// Copyright (C) 2024 ScyllaDB
+
+package restore
+
+import (
+	"context"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	. "github.com/scylladb/scylla-manager/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
+	"github.com/scylladb/scylla-manager/v3/pkg/scheduler"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/configcache"
+	"github.com/scylladb/scylla-manager/v3/pkg/sstable"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
+	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/models"
+)
+
+// hostScyllaRestoreSupport checks if native restore API is supported for given host.
+func (w *tablesWorker) hostScyllaRestoreSupport(ctx context.Context, host string, nc configcache.NodeConfig) bool {
+	ok, err := nc.SupportsNativeRestoreAPI()
+	if err != nil || !ok {
+		w.logger.Info(ctx, "Can't use Scylla restore API with given Scylla version",
+			"host", host,
+			"version", nc.ScyllaVersion,
+			"error", err)
+		return false
+	}
+	return true
+}
+
+// batchScyllaRestoreSupport checks if we should use native restore API
+// for restoring given batch.
+func (w *tablesWorker) batchScyllaRestoreSupport(ctx context.Context, b batch, nc configcache.NodeConfig) bool {
+	scyllaSupportedProviders := []Provider{
+		S3,
+	}
+	if !slices.Contains(scyllaSupportedProviders, b.Location.Provider) {
+		// As this check is done per batch, we shouldn't flood the logs
+		// with semi-interesting information.
+		return false
+	}
+
+	_, err := nc.ScyllaObjectStorageEndpoint(b.Location.Provider)
+	if err != nil {
+		w.logger.Info(ctx, "Can't use Scylla restore API without object storage endpoint configuration",
+			"error", err)
+		return false
+	}
+
+	if b.batchType.Versioned {
+		w.logger.Info(ctx, "Can't use Scylla restore API with versioned sstables",
+			"backup node ID", b.NodeID,
+			"keyspace", b.Keyspace,
+			"table", b.Table)
+		return false
+	}
+
+	if b.batchType.IDType == sstable.IntegerID {
+		w.logger.Info(ctx, "Can't use Scylla restore API with integer based sstable ID",
+			"backup node ID", b.NodeID,
+			"keyspace", b.Keyspace,
+			"table", b.Table)
+		return false
+	}
+	return true
+}
+
+// tryScyllaRestore returns true and runs scyllaRestore if hostScyllaRestoreSupport and batchScyllaRestoreSupport
+// checks have passed. Otherwise, it returns false, nil.
+// Note that hostScyllaRestoreSupport needs to be evaluated before running this method.
+func (w *tablesWorker) tryScyllaRestore(ctx context.Context, hostScyllaRestoreSupport bool, host string, b batch, nc configcache.NodeConfig) (bool, error) {
+	if !hostScyllaRestoreSupport {
+		return false, nil
+	}
+	if !w.batchScyllaRestoreSupport(ctx, b, nc) {
+		return false, nil
+	}
+	w.logger.Info(ctx, "Use Scylla restore API",
+		"host", host,
+		"keyspace", b.Keyspace,
+		"table", b.Table)
+	return true, w.scyllaRestore(ctx, host, b, nc)
+}
+
+func (w *tablesWorker) scyllaRestore(ctx context.Context, host string, b batch, nc configcache.NodeConfig) (err error) {
+	w.logger.Info(ctx, "Use native Scylla restore API", "host", host, "keyspace", b.Keyspace, "table", b.Table)
+	w.metrics.SetRestoreState(w.run.ClusterID, b.Location, w.run.SnapshotTag, host, metrics.RestoreStateNativeRestore)
+	defer func() {
+		if err != nil && scheduler.IsTaskInterrupted(ctx) {
+			w.metrics.SetRestoreState(w.run.ClusterID, b.Location, w.run.SnapshotTag, host, metrics.RestoreStateError)
+		} else {
+			w.metrics.SetRestoreState(w.run.ClusterID, b.Location, w.run.SnapshotTag, host, metrics.RestoreStateIdle)
+		}
+	}()
+
+	// RemoteSSTableDir has "<provider>:<bucket>/<path>" format
+	prefix, ok := strings.CutPrefix(b.RemoteSSTableDir, b.Location.StringWithoutDC())
+	if !ok {
+		return errors.Errorf("remote sstable dir (%s) should contain location path prefix (%s)", b.RemoteSSTableDir, b.Location.Path)
+	}
+	endpoint, err := nc.ScyllaObjectStorageEndpoint(b.Location.Provider)
+	if err != nil {
+		return errors.Wrap(err, "get Scylla object storage endpoint")
+	}
+
+	id, err := w.client.ScyllaRestore(ctx, host, endpoint, b.Location.Path, prefix, b.Keyspace, b.Table, b.TOC())
+	if err != nil {
+		return errors.Wrap(err, "restore")
+	}
+
+	pr := &RunProgress{
+		ClusterID:        w.run.ClusterID,
+		TaskID:           w.run.TaskID,
+		RunID:            w.run.ID,
+		RemoteSSTableDir: b.RemoteSSTableDir,
+		Keyspace:         b.Keyspace,
+		Table:            b.Table,
+		Host:             host,
+		ShardCnt:         int64(w.hostShardCnt[host]),
+		ScyllaTaskID:     id,
+		SSTableID:        b.IDs(),
+	}
+	w.insertRunProgress(ctx, pr)
+
+	w.logger.Info(ctx, "Wait for restore task to finish", "host", host, "task id", id)
+	err = w.scyllaWaitTask(ctx, pr, b)
+	if err != nil {
+		w.cleanupRunProgress(context.Background(), pr)
+	}
+	return err
+}
+
+func (w *tablesWorker) scyllaWaitTask(ctx context.Context, pr *RunProgress, b batch) (err error) {
+	for {
+		if ctx.Err() != nil {
+			w.scyllaAbortTask(pr.Host, pr.ScyllaTaskID)
+			return ctx.Err()
+		}
+
+		task, err := w.client.ScyllaWaitTask(ctx, pr.Host, pr.ScyllaTaskID, int64(w.config.LongPollingTimeoutSeconds))
+		if err != nil {
+			w.scyllaAbortTask(pr.Host, pr.ScyllaTaskID)
+			return errors.Wrap(err, "wait for task")
+		}
+
+		w.scyllaUpdateProgress(ctx, pr, b, task)
+		switch scyllaclient.ScyllaTaskState(task.State) {
+		case scyllaclient.ScyllaTaskStateFailed:
+			return errors.Errorf("task error (%s): %s", pr.ScyllaTaskID, task.Error)
+		case scyllaclient.ScyllaTaskStateDone:
+			return nil
+		}
+	}
+}
+
+func (w *tablesWorker) scyllaAbortTask(host, id string) {
+	if err := w.client.ScyllaAbortTask(context.Background(), host, id); err != nil {
+		w.logger.Error(context.Background(), "Failed to abort task",
+			"host", host,
+			"id", id,
+			"error", err,
+		)
+	}
+}
+
+func (w *tablesWorker) scyllaUpdateProgress(ctx context.Context, pr *RunProgress, b batch, task *models.TaskStatus) {
+	now := timeutc.Now()
+	restored := b.Size * int64(task.ProgressCompleted/task.ProgressTotal)
+	restoredDiff := restored - pr.Restored
+	var startedAt, completedAt *time.Time
+	if t := time.Time(task.StartTime); !t.IsZero() {
+		startedAt = &t
+	}
+	if t := time.Time(task.EndTime); !t.IsZero() {
+		completedAt = &t
+	}
+
+	// Update metrics boilerplate
+	w.metrics.IncreaseRestoredBytes(w.run.ClusterID, pr.Host, restoredDiff)
+	w.metrics.IncreaseRestoreDuration(w.run.ClusterID, pr.Host, timeSub(startedAt, completedAt, now))
+	w.metrics.DecreaseRemainingBytes(metrics.RestoreBytesLabels{
+		ClusterID:   b.ClusterID.String(),
+		SnapshotTag: b.SnapshotTag,
+		Location:    b.Location.String(),
+		DC:          b.DC,
+		Node:        b.NodeID,
+		Keyspace:    b.Keyspace,
+		Table:       b.Table,
+	}, restoredDiff)
+	w.progress.Update(restoredDiff)
+	w.metrics.SetProgress(metrics.RestoreProgressLabels{
+		ClusterID:   w.run.ClusterID.String(),
+		SnapshotTag: w.run.SnapshotTag,
+	}, w.progress.CurrentProgress())
+
+	// Update run progress
+	pr.RestoreStartedAt = startedAt
+	pr.RestoreCompletedAt = completedAt
+	pr.Error = task.Error
+	pr.Restored = restored
+	w.insertRunProgress(ctx, pr)
+}


### PR DESCRIPTION
This PR if a followup to #4381 which contains remaining changes from `ml/scylla-api-2`.
It introduces a replacement for rclone copypaths API in a form of native restore Scylla API. 

Fixes #4144
Fixes #4137
Fixes #4142
Fixes #4158
Fixes #4385
Fixes #4194