### PR TITLE
Hide restore method from users

### DIFF
--- a/docs/source/sctool/partials/sctool_restore.yaml
+++ b/docs/source/sctool/partials/sctool_restore.yaml
@@ -98,19 +98,6 @@ options:
         Note that specifying datacenters closest to backup locations might reduce download time of restored data.
         The supported storage '<provider>'s are 'azure', 'gcs', 's3'.
         The `<bucket>` parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
-    - name: method
-      default_value: rclone
-      usage: |
-        Specify the API used for restoring files:
-        - 'auto': Use the native API when possible, otherwise use the Rclone API.
-        - 'native': Scylla server streams directly from backup location (supports only S3 provider).
-        - 'rclone': Scylla Manager Agent downloads from backup location and calls Scylla server for streaming afterwards.
-
-        Both methods require configuring the Scylla Manager Agent in 'scylla-manager-agent.yaml'.
-        The native API also requires 'object_storage_endpoints' to be configured in 'scylla.yaml' (See https://docs.scylladb.com/manual/stable/operating-scylla/admin.html#object-storage-configuration).
-
-        '--rate-limit', '--transfers', '--unpin-agent-cpu' flags do not take effect when using '--method=native',
-        as the streaming performance is controlled by the Scylla server.
     - name: name
       usage: |
         Task name that can be used instead of ID.

--- a/docs/source/sctool/partials/sctool_restore_update.yaml
+++ b/docs/source/sctool/partials/sctool_restore_update.yaml
@@ -96,19 +96,6 @@ options:
         Note that specifying datacenters closest to backup locations might reduce download time of restored data.
         The supported storage '<provider>'s are 'azure', 'gcs', 's3'.
         The `<bucket>` parameter is a bucket name, it must be an alphanumeric string and **may contain a dash and or a dot, but other characters are forbidden**.
-    - name: method
-      default_value: rclone
-      usage: |
-        Specify the API used for restoring files:
-        - 'auto': Use the native API when possible, otherwise use the Rclone API.
-        - 'native': Scylla server streams directly from backup location (supports only S3 provider).
-        - 'rclone': Scylla Manager Agent downloads from backup location and calls Scylla server for streaming afterwards.
-
-        Both methods require configuring the Scylla Manager Agent in 'scylla-manager-agent.yaml'.
-        The native API also requires 'object_storage_endpoints' to be configured in 'scylla.yaml' (See https://docs.scylladb.com/manual/stable/operating-scylla/admin.html#object-storage-configuration).
-
-        '--rate-limit', '--transfers', '--unpin-agent-cpu' flags do not take effect when using '--method=native',
-        as the streaming performance is controlled by the Scylla server.
     - name: name
       usage: |
         Task name that can be used instead of ID.

--- a/pkg/command/restore/cmd.go
+++ b/pkg/command/restore/cmd.go
@@ -38,7 +38,6 @@ type command struct {
 	dryRun          bool
 	showTables      bool
 	dcMapping       map[string]string
-	method          string
 }
 
 func NewCommand(client *managerclient.Client) *cobra.Command {
@@ -93,7 +92,6 @@ func (cmd *command) init() {
 	w.Unwrap().BoolVar(&cmd.dryRun, "dry-run", false, "")
 	w.Unwrap().BoolVar(&cmd.showTables, "show-tables", false, "")
 	w.Unwrap().StringToStringVar(&cmd.dcMapping, "dc-mapping", nil, "")
-	w.Unwrap().StringVar(&cmd.method, "method", "rclone", "")
 }
 
 func (cmd *command) run(args []string) error {
@@ -191,10 +189,6 @@ func (cmd *command) run(args []string) error {
 			return wrapper("dc-mapping")
 		}
 		props["dc_mapping"] = cmd.dcMapping
-		ok = true
-	}
-	if cmd.Flag("method").Changed {
-		props["method"] = cmd.method
 		ok = true
 	}
 

--- a/pkg/command/restore/res.yaml
+++ b/pkg/command/restore/res.yaml
@@ -84,15 +84,3 @@ dc-mapping: |
 
   Only works with tables restoration (--restore-tables=true). 
   Note: Only DCs that are provided in mappings will be restored.
-
-method: |
-  Specify the API used for restoring files:
-  - 'auto': Use the native API when possible, otherwise use the Rclone API.
-  - 'native': Scylla server streams directly from backup location (supports only S3 provider).
-  - 'rclone': Scylla Manager Agent downloads from backup location and calls Scylla server for streaming afterwards.
-  
-  Both methods require configuring the Scylla Manager Agent in 'scylla-manager-agent.yaml'.
-  The native API also requires 'object_storage_endpoints' to be configured in 'scylla.yaml' (See https://docs.scylladb.com/manual/stable/operating-scylla/admin.html#object-storage-configuration).
-  
-  '--rate-limit', '--transfers', '--unpin-agent-cpu' flags do not take effect when using '--method=native',
-  as the streaming performance is controlled by the Scylla server.

--- a/pkg/service/restore/model.go
+++ b/pkg/service/restore/model.go
@@ -110,6 +110,7 @@ func parseTarget(properties json.RawMessage) (Target, error) {
 	if err := json.Unmarshal(properties, &t); err != nil {
 		return Target{}, err
 	}
+	t.Method = MethodRclone
 	return t, t.validateProperties()
 }
 

--- a/pkg/service/restore/testdata/get_target/tables.target.json
+++ b/pkg/service/restore/testdata/get_target/tables.target.json
@@ -19,5 +19,5 @@
   "parallel": 98,
   "restore_tables": true,
   "continue": true,
-  "method": "auto"
+  "method": "rclone"
 }


### PR DESCRIPTION
This commit:
- removes 'sctool restore --method' flag
- ignores any method set in task properties
- adjusts tests to always expect --method=rclone (despite what is set in task properties)

Fixes #4609
