### PR TITLE
fix VERSION_NAME value in makefile

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,16 +1,16 @@
 RELEASE      := 0.$(shell date +%Y%m%d).$(shell git describe --always)
-VERSION=3.7.0-dev
+VERSION      ?=3.7.0-dev
 PUBLISH      := 0
 
 ifdef $$VERSION
-VERSION=3.7.0-dev
+VERSION := $$VERSION
 endif
 
 ifeq ($(PUBLISH),0)
 publish = --skip=publish
-VERSION=3.7.0-dev
+VERSION_NAME := $(VERSION)-$(RELEASE)
 else
-VERSION=3.7.0-dev
+VERSION_NAME := v$(VERSION)
 endif
 
 $(shell echo $(VERSION) > .version)


### PR DESCRIPTION
follow the commit: https://github.com/scylladb/scylla-manager/commit/e1b19dacaeb282956826bf92776bf16522183a8b manager-build stopped work due to missing tag version

adding back the VERSION_NAME

Fixes: https://github.com/scylladb/scylla-pkg/issues/5242


Verification passed: https://jenkins.scylladb.com/view/scylla-manager/job/manager-master/job/manager-build/1040/