### PR TITLE
fix(docs): render repair --incremental-mode values as list

### DIFF
--- a/docs/source/sctool/partials/sctool_repair.yaml
+++ b/docs/source/sctool/partials/sctool_repair.yaml
@@ -60,6 +60,7 @@ options:
         Incremental repair mode used when repairing tablet tables.
         Available since ScyllaDB 2025.4. Setting it for older versions has no effect.
         It accepts the following values:
+
         - 'incremental': The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair.
         - 'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair.
         - 'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair.

--- a/docs/source/sctool/partials/sctool_repair_update.yaml
+++ b/docs/source/sctool/partials/sctool_repair_update.yaml
@@ -61,6 +61,7 @@ options:
         Incremental repair mode used when repairing tablet tables.
         Available since ScyllaDB 2025.4. Setting it for older versions has no effect.
         It accepts the following values:
+
         - 'incremental': The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair.
         - 'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair.
         - 'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair.

--- a/pkg/command/repair/res.yaml
+++ b/pkg/command/repair/res.yaml
@@ -36,9 +36,10 @@ incremental-mode: |
   Incremental repair mode used when repairing tablet tables.
   Available since ScyllaDB 2025.4. Setting it for older versions has no effect.
   It accepts the following values:
-  - 'incremental': The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair.
-  - 'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair.
-  - 'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair.
+  
+  * 'incremental': The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair.
+  * 'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair.
+  * 'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair.
 
 dry-run: |
   Validates and displays repair information without actually scheduling the repair.


### PR DESCRIPTION
Previous to this change, repair --incremental-mode values were displayed as a bullet list in `sctool repair --help` output, but they were clamped together in the .rst SM docs display. This commit fixes the .rst bullet list formatting while preserving it in `sctool repair --help` output.

Before the change:
<img width="1396" height="223" alt="image" src="https://github.com/user-attachments/assets/f6eecc20-a9b4-4916-b3de-dfcc6cc9c36d" />

After the change:
<img width="1419" height="339" alt="image" src="https://github.com/user-attachments/assets/3926f87f-565a-495b-b9d8-8e3ed4544ecd" />

cc: @mikliapko 