### PR TITLE
.github/workflows/docs-pages.yaml: Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -13,6 +13,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-manager/security/code-scanning/3](https://github.com/scylladb/scylla-manager/security/code-scanning/3)

In general, this issue is fixed by adding an explicit `permissions:` block either at the top level of the workflow (affecting all jobs) or inside each job (to scope permissions per job). The block should grant only the minimum permissions needed by the job. Since this workflow’s only job is to build and deploy documentation using `GITHUB_TOKEN`, the main requirement is the ability to push documentation updates (i.e., `contents: write`). If we want to be conservative and follow the CodeQL hint, we can start from `contents: read` and adjust, but given the `deploy.sh` nature, `contents: write` is appropriate.

The single best fix here, without changing existing functionality, is to add a `permissions` block for the `release` job, so we do not affect other workflows and can constrain this job’s token explicitly. We’ll add it directly under `release:` and before `runs-on: ubuntu-latest`. A reasonable set of least-privilege permissions for a typical GitHub Pages/docs publish that pushes to a branch is:
- `contents: write` (to push the built docs to a branch or repo)
If the deployment only needs read access (for example, pushing via SSH or a different token), we could restrict to `contents: read`, but that risks breaking the existing deployment. To avoid breaking functionality, we assume the script uses `GITHUB_TOKEN` for pushing and keep `contents: write`.

Concretely, in `.github/workflows/docs-pages.yaml`, add:
```yaml
    permissions:
      contents: write
```
between the `release:` line and `runs-on: ubuntu-latest`. No additional imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
