### PR TITLE
.github/workflows/docs-pr.yaml: Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -2,6 +2,9 @@ name: "Docs / Build PR"
 # For more information,
 # see https://sphinx-theme.scylladb.com/stable/deployment/production.html#available-workflows
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-manager/security/code-scanning/2](https://github.com/scylladb/scylla-manager/security/code-scanning/2)

In general, the fix is to explicitly define a minimal `permissions` block for the workflow or for the specific job so that the `GITHUB_TOKEN` used by this workflow has only the scopes it actually needs. Since this workflow only checks out code and runs `make` to build and test docs, it only needs read access to repository contents; it does not perform any write operations to GitHub.

The best way to fix this without changing existing functionality is to add `permissions: contents: read` at the top workflow level so it applies to all jobs in this file. Concretely, in `.github/workflows/docs-pr.yaml`, insert:

```yaml
permissions:
  contents: read
```

between the `name:` line and the `on:` block, or equivalently right under `name:`. This will constrain the `GITHUB_TOKEN` for all jobs in this workflow to read-only access to repository contents, which is sufficient for `actions/checkout` and the subsequent build steps. No additional imports, methods, or other definitions are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
