### PR TITLE
Alternator backup

### DIFF
--- a/pkg/restapi/backup.go
+++ b/pkg/restapi/backup.go
@@ -242,12 +242,12 @@ func (h backupHandler) describeSchema(w http.ResponseWriter, r *http.Request) {
 		TaskID:    queryTaskID,
 	}
 
-	schema, err := h.svc.GetDescribeSchema(r.Context(), cluster.ID, snapshotTag, location, filter)
+	cqlSchema, _, err := h.svc.GetDescribeSchema(r.Context(), cluster.ID, snapshotTag, location, filter)
 	if err != nil {
 		respondError(w, r, errors.Wrap(err, "get describe schema"))
 		return
 	}
-	render.Respond(w, r, convertSchema(schema))
+	render.Respond(w, r, convertSchema(cqlSchema))
 }
 
 func parseOptionalUUID(v string) (uuid.UUID, error) {

--- a/pkg/restapi/backup.go
+++ b/pkg/restapi/backup.go
@@ -237,14 +237,14 @@ func (h backupHandler) describeSchema(w http.ResponseWriter, r *http.Request) {
 		respondError(w, r, util.ErrValidate(errors.Wrap(err, "parse query_task_id")))
 		return
 	}
-	filter := backup.DescribeSchemaFilter{
+	filter := backup.SchemaFilter{
 		ClusterID: queryClusterID,
 		TaskID:    queryTaskID,
 	}
 
-	cqlSchema, _, err := h.svc.GetDescribeSchema(r.Context(), cluster.ID, snapshotTag, location, filter)
+	cqlSchema, _, err := h.svc.GetSchema(r.Context(), cluster.ID, snapshotTag, location, filter)
 	if err != nil {
-		respondError(w, r, errors.Wrap(err, "get describe schema"))
+		respondError(w, r, errors.Wrap(err, "get schema"))
 		return
 	}
 	render.Respond(w, r, convertSchema(cqlSchema))

--- a/pkg/restapi/mock_backupservice_test.go
+++ b/pkg/restapi/mock_backupservice_test.go
@@ -67,21 +67,6 @@ func (mr *MockBackupServiceMockRecorder) ExtractLocations(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractLocations", reflect.TypeOf((*MockBackupService)(nil).ExtractLocations), arg0, arg1)
 }
 
-// GetDescribeSchema mocks base method.
-func (m *MockBackupService) GetDescribeSchema(arg0 context.Context, arg1 uuid.UUID, arg2 string, arg3 backupspec.Location, arg4 backup.DescribeSchemaFilter) (query.DescribedSchema, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDescribeSchema", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(query.DescribedSchema)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDescribeSchema indicates an expected call of GetDescribeSchema.
-func (mr *MockBackupServiceMockRecorder) GetDescribeSchema(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDescribeSchema", reflect.TypeOf((*MockBackupService)(nil).GetDescribeSchema), arg0, arg1, arg2, arg3, arg4)
-}
-
 // GetProgress mocks base method.
 func (m *MockBackupService) GetProgress(arg0 context.Context, arg1, arg2, arg3 uuid.UUID) (backup.Progress, error) {
 	m.ctrl.T.Helper()
@@ -95,6 +80,22 @@ func (m *MockBackupService) GetProgress(arg0 context.Context, arg1, arg2, arg3 u
 func (mr *MockBackupServiceMockRecorder) GetProgress(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProgress", reflect.TypeOf((*MockBackupService)(nil).GetProgress), arg0, arg1, arg2, arg3)
+}
+
+// GetSchema mocks base method.
+func (m *MockBackupService) GetSchema(arg0 context.Context, arg1 uuid.UUID, arg2 string, arg3 backupspec.Location, arg4 backup.SchemaFilter) (query.DescribedSchema, backupspec.AlternatorSchema, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSchema", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(query.DescribedSchema)
+	ret1, _ := ret[1].(backupspec.AlternatorSchema)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetSchema indicates an expected call of GetSchema.
+func (mr *MockBackupServiceMockRecorder) GetSchema(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchema", reflect.TypeOf((*MockBackupService)(nil).GetSchema), arg0, arg1, arg2, arg3, arg4)
 }
 
 // GetTarget mocks base method.

--- a/pkg/restapi/services.go
+++ b/pkg/restapi/services.go
@@ -72,7 +72,8 @@ type BackupService interface {
 	GetValidationTarget(_ context.Context, clusterID uuid.UUID, properties json.RawMessage) (backup.ValidationTarget, error)
 	// GetValidationProgress must work even when the cluster is no longer available.
 	GetValidationProgress(ctx context.Context, clusterID, taskID, runID uuid.UUID) ([]backup.ValidationHostProgress, error)
-	GetDescribeSchema(ctx context.Context, clusterID uuid.UUID, snapshotTag string, location backupspec.Location, filter backup.DescribeSchemaFilter) (query.DescribedSchema, error)
+	GetDescribeSchema(ctx context.Context, clusterID uuid.UUID, snapshotTag string, location backupspec.Location,
+		filter backup.DescribeSchemaFilter) (query.DescribedSchema, backupspec.AlternatorSchema, error)
 }
 
 // RestoreService service interface for the REST API handlers.

--- a/pkg/restapi/services.go
+++ b/pkg/restapi/services.go
@@ -72,8 +72,8 @@ type BackupService interface {
 	GetValidationTarget(_ context.Context, clusterID uuid.UUID, properties json.RawMessage) (backup.ValidationTarget, error)
 	// GetValidationProgress must work even when the cluster is no longer available.
 	GetValidationProgress(ctx context.Context, clusterID, taskID, runID uuid.UUID) ([]backup.ValidationHostProgress, error)
-	GetDescribeSchema(ctx context.Context, clusterID uuid.UUID, snapshotTag string, location backupspec.Location,
-		filter backup.DescribeSchemaFilter) (query.DescribedSchema, backupspec.AlternatorSchema, error)
+	GetSchema(ctx context.Context, clusterID uuid.UUID, snapshotTag string, location backupspec.Location,
+		filter backup.SchemaFilter) (query.DescribedSchema, backupspec.AlternatorSchema, error)
 }
 
 // RestoreService service interface for the REST API handlers.

--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -242,6 +242,14 @@ func (ni *NodeInfo) SupportsSafeDescribeSchemaWithInternals() (SafeDescribeMetho
 	return "", nil
 }
 
+// SupportsAlternatorSchemaBackupFromAPI true if alternator schema should be backed up using alternator API.
+func (ni *NodeInfo) SupportsAlternatorSchemaBackupFromAPI() (bool, error) {
+	// At the moment of writing this code, the only supported scylla versions are:
+	// 2024.1 - both CQL and alternator schema are restored from sstables
+	// 2025.1, 2025.2 - alternator schema is restored from alternator API
+	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2025.1")
+}
+
 // SupportsNativeBackupAPI returns whether node exposes /storage_service/backup API.
 func (ni *NodeInfo) SupportsNativeBackupAPI() (bool, error) {
 	// Check ENT

--- a/pkg/service/backup/schema.go
+++ b/pkg/service/backup/schema.go
@@ -20,14 +20,14 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 )
 
-// DescribeSchemaFilter allows for faster and more robust schema file lookup.
-type DescribeSchemaFilter struct {
+// SchemaFilter allows for faster and more robust schema file lookup.
+type SchemaFilter struct {
 	ClusterID uuid.UUID
 	TaskID    uuid.UUID
 }
 
-// GetDescribeSchema fetches both cql and alternator backed up schema.
-func (s *Service) GetDescribeSchema(ctx context.Context, clusterID uuid.UUID, snapshotTag string, location backupspec.Location, filter DescribeSchemaFilter,
+// GetSchema fetches both cql and alternator backed up schema.
+func (s *Service) GetSchema(ctx context.Context, clusterID uuid.UUID, snapshotTag string, location backupspec.Location, filter SchemaFilter,
 ) (query.DescribedSchema, backupspec.AlternatorSchema, error) {
 	client, err := s.scyllaClient(ctx, clusterID)
 	if err != nil {
@@ -92,7 +92,7 @@ var ErrSchemaFileNotFound = errors.New("no cql schema file found in backup locat
 // getSchemaFilePath looks for cql and alternator schema files in the backup location and returns their remote paths.
 // If no cql schema file is found, ErrSchemaFileNotFound is returned.
 // If no alternator schema file is found, alternatorSchemaPath is empty.
-func getSchemaFilePath(ctx context.Context, client *scyllaclient.Client, host string, loc backupspec.Location, tag string, f DescribeSchemaFilter, log log.Logger,
+func getSchemaFilePath(ctx context.Context, client *scyllaclient.Client, host string, loc backupspec.Location, tag string, f SchemaFilter, log log.Logger,
 ) (cqlSchemaPath, alternatorSchemaPath string, err error) {
 	baseDir := path.Join("backup", string(backupspec.SchemaDirKind), "cluster")
 	opts := scyllaclient.RcloneListDirOpts{

--- a/pkg/service/backup/schema_test.go
+++ b/pkg/service/backup/schema_test.go
@@ -18,7 +18,7 @@ func TestParseSchemaFileName(t *testing.T) {
 		err        bool
 	}{
 		{
-			name:       "valid schema file",
+			name:       "valid cql schema file",
 			schemaFile: "task_1702a53a-2ecd-44b2-9c79-c45653a49d31_tag_sm_20250527161648UTC_schema_with_internals.json.gz",
 			taskID:     uuid.MustParse("1702a53a-2ecd-44b2-9c79-c45653a49d31"),
 			tag:        "sm_20250527161648UTC",
@@ -37,6 +37,12 @@ func TestParseSchemaFileName(t *testing.T) {
 			name:       "invalid tag",
 			schemaFile: "task_1702a53a-2ecd-44b2-9c79-c45653a49d31_tag_invalidtag_schema_with_internals.json.gz",
 			err:        true,
+		},
+		{
+			name:       "valid alternator schema file",
+			schemaFile: "task_1702a53a-2ecd-44b2-9c79-c45653a49d31_tag_sm_20250527161648UTC_alternator_schema.json.gz",
+			taskID:     uuid.MustParse("1702a53a-2ecd-44b2-9c79-c45653a49d31"),
+			tag:        "sm_20250527161648UTC",
 		},
 	}
 

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -2670,7 +2670,7 @@ func TestTGetDescribeSchemaIntegration(t *testing.T) {
 	h := newBackupTestHelper(t, session, config, location, nil)
 
 	if CheckAnyConstraint(h.T, h.Client, "< 6.0", "< 2024.2, > 1000") {
-		t.Skip("GetDescribeSchema works only with DESCRIBE SCHEMA WITH INTERNALS schema backup")
+		t.Skip("GetSchema works only with DESCRIBE SCHEMA WITH INTERNALS schema backup")
 	}
 	ni, err := h.Client.AnyNodeInfo(context.Background())
 	if err != nil {
@@ -2790,19 +2790,19 @@ func TestTGetDescribeSchemaIntegration(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			Print("When: call GetDescribeSchema")
-			filter := backup.DescribeSchemaFilter{
+			Print("When: call GetSchema")
+			filter := backup.SchemaFilter{
 				ClusterID: tc.clusterID,
 				TaskID:    tc.taskID,
 			}
-			cqlSchema, alternatorSchema, err := h.service.GetDescribeSchema(ctx, h.ClusterID, tc.tag, location, filter)
+			cqlSchema, alternatorSchema, err := h.service.GetSchema(ctx, h.ClusterID, tc.tag, location, filter)
 			if err != nil {
-				t.Fatal(errors.Wrap(err, "GetDescribeSchema"))
+				t.Fatal(errors.Wrap(err, "GetSchema"))
 			}
 			// Validate always existing CQL schema
 			slices.SortFunc(cqlSchema, func(a, b query.DescribedSchemaRow) int { return stdCmp.Compare(a.Keyspace+a.Name, b.Keyspace+b.Name) })
 			slices.SortFunc(tc.cqlSchema, func(a, b query.DescribedSchemaRow) int { return stdCmp.Compare(a.Keyspace+a.Name, b.Keyspace+b.Name) })
-			Print("Then: GetDescribeSchema returned correct cqlSchema")
+			Print("Then: GetSchema returned correct cqlSchema")
 			if diff := cmp.Diff(cqlSchema, tc.cqlSchema); diff != "" {
 				t.Fatalf("Schema mismatch\n%s", diff)
 			}

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -761,6 +761,11 @@ func TestBackupSmokeIntegration(t *testing.T) {
 		}
 	}
 
+	ni, err := h.Client.AnyNodeInfo(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	Print("And: files")
 	manifests, schemas, _ := h.listS3Files()
 	// Manifest meta per host per snapshot
@@ -770,7 +775,13 @@ func TestBackupSmokeIntegration(t *testing.T) {
 	}
 
 	// Schema meta per snapshot
-	const schemasCount = 2
+	var schemasCount = 2
+	if ok, err := ni.SupportsAlternatorSchemaBackupFromAPI(); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		// Alternator schema per snapshot
+		schemasCount *= 2
+	}
 	if len(schemas) != schemasCount {
 		t.Fatalf("expected %d schemas, got %d", schemasCount, len(schemas))
 	}

--- a/pkg/service/backup/stage.go
+++ b/pkg/service/backup/stage.go
@@ -29,7 +29,7 @@ var stageDescription = map[Stage]string{
 	StageAwaitSchema:  "awaiting schema agreement",
 	StageIndex:        "indexing snapshot files",
 	StageManifest:     "uploading manifest files",
-	StageSchema:       "uploading cql schema",
+	StageSchema:       "uploading schema",
 	StageUpload:       "uploading snapshot files",
 	StageMoveManifest: "moving manifest files",
 	StagePurge:        "purging stale snapshots",

--- a/pkg/service/backup/worker.go
+++ b/pkg/service/backup/worker.go
@@ -72,12 +72,13 @@ type workerTools struct {
 type worker struct {
 	workerTools
 
-	PrevStage      Stage
-	Metrics        metrics.BackupMetrics
-	Units          []Unit
-	Schema         bytes.Buffer
-	SchemaFilePath string
-	OnRunProgress  func(ctx context.Context, p *RunProgress)
+	PrevStage        Stage
+	Metrics          metrics.BackupMetrics
+	Units            []Unit
+	Schema           bytes.Buffer
+	SchemaFilePath   string
+	AlternatorSchema bytes.Buffer
+	OnRunProgress    func(ctx context.Context, p *RunProgress)
 	// ResumeUploadProgress populates upload stats of the provided run progress
 	// with previous run progress.
 	// If there is no previous run there should be no update.

--- a/pkg/service/backup/worker_alternator.go
+++ b/pkg/service/backup/worker_alternator.go
@@ -1,0 +1,164 @@
+// Copyright (C) 2025 ScyllaDB
+
+package backup
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-manager/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/cluster"
+)
+
+func (w *worker) DumpAlternatorSchema(ctx context.Context, his []hostInfo, alternatorFunc cluster.AlternatorClientFunc) error {
+	hi, ok := getAlternatorHost(his)
+	if !ok {
+		// Nothing to do if alternator is not enabled
+		return nil
+	}
+	w.Logger.Info(ctx, "Chose node for alternator schema dump", "node", hi.IP)
+
+	if ok, err := hi.NodeConfig.SupportsAlternatorSchemaBackupFromAPI(); err != nil {
+		return errors.Wrap(err, "check alternator schema backup support")
+	} else if !ok {
+		// Nothing to do if alternator schema should be restored from sstables
+		return nil
+	}
+
+	// All supported versions which support alternator schema
+	// backup from API also support raft read barrier API.
+	if err := w.Client.RaftReadBarrier(ctx, hi.IP, ""); err != nil {
+		return errors.Wrap(err, "make raft read barrier")
+	}
+
+	client, err := alternatorFunc(ctx, w.ClusterID, hi.IP)
+	if err != nil {
+		return errors.Wrapf(err, "create alternator client to node")
+	}
+
+	schema, err := w.getAlternatorSchema(ctx, client)
+	if err != nil {
+		return errors.Wrap(err, "get alternator schema")
+	}
+
+	archive, err := marshalAndCompressArchive(schema)
+	if err != nil {
+		return errors.Wrap(err, "create alternator schema archive")
+	}
+
+	w.Logger.Info(ctx, "Created alternator schema archive")
+	w.AlternatorSchema = archive
+	return nil
+}
+
+func (w *worker) UploadAlternatorSchema(ctx context.Context, his []hostInfo) error {
+	if w.AlternatorSchema.Len() == 0 {
+		w.Logger.Info(ctx, "No alternator schema to upload")
+		return nil
+	}
+
+	visited := map[backupspec.Location]struct{}{}
+	for i := range his {
+		if _, ok := visited[his[i].Location]; ok {
+			continue
+		}
+		visited[his[i].Location] = struct{}{}
+
+		remoteAlternatorSchemaPath := his[i].Location.RemotePath(backupspec.AlternatorSchemaPath(w.ClusterID, w.TaskID, w.SnapshotTag))
+		if err := w.Client.RclonePut(ctx, his[i].IP, remoteAlternatorSchemaPath, &w.AlternatorSchema); err != nil {
+			return errors.Wrapf(err, "upload alternator schema from node (%q) to location (%q)", his[i].IP, remoteAlternatorSchemaPath)
+		}
+	}
+
+	return nil
+}
+
+// getAlternatorHost returns IP of host (if any) with alternator enabled.
+func getAlternatorHost(his []hostInfo) (hostInfo, bool) {
+	for i := range his {
+		if his[i].NodeConfig.AlternatorEnabled() {
+			return his[i], true
+		}
+	}
+	return hostInfo{}, false
+}
+
+// getAlternatorSchema queries alternator API in order to get alternator schema.
+func (w *worker) getAlternatorSchema(ctx context.Context, client *dynamodb.Client) (backupspec.AlternatorSchema, error) {
+	tableNames, err := listAllTables(ctx, client)
+	if err != nil {
+		return backupspec.AlternatorSchema{}, errors.Wrap(err, "list all alternator tables")
+	}
+
+	var tableSchema []backupspec.AlternatorTableSchema
+	for _, name := range tableNames {
+		describeOut, err := client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
+			TableName: &name,
+		})
+		if err != nil {
+			return backupspec.AlternatorSchema{}, errors.Wrapf(err, "describe alternator table: %q", name)
+		}
+
+		tags, err := listAllTags(ctx, client, *describeOut.Table.TableArn)
+		if err != nil {
+			return backupspec.AlternatorSchema{}, errors.Wrapf(err, "list tags of alternator table: %q", name)
+		}
+
+		TTLOut, err := client.DescribeTimeToLive(ctx, &dynamodb.DescribeTimeToLiveInput{
+			TableName: &name,
+		})
+		if err != nil {
+			return backupspec.AlternatorSchema{}, errors.Wrapf(err, "describe TTL of alternator table: %q", name)
+		}
+
+		tableSchema = append(tableSchema, backupspec.AlternatorTableSchema{
+			Describe: describeOut.Table,
+			Tags:     tags,
+			TTL:      TTLOut.TimeToLiveDescription,
+		})
+	}
+	return backupspec.AlternatorSchema{
+		Tables: tableSchema,
+	}, nil
+}
+
+// listAllTables is a wrapper for ListTables which returns all tables.
+func listAllTables(ctx context.Context, client *dynamodb.Client) ([]string, error) {
+	var tableNames []string
+	var exclusiveStartTableName *string
+	for {
+		listOut, err := client.ListTables(ctx, &dynamodb.ListTablesInput{
+			ExclusiveStartTableName: exclusiveStartTableName,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "list tables")
+		}
+		tableNames = append(tableNames, listOut.TableNames...)
+		exclusiveStartTableName = listOut.LastEvaluatedTableName
+		if exclusiveStartTableName == nil {
+			return tableNames, nil
+		}
+	}
+}
+
+// listAllTags is a wrapper for ListTagsOfResource which returns all tags.
+func listAllTags(ctx context.Context, client *dynamodb.Client, resourceArn string) ([]types.Tag, error) {
+	var tags []types.Tag
+	var nextToken *string
+	for {
+		listTagsOut, err := client.ListTagsOfResource(ctx, &dynamodb.ListTagsOfResourceInput{
+			ResourceArn: &resourceArn,
+			NextToken:   nextToken,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "list tags of resource")
+		}
+		tags = append(tags, listTagsOut.Tags...)
+		nextToken = listTagsOut.NextToken
+		if nextToken == nil {
+			return tags, nil
+		}
+	}
+}

--- a/pkg/service/backup/worker_schema.go
+++ b/pkg/service/backup/worker_schema.go
@@ -63,7 +63,7 @@ func (w *worker) safeBackupAndRestoreSchemaDump(ctx context.Context, descSchemaH
 	if err != nil {
 		return err
 	}
-	b, err := marshalAndCompressSchema(schema)
+	b, err := marshalAndCompressArchive(schema)
 	if err != nil {
 		return errors.Wrap(err, "create safe schema file")
 	}
@@ -153,16 +153,16 @@ func (w *worker) createSingleHostSessionToAnyHost(ctx context.Context, hosts []s
 	return gocqlx.Session{}, "", errors.Wrap(retErr, "no host that can be accessed via CQL (more info in the logs)")
 }
 
-func marshalAndCompressSchema(schema query.DescribedSchema) (bytes.Buffer, error) {
-	rawSchema, err := json.Marshal(schema)
+func marshalAndCompressArchive(v any) (bytes.Buffer, error) {
+	rawSchema, err := json.Marshal(v)
 	if err != nil {
-		return bytes.Buffer{}, errors.Wrap(err, "marshal schema")
+		return bytes.Buffer{}, errors.Wrap(err, "marshal to json")
 	}
 
 	var b bytes.Buffer
 	gw := gzip.NewWriter(&b)
 	if _, err := gw.Write(rawSchema); err != nil {
-		return bytes.Buffer{}, errors.Wrap(err, "write compressed schema")
+		return bytes.Buffer{}, errors.Wrap(err, "compress with gzip")
 	}
 	if err := gw.Close(); err != nil {
 		return bytes.Buffer{}, errors.Wrap(err, "close gzip writer")


### PR DESCRIPTION
This PR extends backup procedure with alternator schema.
It also extends GetDescribeSchema to GetSchema which also returns alternator schema and it's used for testing alternator schema completion. The real backup restore tests will be performed when alternator restore is implemented.

Fixes #4512
