### PR TITLE
Fix scylla master checks

### DIFF
--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -117,6 +117,7 @@ func (s *server) makeServices(ctx context.Context) error {
 		s.session,
 		s.config.Backup,
 		metrics.NewBackupMetrics().MustRegister(),
+		featuregate.ScyllaFeatureGate{},
 		s.clusterSvc.GetClusterName,
 		s.clusterSvc.Client,
 		s.clusterSvc.GetSession,

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/gocqlx/v2"
 	config "github.com/scylladb/scylla-manager/v3/pkg/config/server"
+	"github.com/scylladb/scylla-manager/v3/pkg/featuregate"
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/restapi"
 	"github.com/scylladb/scylla-manager/v3/pkg/schema/table"
@@ -102,6 +103,7 @@ func (s *server) makeServices(ctx context.Context) error {
 		s.session,
 		s.config.Repair,
 		metrics.NewRepairMetrics().MustRegister(),
+		featuregate.ScyllaFeatureGate{},
 		s.clusterSvc.Client,
 		s.clusterSvc.GetSession,
 		s.configCacheSvc,

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -133,6 +133,7 @@ func (s *server) makeServices(ctx context.Context) error {
 		s.session,
 		s.config.Restore,
 		metrics.NewRestoreMetrics().MustRegister(),
+		featuregate.ScyllaFeatureGate{},
 		s.clusterSvc.Client,
 		s.clusterSvc.GetSession,
 		s.configCacheSvc,

--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -151,6 +151,7 @@ func (s *server) makeServices(ctx context.Context) error {
 		s.configCacheSvc,
 		s.logger.Named("one2onerestore"),
 		metrics.NewOne2OneRestoreMetrics().MustRegister(),
+		featuregate.ScyllaFeatureGate{},
 	)
 	if err != nil {
 		return errors.Wrapf(err, "one2onerestore service")

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -36,8 +36,8 @@ func (fg ScyllaFeatureGate) NativeBackup(version string) (bool, error) {
 }
 
 // NativeRestore - scylla exposes /storage_service/restore API.
-func (fg ScyllaFeatureGate) NativeRestore(version string) (bool, error) {
-	return checkConstraints(version, ">= 2025.3")
+func (fg ScyllaFeatureGate) NativeRestore(_ string) (bool, error) {
+	return false, nil
 }
 
 // SkipCleanupAndSkipReshape - scylla supports skip_cleanup and skip_reshape params in /storage_service/sstables/{keyspace} API.

--- a/pkg/featuregate/featuregate.go
+++ b/pkg/featuregate/featuregate.go
@@ -1,0 +1,60 @@
+// Copyright (C) 2025 ScyllaDB
+
+package featuregate
+
+import (
+	"github.com/pkg/errors"
+	scyllaversion "github.com/scylladb/scylla-manager/v3/pkg/util/version"
+)
+
+// ScyllaFeatureGate is a helper for checking scylla feature availability based on scylla version.
+type ScyllaFeatureGate struct{}
+
+// RepairSmallTableOptimization - scylla supports small_table_optimization param in /storage_service/repair_async/{keyspace} API.
+func (fg ScyllaFeatureGate) RepairSmallTableOptimization(version string) (bool, error) {
+	return checkConstraints(version, ">= 6.0, < 2000", ">= 2024.1.5")
+}
+
+// TabletRepair - scylla exposes /storage_service/tablets/repair API.
+func (fg ScyllaFeatureGate) TabletRepair(version string) (bool, error) {
+	return checkConstraints(version, ">= 2025.1")
+}
+
+// SafeDescribeMethodReadBarrierAPI - scylla exposes read barrier API.
+func (fg ScyllaFeatureGate) SafeDescribeMethodReadBarrierAPI(version string) (bool, error) {
+	return checkConstraints(version, ">= 6.1, < 2000", ">= 2025.1")
+}
+
+// SafeDescribeMethodReadBarrierCQL - scylla CQL read barrier can be used.
+func (fg ScyllaFeatureGate) SafeDescribeMethodReadBarrierCQL(version string) (bool, error) {
+	return checkConstraints(version, ">= 6.0, < 2000", ">= 2024.2, > 1000")
+}
+
+// NativeBackup - scylla exposes /storage_service/backup API.
+func (fg ScyllaFeatureGate) NativeBackup(version string) (bool, error) {
+	return checkConstraints(version, ">= 2025.2")
+}
+
+// NativeRestore - scylla exposes /storage_service/restore API.
+func (fg ScyllaFeatureGate) NativeRestore(version string) (bool, error) {
+	return checkConstraints(version, ">= 2025.3")
+}
+
+// SkipCleanupAndSkipReshape - scylla supports skip_cleanup and skip_reshape params in /storage_service/sstables/{keyspace} API.
+// Note that scylla 2025.2.0 has a bug if these params are set to true - https://github.com/scylladb/scylladb/issues/24913.
+func (fg ScyllaFeatureGate) SkipCleanupAndSkipReshape(version string) (bool, error) {
+	return checkConstraints(version, ">= 2025.2.0")
+}
+
+func checkConstraints(version string, constraints ...string) (bool, error) {
+	for _, constraint := range constraints {
+		supports, err := scyllaversion.CheckConstraint(version, constraint)
+		if err != nil {
+			return false, errors.Wrapf(err, "unknown scylla version: %s", version)
+		}
+		if supports {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/pkg/featuregate/featuregate_test.go
+++ b/pkg/featuregate/featuregate_test.go
@@ -1,0 +1,245 @@
+// Copyright (C) 2025 ScyllaDB
+
+package featuregate_test
+
+import (
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/featuregate"
+)
+
+func TestRepairSmallTableOptimization(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		scyllaVer string
+		expected  bool
+	}{
+		{
+			scyllaVer: "2024.1.4",
+			expected:  false,
+		},
+		{
+			scyllaVer: "2024.2.5",
+			expected:  true,
+		},
+		{
+			scyllaVer: "2024.2.6",
+			expected:  true,
+		},
+		{
+			scyllaVer: "5.4.9",
+			expected:  false,
+		},
+		{
+			scyllaVer: "5.5.0",
+			expected:  false,
+		},
+		{
+			scyllaVer: "6.0.0",
+			expected:  true,
+		},
+		{
+			scyllaVer: "6.0.1",
+			expected:  true,
+		},
+		{
+			scyllaVer: "6.1.0",
+			expected:  true,
+		},
+	}
+
+	fg := featuregate.ScyllaFeatureGate{}
+	for _, tc := range testCases {
+		result, err := fg.RepairSmallTableOptimization(tc.scyllaVer)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result != tc.expected {
+			t.Fatalf("expected {%v}, but got {%v}, version = {%s}", tc.expected, result, tc.scyllaVer)
+		}
+	}
+}
+
+func TestSafeDescribeMethodReadBarrierAPI(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		scyllaVersion   string
+		expectedSupport bool
+		expectedError   bool
+	}{
+		{
+			name:            "when scylla >= 2025.1, then it is expected to support read barrier api",
+			scyllaVersion:   "2025.1.0-candidate-20241106103631",
+			expectedSupport: true,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla >= 6.1, then it is expected to support read barrier api",
+			scyllaVersion:   "6.2.1-candidate-20241106103631",
+			expectedSupport: true,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla >= 2024.2, then it is expected to support read barrier cql",
+			scyllaVersion:   "2024.2",
+			expectedSupport: false,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla >= 6.0, then it is expected to support read barrier cql",
+			scyllaVersion:   "6.0.1",
+			expectedSupport: false,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla < 6.0, then it is expected to not support any safe method",
+			scyllaVersion:   "5.9.9",
+			expectedSupport: false,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla < 2024.2, then it is expected to not support any safe method",
+			scyllaVersion:   "2024.1",
+			expectedSupport: false,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla version is not a semver, then it is expected to return an error",
+			scyllaVersion:   "main",
+			expectedSupport: false,
+			expectedError:   true,
+		},
+	}
+
+	fg := featuregate.ScyllaFeatureGate{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			support, err := fg.SafeDescribeMethodReadBarrierAPI(tc.scyllaVersion)
+			if tc.expectedError != (err != nil) {
+				t.Fatalf("Expected error to be %v, got %v", tc.expectedError, err != nil)
+			}
+			if tc.expectedSupport != support {
+				t.Fatalf("Expected support to be %v, got %v", tc.expectedSupport, support)
+			}
+		})
+	}
+}
+
+func TestSafeDescribeMethodReadBarrierCQL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		scyllaVersion   string
+		expectedSupport bool
+		expectedError   bool
+	}{
+		{
+			name:            "when scylla >= 2025.1, then it is expected to support read barrier api",
+			scyllaVersion:   "2025.1.0-candidate-20241106103631",
+			expectedSupport: true,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla >= 6.1, then it is expected to support read barrier api",
+			scyllaVersion:   "6.2.1-candidate-20241106103631",
+			expectedSupport: true,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla >= 2024.2, then it is expected to support read barrier cql",
+			scyllaVersion:   "2024.2",
+			expectedSupport: true,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla >= 6.0, then it is expected to support read barrier cql",
+			scyllaVersion:   "6.0.1",
+			expectedSupport: true,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla < 6.0, then it is expected to not support any safe method",
+			scyllaVersion:   "5.9.9",
+			expectedSupport: false,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla < 2024.2, then it is expected to not support any safe method",
+			scyllaVersion:   "2024.1",
+			expectedSupport: false,
+			expectedError:   false,
+		},
+		{
+			name:            "when scylla version is not a semver, then it is expected to return an error",
+			scyllaVersion:   "main",
+			expectedSupport: false,
+			expectedError:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fg := featuregate.ScyllaFeatureGate{}
+			for _, tc := range testCases {
+				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
+					support, err := fg.SafeDescribeMethodReadBarrierCQL(tc.scyllaVersion)
+					if tc.expectedError != (err != nil) {
+						t.Fatalf("Expected error to be %v, got %v", tc.expectedError, err != nil)
+					}
+					if tc.expectedSupport != support {
+						t.Fatalf("Expected support to be %v, got %v", tc.expectedSupport, support)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestSkipCleanupAndSkipReshape(t *testing.T) {
+	testCases := []struct {
+		name          string
+		scyllaVersion string
+		expected      bool
+	}{
+		{
+			name:          "2025.3.0 is supported",
+			scyllaVersion: "2025.3.0",
+			expected:      true,
+		},
+		{
+			name:          "2025.2.1 is supported",
+			scyllaVersion: "2025.2.1",
+			expected:      true,
+		},
+		{
+			name:          "2025.2.0 is supported",
+			scyllaVersion: "2025.2.0",
+			expected:      true,
+		},
+		{
+			name:          "2025.1.0 is not supported",
+			scyllaVersion: "2025.1.0",
+			expected:      false,
+		},
+	}
+
+	fg := featuregate.ScyllaFeatureGate{}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			supported, err := fg.SkipCleanupAndSkipReshape(tc.scyllaVersion)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if supported != tc.expected {
+				t.Fatalf("expected %v, got %v", tc.expected, supported)
+			}
+		})
+	}
+}

--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -139,21 +139,6 @@ func (ni *NodeInfo) AlternatorEncryptionEnabled() bool {
 	return ni.AlternatorHTTPSPort != "0" && ni.AlternatorHTTPSPort != ""
 }
 
-// SupportsAlternatorQuery returns if Alternator supports querying system tables.
-func (ni NodeInfo) SupportsAlternatorQuery() (bool, error) {
-	// Detect master builds
-	if scyllaversion.MasterVersion(ni.ScyllaVersion) {
-		return true, nil
-	}
-
-	supports, err := scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 4.1, < 2000")
-	if err != nil {
-		return false, errors.Errorf("Unsupported Scylla version: %s", ni.ScyllaVersion)
-	}
-
-	return supports, nil
-}
-
 // AlternatorAddr returns Alternator address from NodeInfo.
 // It chooses right address and port based on information stored in NodeInfo.
 // HTTPS port has preference over HTTP.

--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -223,16 +223,6 @@ func (ni *NodeInfo) SupportsSafeDescribeSchemaWithInternals() (SafeDescribeMetho
 	return "", nil
 }
 
-// SupportsNativeRestoreAPI returns whether node exposes /storage_service/restore API.
-func (ni *NodeInfo) SupportsNativeRestoreAPI() (bool, error) {
-	// Detect master builds
-	if scyllaversion.MasterVersion(ni.ScyllaVersion) {
-		return true, nil
-	}
-	// Check ENT
-	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2025.3")
-}
-
 // ScyllaObjectStorageEndpoint returns endpoint that should be used when calling /storage_service/<backup|restore> API.
 // It also validates that agent's and Scylla's configurations match.
 func (ni *NodeInfo) ScyllaObjectStorageEndpoint(provider backupspec.Provider) (string, error) {

--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -223,16 +223,6 @@ func (ni *NodeInfo) SupportsSafeDescribeSchemaWithInternals() (SafeDescribeMetho
 	return "", nil
 }
 
-// SupportsNativeBackupAPI returns whether node exposes /storage_service/backup API.
-func (ni *NodeInfo) SupportsNativeBackupAPI() (bool, error) {
-	// Detect master builds
-	if scyllaversion.MasterVersion(ni.ScyllaVersion) {
-		return true, nil
-	}
-	// Check ENT
-	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2025.2")
-}
-
 // SupportsNativeRestoreAPI returns whether node exposes /storage_service/restore API.
 func (ni *NodeInfo) SupportsNativeRestoreAPI() (bool, error) {
 	// Detect master builds

--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -182,38 +182,6 @@ func (ni NodeInfo) AlternatorTLSEnabled() (tlsEnabled, certAuth bool) {
 	return ni.AlternatorEncryptionEnabled(), certAuth
 }
 
-// SupportsRepairSmallTableOptimization returns true if /storage_service/repair_async/{keyspace} supports small_table_optimization param.
-func (ni *NodeInfo) SupportsRepairSmallTableOptimization() (bool, error) {
-	// Detect master builds
-	if scyllaversion.MasterVersion(ni.ScyllaVersion) {
-		return true, nil
-	}
-	// Check OSS
-	supports, err := scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 6.0, < 2000")
-	if err != nil {
-		return false, errors.Errorf("Unsupported Scylla version: %s", ni.ScyllaVersion)
-	}
-	if supports {
-		return true, nil
-	}
-	// Check ENT
-	supports, err = scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2024.1.5")
-	if err != nil {
-		return false, errors.Errorf("Unsupported Scylla version: %s", ni.ScyllaVersion)
-	}
-	return supports, nil
-}
-
-// SupportsTabletRepair returns true if /storage_service/tablets/repair API is exposed.
-func (ni *NodeInfo) SupportsTabletRepair() (bool, error) {
-	// Detect master builds
-	if scyllaversion.MasterVersion(ni.ScyllaVersion) {
-		return true, nil
-	}
-	// Check ENT
-	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2025.1")
-}
-
 // SafeDescribeMethod describes supported methods to ensure that scylla schema is consistent.
 type SafeDescribeMethod string
 

--- a/pkg/scyllaclient/client_agent_test.go
+++ b/pkg/scyllaclient/client_agent_test.go
@@ -222,61 +222,6 @@ func TestNodeInfoCQLSSLAddr(t *testing.T) {
 	}
 }
 
-func TestNodeInfoSupportsRepairSmallTableOptimization(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		scyllaVer string
-		expected  bool
-	}{
-		{
-			scyllaVer: "2024.1.4",
-			expected:  false,
-		},
-		{
-			scyllaVer: "2024.2.5",
-			expected:  true,
-		},
-		{
-			scyllaVer: "2024.2.6",
-			expected:  true,
-		},
-		{
-			scyllaVer: "5.4.9",
-			expected:  false,
-		},
-		{
-			scyllaVer: "5.5.0",
-			expected:  false,
-		},
-		{
-			scyllaVer: "6.0.0",
-			expected:  true,
-		},
-		{
-			scyllaVer: "6.0.1",
-			expected:  true,
-		},
-		{
-			scyllaVer: "6.1.0",
-			expected:  true,
-		},
-	}
-
-	for _, tc := range testCases {
-		ni := scyllaclient.NodeInfo{
-			ScyllaVersion: tc.scyllaVer,
-		}
-		result, err := ni.SupportsRepairSmallTableOptimization()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if result != tc.expected {
-			t.Fatalf("expected {%v}, but got {%v}, version = {%s}", tc.expected, result, tc.scyllaVer)
-		}
-	}
-}
-
 func TestSupportsSafeDescribeSchemaWithInternals(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/scyllaclient/client_agent_test.go
+++ b/pkg/scyllaclient/client_agent_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/agent/models"
@@ -220,85 +219,6 @@ func TestNodeInfoCQLSSLAddr(t *testing.T) {
 				t.Errorf("expected %s address, got %s", test.GoldenAddress, addr)
 			}
 		})
-	}
-}
-
-func TestNodeInfoSupportsAlternatorQuery(t *testing.T) {
-	t.Parallel()
-
-	table := []struct {
-		Version string
-		Golden  bool
-	}{
-		{
-			Version: "2019.1.2-0.20190814.2772d52",
-			Golden:  false,
-		},
-		{
-			Version: "3.1.0-0.20191012.9c3cdded9",
-			Golden:  false,
-		},
-		{
-			Version: "3.2.2-0.20200222.0b23e7145d0",
-			Golden:  false,
-		},
-		{
-			Version: "666.development",
-			Golden:  true,
-		},
-		{
-			Version: "9999.enterprise_dev",
-			Golden:  true,
-		},
-		{
-			Version: "3.3.rc2",
-			Golden:  false,
-		},
-		{
-			Version: "3.1.hotfix",
-			Golden:  false,
-		},
-		{
-			Version: "3.0.rc8",
-			Golden:  false,
-		},
-		{
-			Version: "2019.1.1-2.reader_concurrency_semaphore.20190730.f0071c669",
-			Golden:  false,
-		},
-		{
-			Version: "2019.1.5-2.many_tables.20200311.be960ed96",
-			Golden:  false,
-		},
-		{
-			Version: "4.0.0",
-			Golden:  false,
-		},
-		{
-			Version: "4.1.0",
-			Golden:  true,
-		},
-		{
-			Version: "2020.1",
-			Golden:  false,
-		},
-		{
-			Version: "2021.1",
-			Golden:  false,
-		},
-	}
-
-	for i := range table {
-		test := table[i]
-
-		supports, err := scyllaclient.NodeInfo{ScyllaVersion: test.Version}.SupportsAlternatorQuery()
-		if err != nil {
-			t.Error(err)
-		}
-
-		if !cmp.Equal(supports, test.Golden) {
-			t.Errorf("SupportsAlternatorQuery(%s) = %+v, expected %+v", test.Version, supports, test.Golden)
-		}
 	}
 }
 

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/scylla-manager/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/featuregate"
 	"github.com/scylladb/scylla-manager/v3/pkg/util"
 	"github.com/scylladb/scylla-manager/v3/pkg/util2/maps"
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/agent/models"
@@ -144,6 +145,7 @@ func newTestServiceWithUser(t *testing.T, session gocqlx.Session, client *scylla
 		session,
 		c,
 		metrics.NewBackupMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(_ context.Context, id uuid.UUID) (string, error) {
 			return "test_cluster", nil
 		},
@@ -2532,7 +2534,7 @@ func TestBackupMethodIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	support, err := ni.SupportsNativeBackupAPI()
+	support, err := featuregate.ScyllaMasterFeatureGate{}.NativeBackup(ni.ScyllaVersion)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/service/backup/worker.go
+++ b/pkg/service/backup/worker.go
@@ -65,6 +65,7 @@ type workerTools struct {
 	Method      Method
 	Config      Config
 	Client      *scyllaclient.Client
+	FG          ScyllaFeatureGate
 	Logger      log.Logger
 }
 

--- a/pkg/service/backup/worker_scylla_upload.go
+++ b/pkg/service/backup/worker_scylla_upload.go
@@ -13,8 +13,8 @@ import (
 )
 
 // hostNativeBackupSupport validates that native backup API can be used for given host.
-func hostNativeBackupSupport(ni *scyllaclient.NodeInfo, loc backupspec.Location) error {
-	ok, err := ni.SupportsNativeBackupAPI()
+func hostNativeBackupSupport(fg ScyllaFeatureGate, ni *scyllaclient.NodeInfo, loc backupspec.Location) error {
+	ok, err := fg.NativeBackup(ni.ScyllaVersion)
 	if err != nil {
 		return errors.Wrap(err, "check native backup api support")
 	}
@@ -30,7 +30,7 @@ func hostNativeBackupSupport(ni *scyllaclient.NodeInfo, loc backupspec.Location)
 
 // hostNativeBackupSupport is the regular hostNativeBackupSupport with logging on error.
 func (w *worker) hostNativeBackupSupport(ctx context.Context, host string, ni *scyllaclient.NodeInfo, loc backupspec.Location) error {
-	err := hostNativeBackupSupport(ni, loc)
+	err := hostNativeBackupSupport(w.FG, ni, loc)
 	if err != nil {
 		w.Logger.Info(ctx, "Can't use native backup api", "host", host, "error", err)
 	}

--- a/pkg/service/healthcheck/service.go
+++ b/pkg/service/healthcheck/service.go
@@ -309,9 +309,7 @@ func (s *Service) pingAlternator(ctx context.Context, _ uuid.UUID, host string, 
 
 	pingFunc := dynamoping.SimplePing
 	if !config.RequiresAuthentication {
-		if queryPing, err := ni.SupportsAlternatorQuery(); err == nil && queryPing {
-			pingFunc = dynamoping.QueryPing
-		}
+		pingFunc = dynamoping.QueryPing
 	}
 
 	tlsConfig := ni.AlternatorTLSConfig()

--- a/pkg/service/one2onerestore/helpers_integration_test.go
+++ b/pkg/service/one2onerestore/helpers_integration_test.go
@@ -175,6 +175,7 @@ func newRestoreSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient
 		configCacheSvc,
 		log.NewDevelopmentWithLevel(zapcore.InfoLevel).Named("1-1-restore"),
 		metrics.NewOne2OneRestoreMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/service/one2onerestore/helpers_integration_test.go
+++ b/pkg/service/one2onerestore/helpers_integration_test.go
@@ -123,6 +123,7 @@ func newBackupSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient.
 		mgrSession,
 		defaultBackupTestConfig(),
 		metrics.NewBackupMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(_ context.Context, id uuid.UUID) (string, error) {
 			return "test_cluster", nil
 		},

--- a/pkg/service/one2onerestore/helpers_integration_test.go
+++ b/pkg/service/one2onerestore/helpers_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/service/repair"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/featuregate"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testhelper"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 	"go.uber.org/zap/zapcore"
@@ -147,6 +148,7 @@ func newRestoreSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient
 		mgrSession,
 		repair.DefaultConfig(),
 		metrics.NewRepairMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
 			return client, nil
 		},

--- a/pkg/service/one2onerestore/worker_validate_integration_test.go
+++ b/pkg/service/one2onerestore/worker_validate_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
 	"github.com/scylladb/scylla-manager/v3/pkg/testutils"
 	"github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/featuregate"
 	"github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/httpx"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
@@ -262,6 +263,7 @@ func newTestWorker(t *testing.T, hosts []string) (*worker, *testutils.HackableRo
 		},
 		logger:  log.NopLogger,
 		metrics: metrics.NewOne2OneRestoreMetrics(),
+		fg:      featuregate.ScyllaMasterFeatureGate{},
 	}
 	return w, hrt
 }

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/featuregate"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/httpx"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
@@ -43,7 +44,7 @@ var globalNodeInfo *scyllaclient.NodeInfo
 func tabletRepairSupport(t *testing.T) bool {
 	t.Helper()
 
-	ok, err := globalNodeInfo.SupportsTabletRepair()
+	ok, err := featuregate.ScyllaMasterFeatureGate{}.TabletRepair(globalNodeInfo.ScyllaVersion)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/schema/table"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/scheduler"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/featuregate"
 	"github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testhelper"
@@ -338,6 +339,7 @@ func newTestService(t *testing.T, session gocqlx.Session, client *scyllaclient.C
 		session,
 		c,
 		metrics.NewRepairMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
 			return client, nil
 		},
@@ -361,6 +363,7 @@ func newTestServiceWithClusterSession(t *testing.T, session gocqlx.Session, clie
 		session,
 		c,
 		metrics.NewRepairMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
 			return client, nil
 		},
@@ -1716,7 +1719,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		defer cancel()
 
 		// Check small_table_optimization support
-		support, err := globalNodeInfo.SupportsRepairSmallTableOptimization()
+		support, err := featuregate.ScyllaMasterFeatureGate{}.RepairSmallTableOptimization(globalNodeInfo.ScyllaVersion)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/service/restore/helper_integration_test.go
+++ b/pkg/service/restore/helper_integration_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/scylladb/gocqlx/v2/qb"
 	"github.com/scylladb/scylla-manager/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/featuregate"
 	"github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"go.uber.org/zap/zapcore"
 
@@ -153,6 +154,7 @@ func newRestoreSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient
 		mgrSession,
 		repair.DefaultConfig(),
 		metrics.NewRepairMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
 			return client, nil
 		},

--- a/pkg/service/restore/helper_integration_test.go
+++ b/pkg/service/restore/helper_integration_test.go
@@ -174,6 +174,7 @@ func newRestoreSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient
 		mgrSession,
 		defaultTestConfig(),
 		metrics.NewRestoreMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
 			return client, nil
 		},

--- a/pkg/service/restore/helper_integration_test.go
+++ b/pkg/service/restore/helper_integration_test.go
@@ -129,6 +129,7 @@ func newBackupSvc(t *testing.T, mgrSession gocqlx.Session, client *scyllaclient.
 		mgrSession,
 		defaultBackupTestConfig(),
 		metrics.NewBackupMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(_ context.Context, id uuid.UUID) (string, error) {
 			return "test_cluster", nil
 		},

--- a/pkg/service/restore/restore_integration_test.go
+++ b/pkg/service/restore/restore_integration_test.go
@@ -495,7 +495,7 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	nativeRestoreSupport, err := ni.SupportsNativeRestoreAPI()
+	nativeRestoreSupport, err := featuregate.ScyllaMasterFeatureGate{}.NativeRestore(ni.ScyllaVersion)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/service/restore/restore_integration_test.go
+++ b/pkg/service/restore/restore_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/service/restore"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/featuregate"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/httpx"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/maputil"
@@ -490,7 +491,7 @@ func TestRestoreTablesPreparationIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	nativeBackupSupport, err := ni.SupportsNativeBackupAPI()
+	nativeBackupSupport, err := featuregate.ScyllaMasterFeatureGate{}.NativeBackup(ni.ScyllaVersion)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/service/repair"
 	. "github.com/scylladb/scylla-manager/v3/pkg/service/restore"
 	"github.com/scylladb/scylla-manager/v3/pkg/sstable"
+	"github.com/scylladb/scylla-manager/v3/pkg/testutils/featuregate"
 	"github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testhelper"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/jsonutil"
@@ -121,6 +122,7 @@ func newTestService(t *testing.T, session gocqlx.Session, client *scyllaclient.C
 		session,
 		repair.DefaultConfig(),
 		metrics.NewRepairMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
 			return client, nil
 		},

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -162,6 +162,7 @@ func newTestService(t *testing.T, session gocqlx.Session, client *scyllaclient.C
 		session,
 		c,
 		metrics.NewRestoreMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(context.Context, uuid.UUID) (*scyllaclient.Client, error) {
 			return client, nil
 		},

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -140,6 +140,7 @@ func newTestService(t *testing.T, session gocqlx.Session, client *scyllaclient.C
 		session,
 		defaultBackupTestConfig(),
 		metrics.NewBackupMetrics(),
+		featuregate.ScyllaMasterFeatureGate{},
 		func(_ context.Context, id uuid.UUID) (string, error) {
 			return "test_cluster", nil
 		},

--- a/pkg/service/restore/worker.go
+++ b/pkg/service/restore/worker.go
@@ -41,6 +41,7 @@ type worker struct {
 	config  Config
 	logger  log.Logger
 	metrics metrics.RestoreMetrics
+	fg      ScyllaFeatureGate
 
 	client         *scyllaclient.Client
 	session        gocqlx.Session

--- a/pkg/service/restore/worker_scylla_restore.go
+++ b/pkg/service/restore/worker_scylla_restore.go
@@ -21,7 +21,7 @@ import (
 
 // hostScyllaRestoreSupport checks if native restore API is supported for given host.
 func (w *tablesWorker) hostScyllaRestoreSupport(ctx context.Context, host string, nc configcache.NodeConfig) bool {
-	ok, err := nc.SupportsNativeRestoreAPI()
+	ok, err := w.fg.NativeRestore(nc.ScyllaVersion)
 	if err != nil || !ok {
 		w.logger.Info(ctx, "Can't use Scylla restore API with given Scylla version",
 			"host", host,

--- a/pkg/testutils/featuregate/featuregate.go
+++ b/pkg/testutils/featuregate/featuregate.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2025 ScyllaDB
+
+package featuregate
+
+import (
+	"strings"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/featuregate"
+)
+
+// ScyllaMasterFeatureGate is a special feature gate which assumes that all
+// features are available on scylla versions from master branch.
+// Otherwise, it works the same as featuregate.ScyllaFeatureGate.
+type ScyllaMasterFeatureGate struct{}
+
+// RepairSmallTableOptimization - true.
+func (fg ScyllaMasterFeatureGate) RepairSmallTableOptimization(version string) (bool, error) {
+	if isScyllaMaster(version) {
+		return true, nil
+	}
+	return featuregate.ScyllaFeatureGate{}.RepairSmallTableOptimization(version)
+}
+
+// TabletRepair - true.
+func (fg ScyllaMasterFeatureGate) TabletRepair(version string) (bool, error) {
+	if isScyllaMaster(version) {
+		return true, nil
+	}
+	return featuregate.ScyllaFeatureGate{}.TabletRepair(version)
+}
+
+// SafeDescribeMethodReadBarrierAPI - true.
+func (fg ScyllaMasterFeatureGate) SafeDescribeMethodReadBarrierAPI(version string) (bool, error) {
+	if isScyllaMaster(version) {
+		return true, nil
+	}
+	return featuregate.ScyllaFeatureGate{}.SafeDescribeMethodReadBarrierAPI(version)
+}
+
+// SafeDescribeMethodReadBarrierCQL - true.
+func (fg ScyllaMasterFeatureGate) SafeDescribeMethodReadBarrierCQL(version string) (bool, error) {
+	if isScyllaMaster(version) {
+		return true, nil
+	}
+	return featuregate.ScyllaFeatureGate{}.SafeDescribeMethodReadBarrierCQL(version)
+}
+
+// NativeBackup - true.
+func (fg ScyllaMasterFeatureGate) NativeBackup(version string) (bool, error) {
+	if isScyllaMaster(version) {
+		return true, nil
+	}
+	return featuregate.ScyllaFeatureGate{}.NativeBackup(version)
+}
+
+// NativeRestore - true.
+func (fg ScyllaMasterFeatureGate) NativeRestore(version string) (bool, error) {
+	if isScyllaMaster(version) {
+		return true, nil
+	}
+	return featuregate.ScyllaFeatureGate{}.NativeRestore(version)
+}
+
+// SkipCleanupAndSkipReshape - true.
+func (fg ScyllaMasterFeatureGate) SkipCleanupAndSkipReshape(version string) (bool, error) {
+	if isScyllaMaster(version) {
+		return true, nil
+	}
+	return featuregate.ScyllaFeatureGate{}.SkipCleanupAndSkipReshape(version)
+}
+
+func isScyllaMaster(version string) bool {
+	version = strings.Split(version, "-")[0]
+	return strings.Contains(version, "dev")
+}


### PR DESCRIPTION
This PR tackles #4484 by getting rid of using direct NodeInfo methods for checking scylla features availability.
The were problematic, because they used `version.MasterVersion` that doesn't work and it's difficult to make it work robustly for a production code.
Instead, this PR introduces feature gates:
- `ScyllaFeatureGate` - used in production - does not try to detect master version at all
- `ScyllaMasterFeatureGate` - used in tests - tries to detect master version by looking for `dev` substring (this method might not work in production for custom builds) 

This PR also removes the NodeInfo methods from the code, so that they are not used by mistake.

Finally, this PR allows for removing assumption that native restore will be ready to use in scylla 2025.3 without impacting the ability to test it against scylla master builds. This assumption is just guessing and we can't release any SM version with such a check.

Fixes #4484
