### PR TITLE
.github/workflows/sanity-checks.yml: Potential fix for code scanning alert no. 53: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sanity-checks.yml
+++ b/.github/workflows/sanity-checks.yml
@@ -16,6 +16,8 @@ jobs:
   checks:
     name: Various checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-manager/security/code-scanning/53](https://github.com/scylladb/scylla-manager/security/code-scanning/53)

To fix this, add a `permissions` block that explicitly limits the `GITHUB_TOKEN` to the least privileges required. For this workflow, the steps only need to read the repository contents (for checkout and running tests), so `contents: read` at the job level is sufficient unless the local `.github/actions/test-setup` composite action requires more. The minimal non-breaking fix is to add `permissions: contents: read` under the `checks` job, keeping its behavior while preventing unintended write access if repo defaults are broad.

Concretely, in `.github/workflows/sanity-checks.yml`, under `jobs:`, inside the `checks:` job configuration (near line 17), insert a `permissions:` section at the same indentation level as `runs-on:` and `steps:`. The block should specify `contents: read`. No additional imports or dependencies are needed, as this is purely a YAML configuration change for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
