### PR TITLE
Explicitly disable tablets for SimpleStrategy replication

### DIFF
--- a/pkg/cmd/scylla-manager/db.go
+++ b/pkg/cmd/scylla-manager/db.go
@@ -61,7 +61,8 @@ func createKeyspace(ctx context.Context, c config.Config, logger log.Logger) err
 	return session.Query(mustEvaluateCreateKeyspaceStmt(c)).Exec()
 }
 
-const createKeyspaceStmt = "CREATE KEYSPACE {{.Keyspace}} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': {{.ReplicationFactor}}}"
+const createKeyspaceStmt = "CREATE KEYSPACE {{.Keyspace}} WITH replication = {'class': 'SimpleStrategy', 'replication_factor': {{.ReplicationFactor}}}" +
+	" AND tablets = {'enabled': false}"
 
 func mustEvaluateCreateKeyspaceStmt(c config.Config) string {
 	t := template.New("")

--- a/pkg/scyllaclient/client_scylla_integration_test.go
+++ b/pkg/scyllaclient/client_scylla_integration_test.go
@@ -130,7 +130,11 @@ func TestClientDescribeRingIntegration(t *testing.T) {
 	for i := range testCases {
 		tc := testCases[i]
 		t.Run(tc.name, func(t *testing.T) {
-			if err := clusterSession.ExecStmt(fmt.Sprintf("CREATE KEYSPACE %s WITH replication = %s", tc.name, tc.replicationStmt)); err != nil {
+			ksStmt := fmt.Sprintf("CREATE KEYSPACE %s WITH replication = %s", tc.name, tc.replicationStmt)
+			if tc.replication == scyllaclient.SimpleStrategy {
+				ksStmt += " AND tablets = {'enabled': false}"
+			}
+			if err := clusterSession.ExecStmt(ksStmt); err != nil {
 				t.Fatal(err)
 			}
 			defer func() {

--- a/pkg/service/restore/restore_integration_test.go
+++ b/pkg/service/restore/restore_integration_test.go
@@ -62,7 +62,8 @@ func TestRestoreTablesUserIntegration(t *testing.T) {
 	Print("Log in via restored user and check permissions")
 	userSession := CreateManagedClusterSession(t, false, h.dstCluster.Client, user, pass)
 	newKs := randomizedName("ks_")
-	ExecStmt(t, userSession, fmt.Sprintf("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}", newKs))
+	ksStmt := fmt.Sprintf("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2} AND tablets = {'enabled': false}", newKs)
+	ExecStmt(t, userSession, ksStmt)
 }
 
 func TestRestoreTablesNoReplicationIntegration(t *testing.T) {
@@ -71,7 +72,7 @@ func TestRestoreTablesNoReplicationIntegration(t *testing.T) {
 	ks := randomizedName("no_rep_ks_")
 	tab := randomizedName("tab_")
 	Printf("Create non replicated %s.%s in both cluster", ks, tab)
-	ksStmt := fmt.Sprintf("CREATE KEYSPACE %q WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}", ks)
+	ksStmt := fmt.Sprintf("CREATE KEYSPACE %q WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}", ks)
 	tabStmt := fmt.Sprintf("CREATE TABLE %q.%q (id int PRIMARY KEY, data int)", ks, tab)
 	ExecStmt(t, h.srcCluster.rootSession, ksStmt)
 	ExecStmt(t, h.srcCluster.rootSession, tabStmt)

--- a/pkg/testutils/db/db.go
+++ b/pkg/testutils/db/db.go
@@ -154,7 +154,7 @@ func createTestKeyspace(tb testing.TB, cluster *gocql.ClusterConfig, keyspace st
 	WITH replication = {
 		'class' : 'SimpleStrategy',
 		'replication_factor' : %d
-	}`, keyspace, 1))
+	} AND tablets = {'enabled': false}`, keyspace, 1))
 }
 
 func dropAllKeyspaces(tb testing.TB, session gocqlx.Session) {


### PR DESCRIPTION
Currently, tablets enabled by default are not enforced. Thus, creating keyspaces that do not support tablets, silently disable them and use vnodes.

This patch adds `AND tablets = {'enabled': false}` to explicitly disable tablets for keyspaces using SimpleStrategy replication.

This is a preparation step for https://github.com/scylladb/scylladb/pull/25342 that changes the current behaviour and forces users to explicitly disable tablets when enabled by default.

Refs: https://github.com/scylladb/scylladb/issues/25340