### PR TITLE
Don't display "invalid IP" when repair --host is not set

### DIFF
--- a/pkg/service/repair/model.go
+++ b/pkg/service/repair/model.go
@@ -45,6 +45,14 @@ type Target struct {
 	IncrementalMode     scyllaclient.IncrementalMode `json:"incremental_mode"`
 }
 
+// HostString is a wrapper for Target.Host.String().
+func (t Target) HostString() string {
+	if t.Host.IsValid() {
+		return t.Host.String()
+	}
+	return ""
+}
+
 // taskProperties is the main data structure of the runner.Properties blob.
 type taskProperties struct {
 	Keyspace            []string                         `json:"keyspace"`

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -289,7 +289,7 @@ func (s *Service) Repair(ctx context.Context, clusterID, taskID, runID uuid.UUID
 		TaskID:    taskID,
 		ID:        runID,
 		DC:        target.DC,
-		Host:      target.Host.String(),
+		Host:      target.HostString(),
 		Parallel:  target.Parallel,
 		Intensity: target.Intensity,
 		StartTime: timeutc.Now(),


### PR DESCRIPTION
Before:

```
miles@fedora:~/scylla-manager$ ./sctool.dev progress -c myc repair/haha
Run:            fe65aa7d-d430-11f0-acec-0892040e83bb
Status:         DONE
Start time:     08 Dec 25 13:25:34 CET
End time:       08 Dec 25 13:25:34 CET
Duration:       0s
Progress:       -
Intensity:      1
Parallel:       0
Host:   invalid IP
Datacenters:    
  - dc1
  - dc2
```

After:

```
miles@fedora:~/scylla-manager$ ./sctool.dev progress -c myc repair/reppp
Run:            2f272296-d439-11f0-92b9-0892040e83bb
Status:         DONE
Start time:     08 Dec 25 14:24:11 CET
End time:       08 Dec 25 14:24:13 CET
Duration:       2s
Progress:       100%
Intensity:      1
Parallel:       0
Datacenters:    
  - dc1
  - dc2

╭───────────────────────────────┬────────────────────────────────┬──────────┬──────────╮
│ Keyspace                      │                          Table │ Progress │ Duration │
├───────────────────────────────┼────────────────────────────────┼──────────┼──────────┤
│ system_distributed_everywhere │ cdc_generation_descriptions_v2 │ 100%     │ 1s       │
├───────────────────────────────┼────────────────────────────────┼──────────┼──────────┤
│ system_distributed            │      cdc_generation_timestamps │ 100%     │ 1s       │
│ system_distributed            │    cdc_streams_descriptions_v2 │ 100%     │ 1s       │
│ system_distributed            │                 service_levels │ 100%     │ 1s       │
│ system_distributed            │              view_build_status │ 100%     │ 1s       │
├───────────────────────────────┼────────────────────────────────┼──────────┼──────────┤
│ system_replicated_keys        │                 encrypted_keys │ 100%     │ 1s       │
╰───────────────────────────────┴────────────────────────────────┴──────────┴──────────╯
```

Fixes https://github.com/scylladb/siren/issues/14382