### PR TITLE
Fix sm 3.6 release

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -1,16 +1,16 @@
 RELEASE      := 0.$(shell date +%Y%m%d).$(shell git describe --always)
-VERSION=3.6.0
+VERSION      ?=3.6.0
 PUBLISH      := 0
 
 ifdef $$VERSION
-VERSION=3.6.0
+VERSION := $$VERSION
 endif
 
 ifeq ($(PUBLISH),0)
 publish = --skip=publish
-VERSION=3.6.0
+VERSION_NAME := $(VERSION)-$(RELEASE)
 else
-VERSION=3.6.0
+VERSION_NAME := v$(VERSION)
 endif
 
 $(shell echo $(VERSION) > .version)


### PR DESCRIPTION
It seems that https://github.com/scylladb/scylla-pkg/issues/5242 is still not fully fixed.
The [3.6.0 release job](https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.6/job/manager-release/1/) broke the version file again - this commits fixes that by reverting this change.
