### PR TITLE
.github/workflows/release.yml: Potential fix for code scanning alert no. 48: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 permissions:
-  contents: read
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-manager/security/code-scanning/48](https://github.com/scylladb/scylla-manager/security/code-scanning/48)

To fix the problem, explicitly define the least-privilege `permissions` for this workflow or for the `release` job. Since there is only one job and it appears to only need read access to the repository contents, we can safely set `contents: read`. This limits the `GITHUB_TOKEN` so that even if the organization/repo default is `read-write`, this workflow will run with read-only contents permissions.

The best minimal fix without changing existing functionality is:

- Add a `permissions:` block at the workflow root (top level, alongside `name` and `on`) so it applies to all jobs.
- Set `contents: read` inside that block.

Concretely, edit `.github/workflows/release.yml` near the top:

- Insert

```yaml
permissions:
  contents: read
```

between the `name: Release` line and the `on:` block (or equivalently between `on:` and `jobs:`; both are valid, but placing it after `name` is clear and conventional). No imports or additional definitions are needed; this is pure YAML configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
