### PR TITLE
Stop disabled and stopped task

### DIFF
--- a/pkg/restapi/services.go
+++ b/pkg/restapi/services.go
@@ -96,7 +96,7 @@ type SchedService interface {
 	DeleteTask(ctx context.Context, t *scheduler.Task) error
 	ListTasks(ctx context.Context, clusterID uuid.UUID, filter scheduler.ListFilter) ([]*scheduler.TaskListItem, error)
 	StartTask(ctx context.Context, t *scheduler.Task) error
-	StopTask(ctx context.Context, t *scheduler.Task) error
+	StopTask(ctx context.Context, t *scheduler.Task, disable bool) error
 	SetTaskNoContinue(taskID uuid.UUID, force bool)
 	GetRun(ctx context.Context, t *scheduler.Task, runID uuid.UUID) (*scheduler.Run, error)
 	GetNthLastRun(ctx context.Context, t *scheduler.Task, n int) (*scheduler.Run, error)

--- a/pkg/restapi/task.go
+++ b/pkg/restapi/task.go
@@ -410,14 +410,7 @@ func (h *taskHandler) stopTask(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if t.Enabled && disable {
-		t.Enabled = false
-		// current task is canceled on save no need to stop it again
-		if err := h.Scheduler.PutTask(r.Context(), t); err != nil {
-			respondError(w, r, errors.Wrapf(err, "update task %q", t.ID))
-			return
-		}
-	} else if err := h.Scheduler.StopTask(r.Context(), t); err != nil {
+	if err := h.Scheduler.StopTask(r.Context(), t, disable); err != nil {
 		respondError(w, r, errors.Wrapf(err, "stop task %q", t.ID))
 		return
 	}


### PR DESCRIPTION
There are 2 ways of disabling a task:
- with 'sctool stop --disable' (or corresponding '/stop' API)
- by updating task's 'enabled' property

It makes some sense that directly modyfing 'enabled' property does not result in stopping the task, but it makes no sense that stopping and disabling the task does not stop the task.

It can even be seen in the removed comment:
'// current task is canceled on save no need to stop it again', which is false, that this behavior is unintended.
We also execute our tests as if the code executed when calling '/stop' endpoint wasn't supposed to stop the task.

This commit fixes behavior of '/stop' endpoint to always stop the task and additionally disable it if requested. To improve readability and testing, I moved the logic of disabling the task to Scheduer.StopTask method, so that the API handler can just call it, and we can just test it.

Fixes #4736
