### PR TITLE
Don't check healthcheck task mode by task name

### DIFF
--- a/pkg/cmd/scylla-manager/server.go
+++ b/pkg/cmd/scylla-manager/server.go
@@ -352,8 +352,10 @@ func (s *server) startServices(ctx context.Context) error {
 	if err := s.clusterSvc.Init(ctx); err != nil {
 		return errors.Wrap(err, "cluster service")
 	}
+	// Not being able to update healthcheck tasks is not critical,
+	// so we shouldn't fail service start because of that.
 	if err := s.schedSvc.UpdateHealthcheckTasks(ctx, s.config.Healthcheck); err != nil {
-		return errors.Wrap(err, "update healthcheck tasks")
+		s.logger.Error(ctx, "Failed to update healthcheck tasks", "error", err)
 	}
 	if err := s.schedSvc.LoadTasks(ctx); err != nil {
 		return errors.Wrap(err, "schedule service")

--- a/pkg/service/healthcheck/runner.go
+++ b/pkg/service/healthcheck/runner.go
@@ -27,12 +27,12 @@ type Runner struct {
 }
 
 func (r Runner) Run(ctx context.Context, clusterID, taskID, runID uuid.UUID, properties json.RawMessage) error {
-	p := taskProperties{}
-	if err := json.Unmarshal(properties, &p); err != nil {
-		return util.ErrValidate(err)
+	m, err := ModeFromProperties(properties)
+	if err != nil {
+		return err
 	}
 
-	switch p.Mode {
+	switch m {
 	case CQLMode:
 		return r.cql.Run(ctx, clusterID, taskID, runID, properties)
 	case RESTMode:
@@ -42,6 +42,15 @@ func (r Runner) Run(ctx context.Context, clusterID, taskID, runID uuid.UUID, pro
 	default:
 		return errors.Errorf("unspecified mode")
 	}
+}
+
+// ModeFromProperties return Mode of healthcheck task based on its properties.
+func ModeFromProperties(properties json.RawMessage) (Mode, error) {
+	p := taskProperties{}
+	if err := json.Unmarshal(properties, &p); err != nil {
+		return "", util.ErrValidate(err)
+	}
+	return p.Mode, nil
 }
 
 type runner struct {

--- a/pkg/service/scheduler/service_integration_test.go
+++ b/pkg/service/scheduler/service_integration_test.go
@@ -341,6 +341,7 @@ func TestServiceScheduleIntegration(t *testing.T) {
 				Sched: scheduler.Schedule{
 					Cron: healthcheck.DefaultConfig().CQLPingCron,
 				},
+				Properties: json.RawMessage(`{"mode": "cql"}`),
 			},
 			{
 				ClusterID: h.clusterID,
@@ -350,6 +351,7 @@ func TestServiceScheduleIntegration(t *testing.T) {
 				Sched: scheduler.Schedule{
 					Cron: healthcheck.DefaultConfig().RESTPingCron,
 				},
+				Properties: json.RawMessage(`{"mode": "rest"}`),
 			},
 			{
 				ClusterID: h.clusterID,
@@ -359,6 +361,7 @@ func TestServiceScheduleIntegration(t *testing.T) {
 				Sched: scheduler.Schedule{
 					Cron: healthcheck.DefaultConfig().AlternatorPingCron,
 				},
+				Properties: json.RawMessage(`{"mode": "alternator"}`),
 			},
 		}
 		for _, task := range tasks {
@@ -407,6 +410,17 @@ func TestServiceScheduleIntegration(t *testing.T) {
 			if nameToSpec[task.Name] != task.Sched.Cron.Spec {
 				t.Fatalf("Healthcheck task %s cron spec %q: expected %q", task.Name, task.Sched.Cron.Spec, nameToSpec[task.Name])
 			}
+		}
+
+		// Checks for #4599
+		Print("When: delete one healthcheck task")
+		if err := h.service.DeleteTask(ctx, tasks[0]); err != nil {
+			t.Fatal(err)
+		}
+
+		Print("Then: update healthcheck tasks succeeds")
+		if err := h.service.UpdateHealthcheckTasks(ctx, cfg); err != nil {
+			t.Fatal(err)
 		}
 	})
 


### PR DESCRIPTION
As described in the fixed issue, task names are deleted when tasks are deleted
(even though the tasks themselves are kept in the SM DB with 'deleted' column set to true).
Even though users shouldn't delete healthcheck tasks, they are deleted automatically
on cluster deletion. Since UpdateHealthcheckTasks works on task from all clusters,
it was panicking when trying to get healthcheck task mode from the task deleted name.

This commit makes a few improvements to this process:
- healthcheck task mode is extracted from task properties, not the problematic name
- UpdateHealthcheckTasks is not applied on deleted tasks
- UpdateHealthcheckTasks does not stop trying to update tasks on first error
- error in UpdateHealthcheckTasks won't cause service startup error

This commit also adds a simple test for the case which detected this issue.

Fixes #4599
