### PR TITLE
Add SM 3.7 docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,9 +7,9 @@ from sphinx_scylladb_theme.utils import multiversion_regex_builder
 
 # Build documentation for the following tags and branches
 TAGS = []
-BRANCHES = ['master', 'branch-3.4', 'branch-3.5', 'branch-3.6']
+BRANCHES = ['master', 'branch-3.5', 'branch-3.6', 'branch-3.7']
 # Set the latest version.
-LATEST_VERSION = 'branch-3.6'
+LATEST_VERSION = 'branch-3.7'
 # Set which versions are not released yet.
 UNSTABLE_VERSIONS = ['master']
 # Set which versions are deprecated


### PR DESCRIPTION
This PR:
- adds SM 3.7 docs
- marks SM 3.7 as latest stable in docs
