### PR TITLE
Handle alternator creds

### DIFF
--- a/pkg/restapi/mock_clusterservice_test.go
+++ b/pkg/restapi/mock_clusterservice_test.go
@@ -36,6 +36,21 @@ func (m *MockClusterService) EXPECT() *MockClusterServiceMockRecorder {
 	return m.recorder
 }
 
+// CheckAlternatorCredentials mocks base method.
+func (m *MockClusterService) CheckAlternatorCredentials(arg0 uuid.UUID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckAlternatorCredentials", arg0)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckAlternatorCredentials indicates an expected call of CheckAlternatorCredentials.
+func (mr *MockClusterServiceMockRecorder) CheckAlternatorCredentials(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAlternatorCredentials", reflect.TypeOf((*MockClusterService)(nil).CheckAlternatorCredentials), arg0)
+}
+
 // CheckCQLCredentials mocks base method.
 func (m *MockClusterService) CheckCQLCredentials(arg0 uuid.UUID) (bool, error) {
 	m.ctrl.T.Helper()
@@ -49,6 +64,20 @@ func (m *MockClusterService) CheckCQLCredentials(arg0 uuid.UUID) (bool, error) {
 func (mr *MockClusterServiceMockRecorder) CheckCQLCredentials(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckCQLCredentials", reflect.TypeOf((*MockClusterService)(nil).CheckCQLCredentials), arg0)
+}
+
+// DeleteAlternatorCredentials mocks base method.
+func (m *MockClusterService) DeleteAlternatorCredentials(arg0 context.Context, arg1 uuid.UUID) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAlternatorCredentials", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteAlternatorCredentials indicates an expected call of DeleteAlternatorCredentials.
+func (mr *MockClusterServiceMockRecorder) DeleteAlternatorCredentials(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAlternatorCredentials", reflect.TypeOf((*MockClusterService)(nil).DeleteAlternatorCredentials), arg0, arg1)
 }
 
 // DeleteCQLCredentials mocks base method.

--- a/pkg/restapi/services.go
+++ b/pkg/restapi/services.go
@@ -38,6 +38,8 @@ type ClusterService interface {
 	DeleteCluster(ctx context.Context, id uuid.UUID) error
 	CheckCQLCredentials(id uuid.UUID) (bool, error)
 	DeleteCQLCredentials(ctx context.Context, id uuid.UUID) error
+	CheckAlternatorCredentials(id uuid.UUID) (bool, error)
+	DeleteAlternatorCredentials(ctx context.Context, id uuid.UUID) error
 	DeleteSSLUserCert(ctx context.Context, id uuid.UUID) error
 	ListNodes(ctx context.Context, id uuid.UUID) ([]cluster.Node, error)
 }

--- a/pkg/secrets/alternatorcreds.go
+++ b/pkg/secrets/alternatorcreds.go
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 ScyllaDB
+
+package secrets
+
+import (
+	"encoding/json"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/store"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
+)
+
+// AlternatorCreds specifies alternator credentials to cluster.
+type AlternatorCreds struct {
+	ClusterID       uuid.UUID `json:"-"`
+	AccessKeyID     string    `json:"access_key_id"`
+	SecretAccessKey string    `json:"secret_access_key"`
+}
+
+var _ store.Entry = &AlternatorCreds{}
+
+func (v *AlternatorCreds) Key() (clusterID uuid.UUID, key string) {
+	return v.ClusterID, "alternator_creds"
+}
+
+func (v *AlternatorCreds) MarshalBinary() (data []byte, err error) {
+	if v.AccessKeyID == "" {
+		return nil, nil
+	}
+	return json.Marshal(v)
+}
+
+func (v *AlternatorCreds) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, v)
+}

--- a/pkg/service/cluster/model.go
+++ b/pkg/service/cluster/model.go
@@ -24,11 +24,13 @@ type Cluster struct {
 	ForceTLSDisabled       bool `json:"force_tls_disabled"`
 	ForceNonSSLSessionPort bool `json:"force_non_ssl_session_port"`
 
-	Username        string `json:"username,omitempty" db:"-"`
-	Password        string `json:"password,omitempty" db:"-"`
-	SSLUserCertFile []byte `json:"ssl_user_cert_file,omitempty" db:"-"`
-	SSLUserKeyFile  []byte `json:"ssl_user_key_file,omitempty" db:"-"`
-	WithoutRepair   bool   `json:"without_repair,omitempty" db:"-"`
+	Username                  string `json:"username,omitempty" db:"-"`
+	Password                  string `json:"password,omitempty" db:"-"`
+	AlternatorAccessKeyID     string `json:"alternator_access_key_id,omitempty" db:"-"`
+	AlternatorSecretAccessKey string `json:"alternator_secret_access_key,omitempty" db:"-"`
+	SSLUserCertFile           []byte `json:"ssl_user_cert_file,omitempty" db:"-"`
+	SSLUserKeyFile            []byte `json:"ssl_user_key_file,omitempty" db:"-"`
+	WithoutRepair             bool   `json:"without_repair,omitempty" db:"-"`
 }
 
 // String returns cluster Name or ID if Name is empty.
@@ -56,6 +58,12 @@ func (c *Cluster) Validate() error {
 	}
 	if c.Username != "" && c.Password == "" {
 		errs = multierr.Append(errs, errors.New("missing password"))
+	}
+	if c.AlternatorAccessKeyID == "" && c.AlternatorSecretAccessKey != "" {
+		errs = multierr.Append(errs, errors.New("missing alternator access key ID"))
+	}
+	if c.AlternatorAccessKeyID != "" && c.AlternatorSecretAccessKey == "" {
+		errs = multierr.Append(errs, errors.New("missing alternator secret access key"))
 	}
 	if len(c.SSLUserCertFile) != 0 && len(c.SSLUserKeyFile) == 0 {
 		errs = multierr.Append(errs, errors.New("missing SSL user key"))


### PR DESCRIPTION
Alternator credentials need to be handled similarly to CQL credentials. User should be able to add them with `POST /clusters/`. User should be able to delete them with `DELETE /cluster/<cluster ID>/`. User should be able to check if the credentials are set with `GET /clusters/`.

Refs #4510
