### PR TITLE
fix(1-1-restore): set skip_{cleanup|reshape} only for scylla > 2025.2.0

### DIFF
--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -309,6 +309,19 @@ func (ni *NodeInfo) ScyllaObjectStorageEndpoint(provider backupspec.Provider) (s
 		"and in `scylla.yaml` object_storage_endpoints config", provider)
 }
 
+// SupportsSkipCleanupAndSkipReshape returns whether Scylla supports skip_cleanup and skip_reshape parameters
+// in /storage_service/sstables/{keyspace} endpoint as 2025.2.0 has a bug if this parameters are set to true -
+// https://github.com/scylladb/scylladb/issues/24913.
+func (ni *NodeInfo) SupportsSkipCleanupAndSkipReshape() (bool, error) {
+	// Detect master builds
+	if scyllaversion.MasterVersion(ni.ScyllaVersion) {
+		return true, nil
+	}
+
+	// Check ENT
+	return scyllaversion.CheckConstraint(ni.ScyllaVersion, "> 2025.2.0")
+}
+
 // FreeOSMemory calls debug.FreeOSMemory on the agent to return memory to OS.
 func (c *Client) FreeOSMemory(ctx context.Context, host string) error {
 	p := operations.FreeOSMemoryParams{

--- a/pkg/scyllaclient/client_agent_test.go
+++ b/pkg/scyllaclient/client_agent_test.go
@@ -665,3 +665,58 @@ func TestEqualObjectStorageEndpoints(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeInfoSupportsSkipCleanupAndSkipReshape(t *testing.T) {
+	testCases := []struct {
+		name          string
+		scyllaVersion string
+		expected      bool
+	}{
+		{
+			name:          "master version is supported",
+			scyllaVersion: "9999.enterprise_dev",
+			expected:      true,
+		},
+		{
+			name:          "2025.3.0 is supported",
+			scyllaVersion: "2025.3.0",
+			expected:      true,
+		},
+		{
+			name:          "2025.2.1 is supported",
+			scyllaVersion: "2025.2.1",
+			expected:      true,
+		},
+		{
+			name:          "2025.2.1 is supported",
+			scyllaVersion: "2025.2.1",
+			expected:      true,
+		},
+		{
+			name:          "2025.2.0 is not supported",
+			scyllaVersion: "2025.2.0",
+			expected:      false,
+		},
+		{
+			name:          "2025.1.0 is not supported",
+			scyllaVersion: "2025.1.0",
+			expected:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ni := scyllaclient.NodeInfo{ScyllaVersion: tc.scyllaVersion}
+			supported, err := ni.SupportsSkipCleanupAndSkipReshape()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if supported != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, supported)
+			}
+		})
+	}
+}

--- a/pkg/service/one2onerestore/model.go
+++ b/pkg/service/one2onerestore/model.go
@@ -41,11 +41,12 @@ type node struct {
 
 // Host contains basic information about Scylla node.
 type Host struct {
-	ID                 string
-	DC                 string
-	Addr               string
-	ShardCount         int
-	SafeDescribeMethod scyllaclient.SafeDescribeMethod
+	ID                        string
+	DC                        string
+	Addr                      string
+	ShardCount                int
+	SafeDescribeMethod        scyllaclient.SafeDescribeMethod
+	SkipCleanupAndSkipReshape bool
 }
 
 // ViewType either Materialized View or Secondary Index.

--- a/pkg/service/one2onerestore/worker.go
+++ b/pkg/service/one2onerestore/worker.go
@@ -218,6 +218,11 @@ func (w *worker) prepareHostWorkload(ctx context.Context, manifests []*backupspe
 			return errors.Wrapf(err, "node %s safe describe method", h.Addr)
 		}
 		hw.host.SafeDescribeMethod = method
+		supports, err := nodeInfo.SupportsSkipCleanupAndSkipReshape()
+		if err != nil {
+			return errors.Wrapf(err, "node %s supports skip_cleanup and skip_reshape", h.Addr)
+		}
+		hw.host.SkipCleanupAndSkipReshape = supports
 
 		result[i] = hw
 

--- a/pkg/service/one2onerestore/worker_tables.go
+++ b/pkg/service/one2onerestore/worker_tables.go
@@ -123,7 +123,7 @@ func (w *worker) refreshNodeWorker(ctx context.Context, hostTask hostWorkload, q
 func (w *worker) refreshNode(ctx context.Context, table backupspec.FilesMeta, m *backupspec.ManifestInfo, h Host, pr *RunTableProgress) error {
 	start := timeutc.Now()
 	w.metrics.SetOne2OneRestoreState(w.runInfo.ClusterID, m.Location, m.SnapshotTag, h.Addr, refreshWorkerName, metrics.One2OneRestoreStateLoading)
-	err := w.client.AwaitLoadSSTables(ctx, h.Addr, table.Keyspace, table.Table, false, false, true, true)
+	err := w.awaitLoadSSTables(ctx, h, table.Keyspace, table.Table)
 	w.finishRestoreTableProgress(ctx, pr, err)
 	if err == nil {
 		w.logger.Info(ctx, "Refresh node done",
@@ -136,6 +136,15 @@ func (w *worker) refreshNode(ctx context.Context, table backupspec.FilesMeta, m 
 		w.metrics.SetOne2OneRestoreState(w.runInfo.ClusterID, m.Location, m.SnapshotTag, h.Addr, refreshWorkerName, metrics.One2OneRestoreStateIdle)
 	}
 	return err
+}
+
+func (w *worker) awaitLoadSSTables(ctx context.Context, host Host, keyspace, table string) error {
+	var skipCleanup, skipReshape bool
+	if host.SkipCleanupAndSkipReshape {
+		skipCleanup, skipReshape = true, true
+	}
+
+	return w.client.AwaitLoadSSTables(ctx, host.Addr, keyspace, table, false, false, skipCleanup, skipReshape)
 }
 
 func (w *worker) waitJob(ctx context.Context, jobID int64, m *backupspec.ManifestInfo, h Host, pr *RunTableProgress, stats *restoreStats, pollIntervalSec int) (err error) {


### PR DESCRIPTION
This sets skip_cleanup and skip_reshape parameters to /storage_service/sstables/{keyspace} call only if scylla version greater than 2025.2.0 as this version has a known bug and will return an error if these parameters are provided.

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
