### PR TITLE
Always fill options on provider registration

### DIFF
--- a/pkg/rclone/providers.go
+++ b/pkg/rclone/providers.go
@@ -49,6 +49,7 @@ func RegisterS3Provider(opts S3Options) error {
 		backend = "s3"
 	)
 
+	opts.AutoFill()
 	if err := opts.Validate(); err != nil {
 		return err
 	}
@@ -77,6 +78,8 @@ func RegisterGCSProvider(opts GCSOptions) error {
 		backend = "gcs"
 	)
 
+	opts.AutoFill()
+
 	return errors.Wrap(registerProvider(name, backend, opts), "register provider")
 }
 
@@ -87,6 +90,8 @@ func RegisterAzureProvider(opts AzureOptions) error {
 		name    = "azure"
 		backend = "azureblob"
 	)
+
+	opts.AutoFill()
 
 	return errors.Wrap(registerProvider(name, backend, opts), "register provider")
 }


### PR DESCRIPTION
This reverts part of the a64bf059 commit which moved provider options filling to the top of agent root command in order to utilize filled options in node info handler.
The problem is that it also removed provider options filling from functions registering providers. It worked fine for the agent root command, but it resulted in not filling provider options in other sm-agent commands (e.g. 'scylla-manager-agent check-location').