### PR TITLE
Add backup delete local snapshot command

### DIFF
--- a/docs/source/sctool/partials/sctool_backup_delete.yaml
+++ b/docs/source/sctool/partials/sctool_backup_delete.yaml
@@ -42,3 +42,4 @@ inherited_options:
         If running sctool on the same machine as server, it's generated based on '/etc/scylla-manager/scylla-manager.yaml' file.
 see_also:
     - sctool backup - Schedule a backup (ad-hoc or scheduled)
+    - sctool backup delete local-snapshot - Delete local ScyllaDB Manager snapshots of a given cluster

--- a/docs/source/sctool/partials/sctool_backup_delete_local-snapshot.yaml
+++ b/docs/source/sctool/partials/sctool_backup_delete_local-snapshot.yaml
@@ -1,0 +1,31 @@
+name: sctool backup delete local-snapshot
+synopsis: Delete local ScyllaDB Manager snapshots of a given cluster
+description: |
+    This command removes local snapshots made by ScyllaDB Manager from nodes' disks.
+    It does not delete any files stored in the backup location.
+    Before running this command, ensure that all backup tasks are stopped.
+    After deletion, any interrupted backups should be started from scratch.
+usage: sctool backup delete local-snapshot --cluster <id|name> [flags]
+options:
+    - name: cluster
+      shorthand: c
+      usage: |
+        The target cluster `name or ID` (envvar SCYLLA_MANAGER_CLUSTER).
+    - name: help
+      shorthand: h
+      default_value: "false"
+      usage: help for local-snapshot
+inherited_options:
+    - name: api-cert-file
+      usage: |
+        File `path` to HTTPS client certificate used to access the Scylla Manager server when client certificate validation is enabled (envvar SCYLLA_MANAGER_API_CERT_FILE).
+    - name: api-key-file
+      usage: |
+        File `path` to HTTPS client key associated with --api-cert-file flag (envvar SCYLLA_MANAGER_API_KEY_FILE).
+    - name: api-url
+      default_value: http://127.0.0.1:5080/api/v1
+      usage: |
+        Base `URL` of Scylla Manager server (envvar SCYLLA_MANAGER_API_URL).
+        If running sctool on the same machine as server, it's generated based on '/etc/scylla-manager/scylla-manager.yaml' file.
+see_also:
+    - sctool backup delete - Delete backup files in remote locations

--- a/pkg/command/backup/backupdelete/cmd.go
+++ b/pkg/command/backup/backupdelete/cmd.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/scylladb/scylla-manager/v3/pkg/command/backup/backupdelete/localsnapshot"
 	"github.com/scylladb/scylla-manager/v3/pkg/command/flag"
 	"github.com/scylladb/scylla-manager/v3/pkg/managerclient"
 	"github.com/spf13/cobra"
@@ -38,6 +39,7 @@ func NewCommand(client *managerclient.Client) *cobra.Command {
 	cmd.RunE = func(_ *cobra.Command, _ []string) error {
 		return cmd.run()
 	}
+	cmd.AddCommand(localsnapshot.NewCommand(client))
 	return &cmd.Command
 }
 

--- a/pkg/command/backup/backupdelete/localsnapshot/cmd.go
+++ b/pkg/command/backup/backupdelete/localsnapshot/cmd.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 ScyllaDB
+
+package localsnapshot
+
+import (
+	_ "embed"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/command/flag"
+	"github.com/scylladb/scylla-manager/v3/pkg/managerclient"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+//go:embed res.yaml
+var res []byte
+
+type command struct {
+	cobra.Command
+
+	client *managerclient.Client
+
+	cluster string
+}
+
+func NewCommand(client *managerclient.Client) *cobra.Command {
+	cmd := &command{
+		client: client,
+	}
+	if err := yaml.Unmarshal(res, &cmd.Command); err != nil {
+		panic(err)
+	}
+	cmd.init()
+	cmd.RunE = func(_ *cobra.Command, _ []string) error {
+		return cmd.run()
+	}
+	return &cmd.Command
+}
+
+func (cmd *command) init() {
+	defer flag.MustSetUsages(&cmd.Command, res, "cluster")
+
+	w := flag.Wrap(cmd.Flags())
+	w.Cluster(&cmd.cluster)
+}
+
+func (cmd *command) run() error {
+	return cmd.client.DeleteLocalSnapshots(cmd.Context(), cmd.cluster)
+}

--- a/pkg/command/backup/backupdelete/localsnapshot/res.yaml
+++ b/pkg/command/backup/backupdelete/localsnapshot/res.yaml
@@ -1,0 +1,9 @@
+use: local-snapshot --cluster <id|name>
+
+short: Delete local ScyllaDB Manager snapshots of a given cluster
+
+long: |
+  This command removes local snapshots made by ScyllaDB Manager from nodes' disks.
+  It does not delete any files stored in the backup location.
+  Before running this command, ensure that all backup tasks are stopped.
+  After deletion, any interrupted backups should be started from scratch.


### PR DESCRIPTION
This commit adds `sctool backup delete local-snapshot` command.
It also runs `make docs`.

Fixes #4648
