### PR TITLE
Bump golangci-lint to 1.64.8

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,7 +46,6 @@ linters:
     - gochecknoglobals
     - gochecknoinits
     - err113
-    - gomnd
     - ireturn
     - nilerr
     - nlreturn
@@ -58,9 +57,10 @@ linters:
     - varnamelen
     - wrapcheck
     - wsl
-    - exportloopref
-    - execinquery
     - mnd
+    - tenv
+    - gomoddirectives
+    - recvcheck
 
 issues:
   exclude-files:

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -35,7 +35,7 @@ rm -f "${LOCAL_BIN}"/*
 echo "==> Installing Go packages at ${LOCAL_BIN}"
 
 export GOBIN=${LOCAL_BIN}
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
 go install github.com/goreleaser/goreleaser@v1.14.1
 go install github.com/go-enry/go-license-detector/v4/cmd/license-detector@latest
 go install github.com/golang/mock/mockgen@v1.6.0

--- a/pkg/rclone/rcserver/rcserver.go
+++ b/pkg/rclone/rcserver/rcserver.go
@@ -129,7 +129,7 @@ func isBadRequestErr(err error) bool {
 	cause := errors.Cause(err)
 	return rc.IsErrParamInvalid(err) ||
 		rc.IsErrParamNotFound(err) ||
-		IsErrParamInvalid(err) ||
+		IsParamInvalidError(err) ||
 		cause == fs.ErrorIsFile ||
 		cause == fs.ErrorNotAFile ||
 		cause == fs.ErrorDirectoryNotEmpty ||
@@ -309,19 +309,19 @@ func validateFsName(in rc.Params) error {
 			return err
 		}
 		if !rclone.HasProvider(remote) {
-			return errParamInvalid{errors.Errorf("invalid provider %s in %s param", remote, name)}
+			return paramInvalidError{errors.Errorf("invalid provider %s in %s param", remote, name)}
 		}
 	}
 	return nil
 }
 
-type errParamInvalid struct {
+type paramInvalidError struct {
 	error
 }
 
-// IsErrParamInvalid checks if the provided error is invalid.
+// IsParamInvalidError checks if the provided error is invalid.
 // Added as a workaround for private error field of fs.ErrParamInvalid.
-func IsErrParamInvalid(err error) bool {
-	_, ok := err.(errParamInvalid) // nolint: errorlint
+func IsParamInvalidError(err error) bool {
+	_, ok := err.(paramInvalidError) // nolint: errorlint
 	return ok
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -37,7 +37,7 @@ var (
 func newRunContext[K comparable](key K, properties Properties, stop time.Time) (*RunContext[K], context.CancelCauseFunc) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	if !stop.IsZero() {
-		ctx, _ = context.WithDeadlineCause(ctx, stop, ErrOutOfWindowTask)
+		ctx, _ = context.WithDeadlineCause(ctx, stop, ErrOutOfWindowTask) // nolint:govet
 	}
 
 	return &RunContext[K]{


### PR DESCRIPTION
Previous version wasn't working correctly with go 1.24. This commit also removes deprecated linters and disables:
- gomoddirectives - since we rely on replace go mod directive
- recvcheck - we have many places where (usually because of marshalling), we have both struct and pointer receivers