### PR TITLE
Mark SM DB queries as idempotent by default

### DIFF
--- a/pkg/cmd/scylla-manager/db.go
+++ b/pkg/cmd/scylla-manager/db.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2025 ScyllaDB
 
 package main
 
@@ -119,6 +119,7 @@ func gocqlClusterConfigForDBInit(ctx context.Context, c config.Config, logger lo
 	cluster := gocqlClusterConfig(c)
 	cluster.Keyspace = "system"
 	cluster.Timeout = c.Database.MigrateTimeout
+	cluster.DefaultIdempotence = false
 	cluster.MaxWaitSchemaAgreement = c.Database.MigrateMaxWaitSchemaAgreement
 
 	cluster.Logger = gocqllog.StdLogger{
@@ -151,6 +152,7 @@ func gocqlClusterConfig(c config.Config) *gocql.ClusterConfig {
 
 	cluster.Keyspace = c.Database.Keyspace
 	cluster.Timeout = c.Database.Timeout
+	cluster.DefaultIdempotence = true
 	cluster.RetryPolicy = &gocql.ExponentialBackoffRetryPolicy{
 		NumRetries: 5,
 		Min:        time.Second,


### PR DESCRIPTION
As explained in the parent issue, we need to mark queries as idempotent for the retry mechanism to work. All CQL queries made by SM during its work are idempotent (they are just simple INSERT/SELECT/DELETE/UPDATE queries). On SM startup, it needs to migrate its schema and those queries are not idempotent. Because of that, this commit sets queries as idempotent by default for the CQL session used for regular SM work, and keeps them as not idempotent for the purposes of SM startup.

Fixes #4705
