### PR TITLE
Setup alternator over TLS when SSL_ENABLED=true

### DIFF
--- a/pkg/ping/dynamoping/dynamoping_integration_test.go
+++ b/pkg/ping/dynamoping/dynamoping_integration_test.go
@@ -22,6 +22,15 @@ func TestPingIntegration(t *testing.T) {
 		Timeout:                250 * time.Millisecond,
 		RequiresAuthentication: true,
 	}
+	if testconfig.IsSSLEnabled() {
+		config.Addr = "https://" + testconfig.ManagedClusterHost() + ":8100"
+		sslOpts := testconfig.CQLSSLOptions()
+		tlsConfig, err := testconfig.TLSConfig(sslOpts)
+		if err != nil {
+			t.Fatalf("setup tls config: %v", err)
+		}
+		config.TLSConfig = tlsConfig
+	}
 
 	t.Run("simple", func(t *testing.T) {
 		d, err := SimplePing(context.Background(), config)

--- a/pkg/service/cluster/service_integration_test.go
+++ b/pkg/service/cluster/service_integration_test.go
@@ -104,9 +104,9 @@ func TestValidateHostConnectivityIntegration(t *testing.T) {
 					}
 				}
 			}()
-			TryUnblockCQL(t, ManagedClusterHosts())
+			TryUnblockCQL(t, ManagedClusterHosts(), IsSSLEnabled())
 			TryUnblockREST(t, ManagedClusterHosts())
-			TryUnblockAlternator(t, ManagedClusterHosts())
+			TryUnblockAlternator(t, ManagedClusterHosts(), IsSSLEnabled())
 			TryStartAgent(t, ManagedClusterHosts())
 			if err := EnsureNodesAreUP(t, ManagedClusterHosts(), time.Minute); err != nil {
 				t.Fatalf("not all nodes are UP, err = {%v}", err)

--- a/pkg/service/healthcheck/service_integration_test.go
+++ b/pkg/service/healthcheck/service_integration_test.go
@@ -49,9 +49,9 @@ func TestStatus_Ping_Independent_From_REST_Integration(t *testing.T) {
 	}
 
 	// Given
-	TryUnblockCQL(t, ManagedClusterHosts())
+	TryUnblockCQL(t, ManagedClusterHosts(), IsSSLEnabled())
 	TryUnblockREST(t, ManagedClusterHosts())
-	TryUnblockAlternator(t, ManagedClusterHosts())
+	TryUnblockAlternator(t, ManagedClusterHosts(), IsSSLEnabled())
 	TryStartAgent(t, ManagedClusterHosts())
 	if err := EnsureNodesAreUP(t, ManagedClusterHosts(), time.Minute); err != nil {
 		t.Fatalf("not all nodes are UP, err = {%v}", err)
@@ -214,15 +214,15 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 	// Tests here do not test the dynamic t/o functionality
 	c := DefaultConfig()
 
-	TryUnblockCQL(t, ManagedClusterHosts())
+	TryUnblockCQL(t, ManagedClusterHosts(), IsSSLEnabled())
 	TryUnblockREST(t, ManagedClusterHosts())
-	TryUnblockAlternator(t, ManagedClusterHosts())
+	TryUnblockAlternator(t, ManagedClusterHosts(), IsSSLEnabled())
 	TryStartAgent(t, ManagedClusterHosts())
 
 	defer func() {
-		TryUnblockCQL(t, ManagedClusterHosts())
+		TryUnblockCQL(t, ManagedClusterHosts(), IsSSLEnabled())
 		TryUnblockREST(t, ManagedClusterHosts())
-		TryUnblockAlternator(t, ManagedClusterHosts())
+		TryUnblockAlternator(t, ManagedClusterHosts(), IsSSLEnabled())
 		TryStartAgent(t, ManagedClusterHosts())
 	}()
 
@@ -338,8 +338,8 @@ func testStatusIntegration(t *testing.T, clusterID uuid.UUID, clusterSvc cluster
 
 	t.Run("node Alternator TIMEOUT", func(t *testing.T) {
 		host := IPFromTestNet("12")
-		BlockAlternator(t, host)
-		defer UnblockAlternator(t, host)
+		BlockAlternator(t, host, IsSSLEnabled())
+		defer UnblockAlternator(t, host, IsSSLEnabled())
 
 		status, err := s.Status(context.Background(), clusterID)
 		if err != nil {

--- a/pkg/testutils/exec.go
+++ b/pkg/testutils/exec.go
@@ -41,6 +41,12 @@ const (
 	// CmdUnblockScyllaAlternator defines the command used for unblocking the Scylla Alternator access.
 	CmdUnblockScyllaAlternator = "iptables -D INPUT -p tcp --destination-port 8000 -j DROP"
 
+	// CmdBlockScyllaAlternatorSSL defines the command used for blocking the Scylla Alternator access.
+	CmdBlockScyllaAlternatorSSL = "iptables -A INPUT -p tcp --destination-port 8100 -j DROP"
+
+	// CmdUnblockScyllaAlternatorSSL defines the command used for unblocking the Scylla Alternator access.
+	CmdUnblockScyllaAlternatorSSL = "iptables -D INPUT -p tcp --destination-port 8100 -j DROP"
+
 	// CmdOrTrueAppend let to accept shell command failure and proceed.
 	CmdOrTrueAppend = " || true"
 )
@@ -213,37 +219,53 @@ func UnblockCQL(t *testing.T, h string, sslEnabled bool) {
 
 // TryUnblockCQL tries to unblock the CQL ports on []hosts machines.
 // Logs an error if the execution failed, but doesn't return it.
-func TryUnblockCQL(t *testing.T, hosts []string) {
+func TryUnblockCQL(t *testing.T, hosts []string, sslEnabled bool) {
 	t.Helper()
+	cmd := CmdUnblockScyllaCQL
+	if sslEnabled {
+		cmd = CmdUnblockScyllaCQLSSL
+	}
 	for _, host := range hosts {
-		if err := RunIptablesCommand(t, host, CmdUnblockScyllaCQL+CmdOrTrueAppend); err != nil {
+		if err := RunIptablesCommand(t, host, cmd+CmdOrTrueAppend); err != nil {
 			t.Log(err)
 		}
 	}
 }
 
 // BlockAlternator blocks the Scylla Alternator ports on h machine by dropping TCP packets.
-func BlockAlternator(t *testing.T, h string) {
+func BlockAlternator(t *testing.T, h string, sslEnabled bool) {
 	t.Helper()
-	if err := RunIptablesCommand(t, h, CmdBlockScyllaAlternator); err != nil {
+	cmd := CmdBlockScyllaAlternator
+	if sslEnabled {
+		cmd = CmdBlockScyllaAlternatorSSL
+	}
+	if err := RunIptablesCommand(t, h, cmd); err != nil {
 		t.Error(err)
 	}
 }
 
 // UnblockAlternator unblocks the Alternator ports on []hosts machines.
-func UnblockAlternator(t *testing.T, h string) {
+func UnblockAlternator(t *testing.T, h string, sslEnabled bool) {
 	t.Helper()
-	if err := RunIptablesCommand(t, h, CmdUnblockScyllaAlternator); err != nil {
+	cmd := CmdUnblockScyllaAlternator
+	if sslEnabled {
+		cmd = CmdUnblockScyllaAlternatorSSL
+	}
+	if err := RunIptablesCommand(t, h, cmd); err != nil {
 		t.Error(err)
 	}
 }
 
 // TryUnblockAlternator tries to unblock the Alternator API ports on []hosts machines.
 // Logs an error if the execution failed, but doesn't return it.
-func TryUnblockAlternator(t *testing.T, hosts []string) {
+func TryUnblockAlternator(t *testing.T, hosts []string, sslEnabled bool) {
 	t.Helper()
+	cmd := CmdUnblockScyllaAlternator
+	if sslEnabled {
+		cmd = CmdUnblockScyllaAlternatorSSL
+	}
 	for _, host := range hosts {
-		if err := RunIptablesCommand(t, host, CmdUnblockScyllaAlternator+CmdOrTrueAppend); err != nil {
+		if err := RunIptablesCommand(t, host, cmd+CmdOrTrueAppend); err != nil {
 			t.Log(err)
 		}
 	}

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -58,7 +58,7 @@ build: ## Build custom docker image
 .PHONY: up
 up: ## Start docker containers
 up:
-	@echo "==> Starting testing env with SCYLLA_VERSION=$(SCYLLA_VERSION) and IP_FAMILY=$(IP_FAMILY) and RAFT_SCHEMA=$(RAFT_SCHEMA) and TABLETS=$(TABLETS)"
+	@echo "==> Starting testing env with SCYLLA_VERSION=$(SCYLLA_VERSION) and IP_FAMILY=$(IP_FAMILY) and RAFT_SCHEMA=$(RAFT_SCHEMA) and TABLETS=$(TABLETS) and SSL_ENABLED=$(SSL_ENABLED)"
 # Scylla bootstrap procedure have requirements that leads us to follow certain recipe:
 # 1. Spin up first node on the cluster
 # 2. Spin up and join other seed node, which is first node from DC2
@@ -70,8 +70,9 @@ up:
 	@$(YQ) write -i scylla/scylla.yaml 'object_storage_endpoints[0].(name)' $(MINIO_HOST)
 
 ifeq ($(SSL_ENABLED),true)
-	# disable non-ssl port
+	# disable non-ssl ports
 	@$(YQ) delete -i scylla/scylla.yaml 'native_transport_port'
+	@$(YQ) delete -i scylla/scylla.yaml 'alternator_port'
 	# merge into scylla.yaml values from config/scylla-ssl.yaml with overwrite option (-x)
 	@$(YQ) merge -i -x scylla/scylla.yaml scylla/config/scylla-ssl.yaml
 	@cp scylla/config/cqlshrc-ssl scylla/cqlshrc

--- a/testing/scylla/config/scylla-ssl.yaml
+++ b/testing/scylla/config/scylla-ssl.yaml
@@ -8,3 +8,8 @@ client_encryption_options:
     keyfile: /etc/scylla/db.key
     truststore: /etc/scylla/ca.crt
     require_client_auth: true
+
+alternator_https_port: 8100
+alternator_encryption_options:
+    certificate: /etc/scylla/db.crt
+    keyfile: /etc/scylla/db.key


### PR DESCRIPTION
This PR makes it so alternator setup respects `SSL_ENABLED` test env variable.

Fixes #4552

