### PR TITLE
Backupspec: add alternator schema format and path

### DIFF
--- a/backupspec/go.mod
+++ b/backupspec/go.mod
@@ -3,6 +3,7 @@ module github.com/scylladb/scylla-manager/backupspec
 go 1.23.2
 
 require (
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.46.0
 	github.com/gocql/gocql v1.6.0
 	github.com/google/go-cmp v0.6.0
 	github.com/json-iterator/go v1.1.12
@@ -12,6 +13,7 @@ require (
 )
 
 require (
+	github.com/aws/smithy-go v1.22.5 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed // indirect

--- a/backupspec/go.sum
+++ b/backupspec/go.sum
@@ -1,3 +1,7 @@
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.46.0 h1:b7F96mjkzsqymMSGhuCqBQTZFx3mhTMa6IoG6SoVvC8=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.46.0/go.mod h1:F8Rqs4FVGBTUzx3wbFm7HB/mgIA4Tc6/x0yQmjoB+/w=
+github.com/aws/smithy-go v1.22.5 h1:P9ATCXPMb2mPjYBgueqJNCA5S9UfktsW0tTxi+a7eqw=
+github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 h1:mXoPYz/Ul5HYEDvkta6I8/rnYM5gSdSV2tJ6XbZuEtY=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
@@ -32,8 +36,7 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250123113205-a6303e03d168 h1:ua8SUnAgg1soc8zP5TInWfNpoWilBah8Mavdll7TxTs=
-github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250123113205-a6303e03d168/go.mod h1:VKqHSrDj9zfgCKilpbdpmqV1TjmSglt/df79eIg6wuI=
+github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250530081649-30bcf253e6a6 h1:Tjt1RNnyWP+7Z32BUn2Q31gYrYCz2QszmNy6GnXhM2c=
 github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250530081649-30bcf253e6a6/go.mod h1:VKqHSrDj9zfgCKilpbdpmqV1TjmSglt/df79eIg6wuI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/backupspec/paths.go
+++ b/backupspec/paths.go
@@ -21,6 +21,8 @@ const (
 	// UnsafeSchema is the name of the schema file that shouldn't be used for restore
 	// (so for Scylla versions older than 6.0).
 	UnsafeSchema = "schema.tar.gz"
+	// AlternatorSchemaFileSuffix is the suffix of all alternator schema files.
+	AlternatorSchemaFileSuffix = "alternator_schema.json.gz"
 	// TempFileExt is suffix for the temporary files.
 	TempFileExt = ".tmp"
 
@@ -121,6 +123,35 @@ func RemoteUnsafeSchemaFile(clusterID, taskID uuid.UUID, snapshotTag string) str
 		remoteSchemaDir(clusterID),
 		manifestName,
 	)
+}
+
+// AlternatorSchemaPath returns path to the alternator schema file starting at backup dir root.
+// It has the following format: 'backup/schema/cluster/<cluster_ID>/task_<task_ID>_tag_<snapshot_tag>_alternator_schema.json.gz'.
+func AlternatorSchemaPath(clusterID, taskID uuid.UUID, snapshotTag string) string {
+	return path.Join(
+		remoteSchemaDir(clusterID),
+		AlternatorSchemaFile(taskID, snapshotTag),
+	)
+}
+
+// AlternatorSchemaFile returns full name (without path) of the alternator schema file.
+// It has the following format: 'task_<task_ID>_tag_<snapshot_tag>_alternator_schema.json.gz'.
+func AlternatorSchemaFile(taskID uuid.UUID, snapshotTag string) string {
+	return strings.Join([]string{
+		"task",
+		taskID.String(),
+		AlternatorSchemaFileSuffixWithTag(snapshotTag),
+	}, "_")
+}
+
+// AlternatorSchemaFileSuffixWithTag returns AlternatorSchemaFileSuffix extended with snapshot tag.
+// It has the following format: 'tag_<snapshot_tag>_alternator_schema.json.gz'.
+func AlternatorSchemaFileSuffixWithTag(snapshotTag string) string {
+	return strings.Join([]string{
+		"tag",
+		snapshotTag,
+		AlternatorSchemaFileSuffix,
+	}, "_")
 }
 
 func remoteSchemaDir(clusterID uuid.UUID) string {

--- a/backupspec/paths_test.go
+++ b/backupspec/paths_test.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 ScyllaDB
+
+package backupspec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+)
+
+func TestAlternatorSchemaPaths(t *testing.T) {
+	var (
+		clusterID   = uuid.NewTime()
+		taskID      = uuid.NewTime()
+		snapshotTag = SnapshotTagAt(timeutc.Now())
+	)
+
+	t.Run("AlternatorSchemaFileSuffixWithTag", func(t *testing.T) {
+		expected := fmt.Sprintf("tag_%s_alternator_schema.json.gz", snapshotTag)
+		if got := AlternatorSchemaFileSuffixWithTag(snapshotTag); got != expected {
+			t.Fatalf("Expected: %s, got: %s", expected, got)
+		}
+	})
+
+	t.Run("AlternatorSchemaFile", func(t *testing.T) {
+		expected := fmt.Sprintf("task_%s_tag_%s_alternator_schema.json.gz", taskID, snapshotTag)
+		if got := AlternatorSchemaFile(taskID, snapshotTag); got != expected {
+			t.Fatalf("Expected: %s, got: %s", expected, got)
+		}
+	})
+
+	t.Run("AlternatorSchemaPath", func(t *testing.T) {
+		expected := fmt.Sprintf("backup/schema/cluster/%s/task_%s_tag_%s_alternator_schema.json.gz", clusterID, taskID, snapshotTag)
+		if got := AlternatorSchemaPath(clusterID, taskID, snapshotTag); got != expected {
+			t.Fatalf("Expected: %s, got: %s", expected, got)
+		}
+	})
+}

--- a/backupspec/schema.go
+++ b/backupspec/schema.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2025 ScyllaDB
+
+package backupspec
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// AlternatorSchema defines the json format of the whole alternator schema file.
+type AlternatorSchema struct {
+	Tables []AlternatorTableSchema `json:"tables,omitempty"`
+}
+
+// AlternatorTableSchema defines the json format of the table alternator schema.
+type AlternatorTableSchema struct {
+	Describe *types.TableDescription      `json:"describe,omitempty"`
+	Tags     []types.Tag                  `json:"tags,omitempty"`
+	TTL      *types.TimeToLiveDescription `json:"ttl,omitempty"`
+}


### PR DESCRIPTION
This PR extends `backupspec` with alternator schema format and paths needed for backing up alternator schema.

Refs #4528
Refs #4512
