### PR TITLE
Look for first slash when parsing task type

### DIFF
--- a/v3/pkg/managerclient/utils.go
+++ b/v3/pkg/managerclient/utils.go
@@ -29,7 +29,7 @@ func TaskSplit(s string) (taskType string, taskID uuid.UUID, taskName string, er
 		return
 	}
 
-	i := strings.LastIndex(s, "/")
+	i := strings.Index(s, "/")
 	if i != -1 {
 		taskType = s[:i]
 	} else {


### PR DESCRIPTION
Task names are not restricted, so they can contain slashes. Task types are controlled by us and they shouldn't contain slashes. So in problematic scenarios, where task name contains slashes, we should look for the first slash in TaskSplit instead of the last one.

After those changes:
```
miles@fedora:~/scylla-manager$ ./sctool.dev repair -c myc --name repair/custom
repair/repair/custom

...

miles@fedora:~/scylla-manager$ ./sctool.dev tasks -c myc
╭────────────────────────┬────────┬──────────────┬────────┬───────────────┬─────────┬───────┬────────────────────────┬────────────┬────────┬────────────────────────╮
│ Task                   │ Labels │ Schedule     │ Window │ Timezone      │ Success │ Error │ Last Success           │ Last Error │ Status │ Next                   │
├────────────────────────┼────────┼──────────────┼────────┼───────────────┼─────────┼───────┼────────────────────────┼────────────┼────────┼────────────────────────┤
│ healthcheck/alternator │        │ * * * * *    │        │ Europe/Warsaw │ 39      │ 0     │ 08 Dec 25 15:04:00 CET │            │ DONE   │ 08 Dec 25 15:05:00 CET │
│ healthcheck/rest       │        │ * * * * *    │        │ Europe/Warsaw │ 39      │ 0     │ 08 Dec 25 15:04:00 CET │            │ DONE   │ 08 Dec 25 15:05:00 CET │
│ healthcheck/cql        │        │ * * * * *    │        │ Europe/Warsaw │ 39      │ 0     │ 08 Dec 25 15:04:00 CET │            │ DONE   │ 08 Dec 25 15:05:00 CET │
│ repair/repair/custom   │        │              │        │ Europe/Warsaw │ 1       │ 0     │ 08 Dec 25 15:04:00 CET │            │ DONE   │                        │
╰────────────────────────┴────────┴──────────────┴────────┴───────────────┴─────────┴───────┴────────────────────────┴────────────┴────────┴────────────────────────╯

...

miles@fedora:~/scylla-manager$ ./sctool.dev stop --delete -c myc repair/repair/custom

...

miles@fedora:~/scylla-manager$ ./sctool.dev tasks -c myc
╭────────────────────────┬────────┬──────────────┬────────┬───────────────┬─────────┬───────┬────────────────────────┬────────────┬────────┬────────────────────────╮
│ Task                   │ Labels │ Schedule     │ Window │ Timezone      │ Success │ Error │ Last Success           │ Last Error │ Status │ Next                   │
├────────────────────────┼────────┼──────────────┼────────┼───────────────┼─────────┼───────┼────────────────────────┼────────────┼────────┼────────────────────────┤
│ healthcheck/alternator │        │ * * * * *    │        │ Europe/Warsaw │ 39      │ 0     │ 08 Dec 25 15:04:00 CET │            │ DONE   │ 08 Dec 25 15:05:00 CET │
│ healthcheck/rest       │        │ * * * * *    │        │ Europe/Warsaw │ 39      │ 0     │ 08 Dec 25 15:04:00 CET │            │ DONE   │ 08 Dec 25 15:05:00 CET │
│ healthcheck/cql        │        │ * * * * *    │        │ Europe/Warsaw │ 39      │ 0     │ 08 Dec 25 15:04:00 CET │            │ DONE   │ 08 Dec 25 15:05:00 CET │
╰────────────────────────┴────────┴──────────────┴────────┴───────────────┴─────────┴───────┴────────────────────────┴────────────┴────────┴────────────────────────╯

```

Fixes #4653
