### PR TITLE
fix(1-1-restore): set skip_{cleanup|reshape} only for scylla > 2025.2.0

### DIFF
--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -320,7 +320,7 @@ func (ni *NodeInfo) SupportsSkipCleanupAndSkipReshape() (bool, error) {
 	}
 
 	// Check ENT
-	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2025.2.0")
+	return scyllaversion.CheckConstraint(ni.ScyllaVersion, "> 2025.2.0")
 }
 
 // FreeOSMemory calls debug.FreeOSMemory on the agent to return memory to OS.

--- a/pkg/scyllaclient/client_agent_test.go
+++ b/pkg/scyllaclient/client_agent_test.go
@@ -688,9 +688,9 @@ func TestNodeInfoSupportsSkipCleanupAndSkipReshape(t *testing.T) {
 			expected:      true,
 		},
 		{
-			name:          "2025.2.0 is supported",
+			name:          "2025.2.0 is not supported",
 			scyllaVersion: "2025.2.0",
-			expected:      true,
+			expected:      false,
 		},
 		{
 			name:          "2025.1.0 is not supported",


### PR DESCRIPTION
This changes the scylla version check to > 2025.2.0, so we do not set skip_cleanup and skip_reshape parameters for 2025.2.0.

P.S.
This is needed to reflect changes made to 3.6 branch: #4483 

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
