### PR TITLE
Don't access unset Run.EndTime

### DIFF
--- a/pkg/service/scheduler/model.go
+++ b/pkg/service/scheduler/model.go
@@ -366,6 +366,15 @@ type Run struct {
 	EndTime   *time.Time `json:"end_time,omitempty"`
 }
 
+// Duration checks if both EndTime and StartTime are set correctly and returns
+// their difference formatted as a string. Otherwise, it returns "unknown" duration.
+func (r Run) Duration() string {
+	if r.EndTime != nil && !r.EndTime.IsZero() && !r.StartTime.IsZero() {
+		return r.EndTime.Sub(r.StartTime).String()
+	}
+	return "unknown"
+}
+
 func newRunFromTaskInfo(ti taskInfo) *Run {
 	var id uuid.UUID
 	if ti.TaskType == HealthCheckTask {

--- a/pkg/service/scheduler/service.go
+++ b/pkg/service/scheduler/service.go
@@ -426,13 +426,13 @@ func (s *Service) run(ctx RunContext) (runErr error) {
 					"task", ti,
 					"status", r.Status,
 					"cause", r.Cause,
-					"duration", r.EndTime.Sub(r.StartTime),
+					"duration", r.Duration(),
 				)
 			} else {
 				logger.Info(runCtx, "Run ended",
 					"task", ti,
 					"status", r.Status,
-					"duration", r.EndTime.Sub(r.StartTime),
+					"duration", r.Duration(),
 				)
 			}
 		}()


### PR DESCRIPTION
Accessing `Run.EndTime` in deferred function caused panic in cases where the run couldn't be executed because of other errors.

The issue is obvious, but we don't have tools for easily reproducing it with existing codebase.
I tested the fix manually by always returning an error from `putRunAndUpdateTask`.
Without the fix, it panics when `putRunAndUpdateTask` returns an error, with the fix it works fine and just logs `unknown` run duration.

Fixes #4601
