### PR TITLE
Force update config cache before reading it

### DIFF
--- a/pkg/service/backup/validation.go
+++ b/pkg/service/backup/validation.go
@@ -149,6 +149,9 @@ func (s *Service) Validate(ctx context.Context, clusterID, taskID, runID uuid.UU
 		}
 	}
 
+	if ok := s.configCache.ForceUpdateCluster(ctx, clusterID); !ok {
+		return errors.New("failed to force update cluster config cache")
+	}
 	rawNodeConfig, err := s.configCache.ReadAll(clusterID)
 	if err != nil {
 		return errors.Wrap(err, "read all nodes config")

--- a/pkg/service/restore/service.go
+++ b/pkg/service/restore/service.go
@@ -186,6 +186,9 @@ func (s *Service) newWorker(ctx context.Context, clusterID uuid.UUID) (worker, e
 	if err != nil {
 		return worker{}, errors.Wrap(err, "get CQL cluster session")
 	}
+	if ok := s.configCache.ForceUpdateCluster(ctx, clusterID); !ok {
+		return worker{}, errors.New("failed to force update cluster config cache")
+	}
 	rawNodeConfig, err := s.configCache.ReadAll(clusterID)
 	if err != nil {
 		return worker{}, errors.Wrap(err, "read all nodes config")


### PR DESCRIPTION
Even though SM does not handle topology changes during backup/restore/repair tasks, we still should respect those which finish right before task is executed, but before config cache is updated.

Fixes #4524
