### PR TITLE
Add flags for handling alternator creds

### DIFF
--- a/docs/source/sctool/partials/sctool_cluster_add.yaml
+++ b/docs/source/sctool/partials/sctool_cluster_add.yaml
@@ -7,6 +7,14 @@ description: |
     see https://manager.docs.scylladb.com/stable/add-a-cluster.html for instructions.
 usage: sctool cluster add --host <IP> [--name <alias>] [--auth-token <token>] [flags]
 options:
+    - name: alternator-access-key-id
+      usage: |
+        Alternator `access-key-id`, for security reasons this account should NOT have access to your data.
+        If you specify the alternator access-key-id and secret-access-key, the alternator health check you see in status command would try to login and execute a query against system table.
+        Otherwise alternator health check is based on sending GET request to alternator port and does not create an alternator client.
+    - name: alternator-secret-access-key
+      usage: |
+        Alternator `secret-access-key` associated with access-key-id.
     - name: auth-token
       usage: |
         The authentication `token` you identified in '/etc/scylla-manager-agent/scylla-manager-agent.yaml'.

--- a/docs/source/sctool/partials/sctool_cluster_update.yaml
+++ b/docs/source/sctool/partials/sctool_cluster_update.yaml
@@ -4,6 +4,14 @@ description: |
     This command modifies managed cluster parameters
 usage: sctool cluster update --cluster <id|name> [flags]
 options:
+    - name: alternator-access-key-id
+      usage: |
+        Alternator `access-key-id`, for security reasons this account should NOT have access to your data.
+        If you specify the alternator access-key-id and secret-access-key, the alternator health check you see in status command would try to login and execute a query against system table.
+        Otherwise alternator health check is based on sending GET request to alternator port and does not create an alternator client.
+    - name: alternator-secret-access-key
+      usage: |
+        Alternator `secret-access-key` associated with access-key-id.
     - name: auth-token
       usage: |
         The authentication `token` you identified in '/etc/scylla-manager-agent/scylla-manager-agent.yaml'.
@@ -11,6 +19,10 @@ options:
       shorthand: c
       usage: |
         The target cluster `name or ID` (envvar SCYLLA_MANAGER_CLUSTER).
+    - name: delete-alternator-credentials
+      default_value: "false"
+      usage: |
+        Deletes alternator access-key-id and secret-access-key, added with --alternator-access-key-id and --alternator-secret-access-key.
     - name: delete-cql-credentials
       default_value: "false"
       usage: |

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/scylladb/go-set v1.0.2
 	github.com/scylladb/gocqlx/v2 v2.8.0
 	github.com/scylladb/scylla-manager/backupspec v1.0.3-0.20250818141015-50f1d9b3b087
-	github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250630160519-24627a91850a
+	github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250828081109-82b83049f8f9
 	github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250530081649-30bcf253e6a6
 	github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250818141015-50f1d9b3b087
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1081,8 +1081,8 @@ github.com/scylladb/rclone v1.54.1-0.20240312172628-afe1fd2aa65e h1:lJRphCtu+nKd
 github.com/scylladb/rclone v1.54.1-0.20240312172628-afe1fd2aa65e/go.mod h1:JGZp4EvCUK+6AM1Fe1dye5xvihTc/Bk0WnHHSCJOePM=
 github.com/scylladb/scylla-manager/backupspec v1.0.3-0.20250818141015-50f1d9b3b087 h1:+2/Wj99GOXZsfA52c85rTesMFlY7M80NNaIGWMyaxlU=
 github.com/scylladb/scylla-manager/backupspec v1.0.3-0.20250818141015-50f1d9b3b087/go.mod h1:q6WQ90LXFM+69NXr9jZertopfiPjJfCTsR3/Fg5/200=
-github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250630160519-24627a91850a h1:9TEBNt22TSt6s/UW3w27PuZl2nxFMr4TiFDfWmI6iC0=
-github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250630160519-24627a91850a/go.mod h1:RmtRlpZS+Ox8xI19NFPzPdDK1MlZoF+WDzPqceW7EQE=
+github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250828081109-82b83049f8f9 h1:bvZHmk92VyYe4G18QMYkhXqKPiC1+ASKHq4dDm7GU5U=
+github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250828081109-82b83049f8f9/go.mod h1:EBBiOVCfH+iYKWyb6h4b1i+YLzk4niX8sDEIFvHUEis=
 github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250530081649-30bcf253e6a6 h1:Tjt1RNnyWP+7Z32BUn2Q31gYrYCz2QszmNy6GnXhM2c=
 github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20250530081649-30bcf253e6a6/go.mod h1:VKqHSrDj9zfgCKilpbdpmqV1TjmSglt/df79eIg6wuI=
 github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20250818141015-50f1d9b3b087 h1:Ou5DrV+EAHUTXypZCJprrOKQ3Hu1gELGYgpJ4JDfSZ8=

--- a/pkg/command/cluster/clusteradd/cmd.go
+++ b/pkg/command/cluster/clusteradd/cmd.go
@@ -23,19 +23,21 @@ type command struct {
 	cobra.Command
 	client *managerclient.Client
 
-	id                     string
-	name                   string
-	label                  flag.Label
-	host                   string
-	port                   int64
-	authToken              string
-	username               string
-	password               string
-	sslUserCertFile        string
-	sslUserKeyFile         string
-	withoutRepair          bool
-	forceTLSDisabled       bool
-	forceNonSSLSessionPort bool
+	id                        string
+	name                      string
+	label                     flag.Label
+	host                      string
+	port                      int64
+	authToken                 string
+	username                  string
+	password                  string
+	alternatorAccessKeyID     string
+	alternatorSecretAccessKey string
+	sslUserCertFile           string
+	sslUserKeyFile            string
+	withoutRepair             bool
+	forceTLSDisabled          bool
+	forceNonSSLSessionPort    bool
 }
 
 func NewCommand(client *managerclient.Client) *cobra.Command {
@@ -64,6 +66,8 @@ func (cmd *command) init() {
 	w.StringVar(&cmd.authToken, "auth-token", "", "")
 	w.StringVarP(&cmd.username, "username", "u", "", "")
 	w.StringVarP(&cmd.password, "password", "p", "", "")
+	w.StringVar(&cmd.alternatorAccessKeyID, "alternator-access-key-id", "", "")
+	w.StringVar(&cmd.alternatorSecretAccessKey, "alternator-secret-access-key", "", "")
 	w.StringVar(&cmd.sslUserCertFile, "ssl-user-cert-file", "", "")
 	w.StringVar(&cmd.sslUserKeyFile, "ssl-user-key-file", "", "")
 	w.BoolVar(&cmd.withoutRepair, "without-repair", false, "")
@@ -85,16 +89,18 @@ func (cmd *command) run() error {
 	}
 
 	c := &managerclient.Cluster{
-		ID:                     cmd.id,
-		Name:                   cmd.name,
-		Labels:                 cmd.label.NewLabels(),
-		Host:                   cmd.host,
-		AuthToken:              cmd.authToken,
-		Username:               cmd.username,
-		Password:               cmd.password,
-		WithoutRepair:          cmd.withoutRepair,
-		ForceTLSDisabled:       cmd.forceTLSDisabled,
-		ForceNonSslSessionPort: cmd.forceNonSSLSessionPort,
+		ID:                        cmd.id,
+		Name:                      cmd.name,
+		Labels:                    cmd.label.NewLabels(),
+		Host:                      cmd.host,
+		AuthToken:                 cmd.authToken,
+		Username:                  cmd.username,
+		Password:                  cmd.password,
+		AlternatorAccessKeyID:     cmd.alternatorAccessKeyID,
+		AlternatorSecretAccessKey: cmd.alternatorSecretAccessKey,
+		WithoutRepair:             cmd.withoutRepair,
+		ForceTLSDisabled:          cmd.forceTLSDisabled,
+		ForceNonSslSessionPort:    cmd.forceNonSSLSessionPort,
 	}
 	if cmd.port != 10001 {
 		c.Port = cmd.port
@@ -105,6 +111,13 @@ func (cmd *command) run() error {
 	}
 	if cmd.password != "" && cmd.username == "" {
 		return errors.New("missing flag \"username\"")
+	}
+
+	if cmd.alternatorAccessKeyID != "" && cmd.alternatorSecretAccessKey == "" {
+		return errors.New("missing flag \"alternator-secret-access-key\"")
+	}
+	if cmd.alternatorSecretAccessKey != "" && cmd.alternatorAccessKeyID == "" {
+		return errors.New("missing flag \"alternator-access-key-id\"")
 	}
 
 	if cmd.sslUserCertFile != "" && cmd.sslUserKeyFile == "" {

--- a/pkg/command/cluster/clusteradd/cmd_integration_api_test.go
+++ b/pkg/command/cluster/clusteradd/cmd_integration_api_test.go
@@ -8,7 +8,6 @@ package clusteradd
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"maps"
 	"os/exec"
 	"strings"
@@ -92,7 +91,6 @@ func TestSctoolClusterAddIntegrationAPITest(t *testing.T) {
 
 			// when
 			output, err := cmd.Output()
-			fmt.Println(string(output))
 			if err != nil {
 				t.Fatalf("Unable to create cluster with sctool cluster add, err = {%v}, stderr = {%v}", err, stderr.String())
 			}

--- a/pkg/command/cluster/clusteradd/res.yaml
+++ b/pkg/command/cluster/clusteradd/res.yaml
@@ -56,6 +56,14 @@ username: |
 password: |
   CQL `password` associated with username.
 
+alternator-access-key-id: |
+  Alternator `access-key-id`, for security reasons this account should NOT have access to your data.
+  If you specify the alternator access-key-id and secret-access-key, the alternator health check you see in status command would try to login and execute a query against system table.
+  Otherwise alternator health check is based on sending GET request to alternator port and does not create an alternator client.
+
+alternator-secret-access-key: |
+  Alternator `secret-access-key` associated with access-key-id.
+
 ssl-user-cert-file: |
   File `path` to client certificate when Scylla uses client/server encryption (require_client_auth enabled).
 

--- a/pkg/command/cluster/clusterupdate/res.yaml
+++ b/pkg/command/cluster/clusterupdate/res.yaml
@@ -43,6 +43,14 @@ username: |
 password: |
   CQL `password` associated with username.
 
+alternator-access-key-id: |
+  Alternator `access-key-id`, for security reasons this account should NOT have access to your data.
+  If you specify the alternator access-key-id and secret-access-key, the alternator health check you see in status command would try to login and execute a query against system table.
+  Otherwise alternator health check is based on sending GET request to alternator port and does not create an alternator client.
+
+alternator-secret-access-key: |
+  Alternator `secret-access-key` associated with access-key-id.
+
 ssl-user-cert-file: |
   File `path` to client certificate when Scylla uses client/server encryption (require_client_auth enabled).
 
@@ -51,6 +59,9 @@ ssl-user-key-file: |
 
 delete-cql-credentials: |
   Deletes CQL username and password, added with --username and --password.
+
+delete-alternator-credentials: |
+  Deletes alternator access-key-id and secret-access-key, added with --alternator-access-key-id and --alternator-secret-access-key.
 
 delete-ssl-user-cert: |
   Deletes SSL user certificate, added with --ssl-user-cert-file flag.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -495,7 +495,7 @@ github.com/scylladb/gocqlx/v2/table
 # github.com/scylladb/scylla-manager/backupspec v1.0.3-0.20250818141015-50f1d9b3b087
 ## explicit; go 1.23.2
 github.com/scylladb/scylla-manager/backupspec
-# github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250630160519-24627a91850a
+# github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20250828081109-82b83049f8f9
 ## explicit; go 1.23.2
 github.com/scylladb/scylla-manager/v3/pkg/managerclient
 github.com/scylladb/scylla-manager/v3/pkg/managerclient/table


### PR DESCRIPTION
This is the final PR regarding handling alternator creds. It contains some api tests, but I also made a manual validation in order to make sure that everything works and looks as expected:

```
miles@fedora:~/scylla-manager$ ./sctool.dev cluster add --host 192.168.200.11 --auth-token token -u cassandra -p cassandra --name myc
965faf8d-5473-4198-b35a-6f6b6a2b4aa8
 __  
/  \     Cluster added! You can set it as default, by exporting its name or ID as env variable:
@  @     $ export SCYLLA_MANAGER_CLUSTER=965faf8d-5473-4198-b35a-6f6b6a2b4aa8
|  |     $ export SCYLLA_MANAGER_CLUSTER=myc
|| |/    
|| ||    Now run:
|\_/|    $ sctool status -c myc
\___/    $ sctool tasks -c myc


miles@fedora:~/scylla-manager$ ./sctool.dev cluster list
╭──────────────────────────────────────┬──────┬────────┬─────────┬─────────────╮
│ ID                                   │ Name │ Labels │ Port    │ Credentials │
├──────────────────────────────────────┼──────┼────────┼─────────┼─────────────┤
│ 965faf8d-5473-4198-b35a-6f6b6a2b4aa8 │ myc  │        │ default │ CQL         │
╰──────────────────────────────────────┴──────┴────────┴─────────┴─────────────╯

miles@fedora:~/scylla-manager$ ./sctool.dev cluster update --alternator-access-key-id key --alternator-secret-access-key key -c myc

miles@fedora:~/scylla-manager$ ./sctool.dev cluster list
╭──────────────────────────────────────┬──────┬────────┬─────────┬─────────────────╮
│ ID                                   │ Name │ Labels │ Port    │ Credentials     │
├──────────────────────────────────────┼──────┼────────┼─────────┼─────────────────┤
│ 965faf8d-5473-4198-b35a-6f6b6a2b4aa8 │ myc  │        │ default │ CQL, Alternator │
╰──────────────────────────────────────┴──────┴────────┴─────────┴─────────────────╯

miles@fedora:~/scylla-manager$ ./sctool.dev cluster update -c myc --delete-alternator-credentials

miles@fedora:~/scylla-manager$ ./sctool.dev cluster list
╭──────────────────────────────────────┬──────┬────────┬─────────┬─────────────╮
│ ID                                   │ Name │ Labels │ Port    │ Credentials │
├──────────────────────────────────────┼──────┼────────┼─────────┼─────────────┤
│ 965faf8d-5473-4198-b35a-6f6b6a2b4aa8 │ myc  │        │ default │ CQL         │
╰──────────────────────────────────────┴──────┴────────┴─────────┴─────────────╯

```

Fixes #4510
