### PR TITLE
Swagger: scylla-manager, add definitions for alternator creds

### DIFF
--- a/v3/swagger/gen/scylla-manager/client/operations/delete_cluster_cluster_id_parameters.go
+++ b/v3/swagger/gen/scylla-manager/client/operations/delete_cluster_cluster_id_parameters.go
@@ -62,6 +62,8 @@ for the delete cluster cluster ID operation typically these are written to a htt
 */
 type DeleteClusterClusterIDParams struct {
 
+	/*AlternatorCreds*/
+	AlternatorCreds *bool
 	/*ClusterID*/
 	ClusterID string
 	/*CqlCreds*/
@@ -107,6 +109,17 @@ func (o *DeleteClusterClusterIDParams) SetHTTPClient(client *http.Client) {
 	o.HTTPClient = client
 }
 
+// WithAlternatorCreds adds the alternatorCreds to the delete cluster cluster ID params
+func (o *DeleteClusterClusterIDParams) WithAlternatorCreds(alternatorCreds *bool) *DeleteClusterClusterIDParams {
+	o.SetAlternatorCreds(alternatorCreds)
+	return o
+}
+
+// SetAlternatorCreds adds the alternatorCreds to the delete cluster cluster ID params
+func (o *DeleteClusterClusterIDParams) SetAlternatorCreds(alternatorCreds *bool) {
+	o.AlternatorCreds = alternatorCreds
+}
+
 // WithClusterID adds the clusterID to the delete cluster cluster ID params
 func (o *DeleteClusterClusterIDParams) WithClusterID(clusterID string) *DeleteClusterClusterIDParams {
 	o.SetClusterID(clusterID)
@@ -147,6 +160,22 @@ func (o *DeleteClusterClusterIDParams) WriteToRequest(r runtime.ClientRequest, r
 		return err
 	}
 	var res []error
+
+	if o.AlternatorCreds != nil {
+
+		// query param alternator_creds
+		var qrAlternatorCreds bool
+		if o.AlternatorCreds != nil {
+			qrAlternatorCreds = *o.AlternatorCreds
+		}
+		qAlternatorCreds := swag.FormatBool(qrAlternatorCreds)
+		if qAlternatorCreds != "" {
+			if err := r.SetQueryParam("alternator_creds", qAlternatorCreds); err != nil {
+				return err
+			}
+		}
+
+	}
 
 	// path param cluster_id
 	if err := r.SetPathParam("cluster_id", o.ClusterID); err != nil {

--- a/v3/swagger/gen/scylla-manager/models/cluster.go
+++ b/v3/swagger/gen/scylla-manager/models/cluster.go
@@ -15,6 +15,12 @@ import (
 // swagger:model Cluster
 type Cluster struct {
 
+	// alternator access key id
+	AlternatorAccessKeyID string `json:"alternator_access_key_id,omitempty"`
+
+	// alternator secret access key
+	AlternatorSecretAccessKey string `json:"alternator_secret_access_key,omitempty"`
+
 	// auth token
 	AuthToken string `json:"auth_token,omitempty"`
 

--- a/v3/swagger/scylla-manager.json
+++ b/v3/swagger/scylla-manager.json
@@ -44,6 +44,12 @@
         "password": {
           "type": "string"
         },
+        "alternator_access_key_id": {
+          "type": "string"
+        },
+        "alternator_secret_access_key": {
+          "type": "string"
+        },
         "labels": {
           "type": "object",
           "additionalProperties": {
@@ -1498,6 +1504,11 @@
           {
             "type": "boolean",
             "name": "cql_creds",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "name": "alternator_creds",
             "in": "query"
           },
           {


### PR DESCRIPTION
Alternator credentials need to be handled similarly to CQL credentials.
User should be able to add them with `sctool cluster <add|update> --alternator-access-key-id  --alternator-secret-access-key`.
User should be able to delete them with `sctool cluster update --delete-alternator-credentials`.
User should be able to check if the credentials are set with `sctool status`.

Refs #4510
