### PR TITLE
Fix alternator backup/restore for scylla 2024.1

### DIFF
--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -250,6 +250,13 @@ func (ni *NodeInfo) SupportsAlternatorSchemaBackupFromAPI() (bool, error) {
 	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2025.1")
 }
 
+// SupportsAlternatorCreateGSIOnExistingTable returns true if it's possible to
+// create alternator GSI on existing table with alternator API.
+func (ni *NodeInfo) SupportsAlternatorCreateGSIOnExistingTable() (bool, error) {
+	// Refs https://github.com/scylladb/scylladb/issues/11567
+	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2025.1")
+}
+
 // SupportsNativeBackupAPI returns whether node exposes /storage_service/backup API.
 func (ni *NodeInfo) SupportsNativeBackupAPI() (bool, error) {
 	// Check ENT

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -2264,7 +2264,7 @@ func TestBackupAlternatorIntegration(t *testing.T) {
 
 	accessKeyID, secretAccessKey := GetAlternatorCreds(t, clusterSession, "")
 	client := CreateAlternatorClient(t, h.Client, ManagedClusterHost(), accessKeyID, secretAccessKey)
-	CreateAlternatorTable(t, client, 0, testTable)
+	CreateAlternatorTable(t, client, 0, 0, testTable)
 	InsertAlternatorTableData(t, client, rowCnt, testTable)
 
 	Print("When: validate data insertion")
@@ -2720,7 +2720,7 @@ func TestTGetDescribeSchemaIntegration(t *testing.T) {
 		tabAltTag     = "tab_alt_tag"
 		tabAltTTLAttr = "tab_alt_ttl_attr"
 	)
-	CreateAlternatorTable(t, client, 1, tabAlt)
+	CreateAlternatorTable(t, client, 1, 0, tabAlt)
 	CreateAlternatorGSI(t, client, tabAlt, tabAltGSI)
 	TagAlternatorTable(t, client, tabAlt, tabAltTag)
 	UpdateAlternatorTableTTL(t, client, tabAlt, tabAltTTLAttr, true)

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1891,7 +1891,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		Print("When: create alternator table with 1 row")
 		accessKeyID, secretAccessKey := GetAlternatorCreds(t, clusterSession, "")
 		client := CreateAlternatorClient(t, h.Client, ManagedClusterHost(), accessKeyID, secretAccessKey)
-		CreateAlternatorTable(t, client, 0, testTable)
+		CreateAlternatorTable(t, client, 0, 0, testTable)
 		InsertAlternatorTableData(t, client, 100, testTable)
 		defer dropKeyspace(t, clusterSession, testKeyspace)
 

--- a/pkg/service/restore/worker.go
+++ b/pkg/service/restore/worker.go
@@ -130,6 +130,13 @@ func (w *worker) getLocationInfo(ctx context.Context, target Target) ([]Location
 	return result, nil
 }
 
+func (w *worker) anyNodeConfig() (configcache.NodeConfig, bool) {
+	for _, nc := range w.nodeConfig {
+		return nc, true
+	}
+	return configcache.NodeConfig{}, false
+}
+
 // From map[k]v to map[v]k.
 func reverseMap(m map[string]string) map[string]string {
 	result := make(map[string]string, len(m))

--- a/pkg/service/restore/worker_views.go
+++ b/pkg/service/restore/worker_views.go
@@ -14,7 +14,11 @@ import (
 )
 
 func (w *worker) stageDropViews(ctx context.Context) error {
-	aw, err := newAlternatorDropViewsWorker(ctx, w.alternatorClient, w.run.Views)
+	nc, ok := w.anyNodeConfig()
+	if !ok {
+		return errors.New("no node config")
+	}
+	aw, err := newAlternatorDropViewsWorker(ctx, w.alternatorClient, nc.NodeInfo, w.run.Views)
 	if err != nil {
 		return errors.Wrap(err, "create alternator drop views worker")
 	}
@@ -35,7 +39,11 @@ func (w *worker) stageDropViews(ctx context.Context) error {
 }
 
 func (w *worker) stageRecreateViews(ctx context.Context) error {
-	aw, err := newAlternatorCreateViewsWorker(ctx, w.alternatorClient, w.run.Views)
+	nc, ok := w.anyNodeConfig()
+	if !ok {
+		return errors.New("no node config")
+	}
+	aw, err := newAlternatorCreateViewsWorker(ctx, w.alternatorClient, nc.NodeInfo, w.run.Views)
 	if err != nil {
 		return errors.Wrap(err, "create alternator create views worker")
 	}


### PR DESCRIPTION
In scylla 2024.1 creating GSIs on existing table is not possible.
Because of that, we need to implement the same workaround as for
restoring LSIs, so just don't interact with them during data restoration.

The test for alternator backup/restore was mistakenly skipped because of
the assumption that if we can't back up alternator schema in a form of schema file,
then we can't restore it. That's not true for scylla 2024.1 where we can safely back up and restore
alternator schema from sstables, but we should still properly use alternator
api for handling other things (e.g. dropping and recreating views).
