### PR TITLE
Document native backup

### DIFF
--- a/docs/source/backup/index.rst
+++ b/docs/source/backup/index.rst
@@ -10,6 +10,7 @@ Backup
    setup-s3-compatible-storage
    setup-gcs
    setup-azure-blobstorage
+   native-backup
    examples
    specification
 

--- a/docs/source/backup/native-backup.rst
+++ b/docs/source/backup/native-backup.rst
@@ -1,0 +1,122 @@
+=============
+Native Backup
+=============
+
+| ScyllaDB Manager uses ScyllaDB Manager Agents deployed on each ScyllaDB node in order to coordinate backups.
+| Those agents serve as a proxy to `ScyllaDB REST API <https://docs.scylladb.com/manual/stable/operating-scylla/rest.html>`_, but they also act as `rclone <https://github.com/scylladb/rclone>`_ servers responsible for communication between the node and backup location.
+
+Since rclone server is separate from ScyllaDB internal schedulers, yet they both live on the same machine,
+it is allocated with limited resources in order not to interfere with ScyllaDB performance.
+
+This solution results in:
+  - inefficient resource utilization (especially when backup is running under high load)
+  - longer backup duration (limited resources allocated to rclone server)
+  - increased disk storage utilization (snapshots are stored on disk for a longer time)
+
+| Native backup aims to solve these problems by moving backup responsibilities from rclone server into ScyllaDB itself.
+| It's important to note that both native and rclone backups performed by ScyllaDB Manager have the same :doc:`specification <specification>` consisting of backup directory layout, manifest, schema and SSTable files. This means that all backups can be used for all types of restores (e.g. regular restore, 1-1-restore, native restore, ...).
+| In the `Status`_ section you can find the parts of backup procedure already moved to ScyllaDB.
+
+Status
+======
+
+| This section contains the parts of backup procedure already moved to ScyllaDB.
+| Note that all other parts are still performed by the rclone server (e.g. deduplication of SSTables, retention of old backups, ...).
+
+.. list-table::
+   :widths: 15 10 50 25
+   :header-rows: 1
+
+   * - Functionality
+     - ScyllaDB Version
+     - Description
+     - Limitations
+   * - SSTable upload
+     - >= 2025.2
+     - As is the most time and resource consuming part of the backup procedure, moving it to ScyllaDB brings the most benefits.
+       It also leverages knowledge of ScyllaDB internals in order to prioritize the upload of already compacted SSTables,
+       which additionally reduces disk storage utilization caused by the snapshot. In order to ensure that native SSTable upload
+       does not interfere with ScyllaDB performance, it should be throttled by configuring
+       `stream_io_throughput_mb_per_sec <https://docs.scylladb.com/manual/stable/reference/configuration-parameters.html#confval-stream_io_throughput_mb_per_sec>`_ in `scylla.yaml`.
+     - | Works with S3 provider only.
+       | Does not support creation of :ref:`versioned SSTables <backup-versioned-sstables>`.
+
+.. _configure-native-backup-in-scylla:
+
+Configuration
+=============
+
+In order to configure native backup, perform the following steps for each ScyllaDB node:
+
+#. Make sure that ScyllaDB Manager Agent is :ref:`configured <install-agent>` as always
+
+#. Configure `object_storage_endpoints <https://docs.scylladb.com/manual/stable/operating-scylla/admin.html#configuring-object-storage-experimental>`_ in `scylla.yaml`
+
+    This configures the backup location access for the ScyllaDB node itself. The backup location access for ScyllaDB Manager Agent needs to be configured separately,
+    in the same way in which it is done for the regular backup purposes (see :doc:`setup-amazon-s3`). The configurations in `scylla.yaml` and `scylla-manager-agent.yaml` should be matching.
+    An example of matching configurations is shown below:
+
+    `scylla-manager-agent.yaml`:
+
+    .. code-block:: yaml
+
+       s3:
+         provider: AWS
+         region: us-east-1
+         endpoint: https://s3.us-east-1.amazonaws.com:443
+
+    `scylla.yaml`:
+
+    .. code-block:: yaml
+
+       object_storage_endpoints:
+         - name: s3.us-east-1.amazonaws
+           port: 443
+           https: true
+           aws_region: us-east-1
+
+#. Throttle `stream_io_throughput_mb_per_sec <https://docs.scylladb.com/manual/stable/reference/configuration-parameters.html#confval-stream_io_throughput_mb_per_sec>`_ in `scylla.yaml`.
+
+    In order to ensure that native SSTable upload does not interfere with ScyllaDB performance, it should be throttled by configuring
+    `stream_io_throughput_mb_per_sec <https://docs.scylladb.com/manual/stable/reference/configuration-parameters.html#confval-stream_io_throughput_mb_per_sec>`_ in `scylla.yaml`.
+
+Usage
+=====
+
+The native backup usage is controlled with the :ref:`sctool backup --method <sctool-backup>` flag.
+It supports three values: ``native``, ``rclone`` and ``auto``:
+
+  * ``native``: Use all native backup functionalities listed in `Status`_ section.
+    Use this value for native backup configuration validation and testing.
+    Note that this will fail when:
+
+    * ScyllaDB is not configured properly (see ``object_storage_endpoints`` in `Configuration`_)
+    * ScyllaDB version does not support all of the native functionalities (see version support in `Status`_)
+    * Other provider than S3 is used (see limitations in `Status`_)
+    * The upload of snapshot directories would result in creation of versioned SSTables (see limitations in `Status`_)
+
+  * ``auto``: Use native backup functionalities when possible, otherwise fallback to rclone backup.
+    Use this value for production backups. The fallback works on per snapshot directory basis,
+    so it allows for utilizing native backup functionalities for most snapshot directories,
+    even if a small subset of them contains versioned SSTables.
+
+  * ``rclone``: Use rclone backup functionalities only. This effectively disables all native backup functionalities.
+
+Note that :ref:`sctool backup --rate-limit --transfers <sctool-backup>` flags do not take effect when using native backup,
+as the upload performance is controlled directly by the ScyllaDB itself. In order to control upload performance on the ScyllaDB side
+configure `stream_io_throughput_mb_per_sec <https://docs.scylladb.com/manual/stable/reference/configuration-parameters.html#confval-stream_io_throughput_mb_per_sec>`_ in `scylla.yaml`.
+
+You can :ref:`create a new backup task <sctool-backup>` with desired method:
+
+.. code-block:: none
+
+   sctool backup -c <cluster ID> -L <backup locations> --method native
+
+You can also :ref:`update existing backup task <backup-update>` to use a different method:
+
+.. code-block:: none
+
+   sctool backup update -c <cluster ID> <backup task ID> -L <backup locations> --method auto
+
+
+

--- a/docs/source/backup/specification.rst
+++ b/docs/source/backup/specification.rst
@@ -159,6 +159,8 @@ Under the node directory each table version has it's directory, the path is stru
 The directory contains all the table files.
 Some files may be used in more than one backup.
 
+.. _backup-versioned-sstables:
+
 You may also find that some of those files have the snapshot tag suffix (e.g. ``.sm_20210809095541UTC``).
 Even though sstables (data files) are immutable by nature, using non UUID sstable identifiers alongside
 `replacing a running node <https://docs.scylladb.com/manual/stable/operating-scylla/procedures/cluster-management/replace-running-node.html#replace-a-running-node-by-taking-its-place-in-the-cluster>`_

--- a/docs/source/install-scylla-manager-agent.rst
+++ b/docs/source/install-scylla-manager-agent.rst
@@ -119,4 +119,5 @@ Next steps
 ==========
 
 * :ref:`Configure backup location <backup-location>`
+* :ref:`Configure native backup <configure-native-backup-in-scylla>`
 * :doc:`Add a Cluster <add-a-cluster>`

--- a/docs/source/sctool/partials/sctool_backup.yaml
+++ b/docs/source/sctool/partials/sctool_backup.yaml
@@ -90,17 +90,13 @@ options:
     - name: method
       default_value: rclone
       usage: |-
-        Specify the API used for uploading files:
-        - 'auto': Use the native API when possible, otherwise use the Rclone API.
-        - 'native': Scylla server uploads directly to backup location (supports only S3 provider).
-        - 'rclone': Scylla Manager Agent uploads to backup location.
+        Control native backup method (See https://manager.docs.scylladb.com/stable/backup/native-backup):
+        - 'auto': Use the native backup functionalities, otherwise use the rclone backup.
+        - 'native': Use the native backup functionalities only.
+        - 'rclone': Use the rclone backup functionalities only.
 
-        Both methods require configuring the Scylla Manager Agent in 'scylla-manager-agent.yaml'.
-        The native API also requires 'object_storage_endpoints' to be configured in 'scylla.yaml' (See https://docs.scylladb.com/manual/stable/operating-scylla/admin.html#object-storage-configuration).
-
-        '--rate-limit' and '--transfers' flags do not take effect when using '--method=native',
-        as the upload performance is controlled by the Scylla server. In order to control it on the Scylla server side,
-        configure 'stream_io_throughput_mb_per_sec' in 'scylla.yaml' (See https://docs.scylladb.com/manual/stable/reference/configuration-parameters.html#confval-stream_io_throughput_mb_per_sec).
+        Using native backup functionalities requires additional configuration and has its own limitations,
+        which are described in details in https://manager.docs.scylladb.com/stable/backup/native-backup.
     - name: name
       usage: |
         Task name that can be used instead of ID.

--- a/docs/source/sctool/partials/sctool_backup_update.yaml
+++ b/docs/source/sctool/partials/sctool_backup_update.yaml
@@ -91,17 +91,13 @@ options:
     - name: method
       default_value: rclone
       usage: |-
-        Specify the API used for uploading files:
-        - 'auto': Use the native API when possible, otherwise use the Rclone API.
-        - 'native': Scylla server uploads directly to backup location (supports only S3 provider).
-        - 'rclone': Scylla Manager Agent uploads to backup location.
+        Control native backup method (See https://manager.docs.scylladb.com/stable/backup/native-backup):
+        - 'auto': Use the native backup functionalities, otherwise use the rclone backup.
+        - 'native': Use the native backup functionalities only.
+        - 'rclone': Use the rclone backup functionalities only.
 
-        Both methods require configuring the Scylla Manager Agent in 'scylla-manager-agent.yaml'.
-        The native API also requires 'object_storage_endpoints' to be configured in 'scylla.yaml' (See https://docs.scylladb.com/manual/stable/operating-scylla/admin.html#object-storage-configuration).
-
-        '--rate-limit' and '--transfers' flags do not take effect when using '--method=native',
-        as the upload performance is controlled by the Scylla server. In order to control it on the Scylla server side,
-        configure 'stream_io_throughput_mb_per_sec' in 'scylla.yaml' (See https://docs.scylladb.com/manual/stable/reference/configuration-parameters.html#confval-stream_io_throughput_mb_per_sec).
+        Using native backup functionalities requires additional configuration and has its own limitations,
+        which are described in details in https://manager.docs.scylladb.com/stable/backup/native-backup.
     - name: name
       usage: |
         Task name that can be used instead of ID.

--- a/docs/source/upgrade/index.rst
+++ b/docs/source/upgrade/index.rst
@@ -237,6 +237,8 @@ For Ubuntu:
     mv scylla-manager-agent.yaml scylla-manager-agent.yaml.old
     mv scylla-manager-agent.yaml.dpkg-dist scylla-manager-agent.yaml
 
+.. note:: This is a good time to :ref:`configure native backup <configure-native-backup-in-scylla>`.
+
 Start the ScyllaDB Manager Agent on all nodes
 -------------------------------------------------
 

--- a/pkg/command/backup/res.yaml
+++ b/pkg/command/backup/res.yaml
@@ -54,14 +54,10 @@ skip-schema: |
   Note that it's impossible to restore schema from such backups.
 
 method: |
-  Specify the API used for uploading files:
-  - 'auto': Use the native API when possible, otherwise use the Rclone API.
-  - 'native': Scylla server uploads directly to backup location (supports only S3 provider).
-  - 'rclone': Scylla Manager Agent uploads to backup location.
+  Control native backup method (See https://manager.docs.scylladb.com/stable/backup/native-backup):
+  - 'auto': Use the native backup functionalities, otherwise use the rclone backup.
+  - 'native': Use the native backup functionalities only.
+  - 'rclone': Use the rclone backup functionalities only.
   
-  Both methods require configuring the Scylla Manager Agent in 'scylla-manager-agent.yaml'.
-  The native API also requires 'object_storage_endpoints' to be configured in 'scylla.yaml' (See https://docs.scylladb.com/manual/stable/operating-scylla/admin.html#object-storage-configuration).
-  
-  '--rate-limit' and '--transfers' flags do not take effect when using '--method=native',
-  as the upload performance is controlled by the Scylla server. In order to control it on the Scylla server side,
-  configure 'stream_io_throughput_mb_per_sec' in 'scylla.yaml' (See https://docs.scylladb.com/manual/stable/reference/configuration-parameters.html#confval-stream_io_throughput_mb_per_sec).
+  Using native backup functionalities requires additional configuration and has its own limitations,
+  which are described in details in https://manager.docs.scylladb.com/stable/backup/native-backup.


### PR DESCRIPTION
This PR adds a separate page for native backup documentation.
It also adds notes about it to the install and upgrade sm-agent pages.

Fixes #4174