### PR TITLE
Fill known hosts when parsing cluster from API

### DIFF
--- a/pkg/restapi/cluster.go
+++ b/pkg/restapi/cluster.go
@@ -149,6 +149,9 @@ func (h clusterHandler) updateCluster(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	newCluster.ID = c.ID
+	// Cluster.KnownHosts are not part of REST API definitions,
+	// so we need to fill them based on current cluster state.
+	newCluster.KnownHosts = c.KnownHosts
 
 	if err := h.svc.PutCluster(r.Context(), newCluster); err != nil {
 		respondError(w, r, errors.Wrapf(err, "update cluster %q", c.ID))


### PR DESCRIPTION
Cluster.KnownHosts are not part of REST API definitions, so we don't set them when running parseCluster.
It resulted in passing cluster with uninitialized
known hosts to ClusterService.PutCluster and in some cases to overwriting previously correctly discovered known hosts. This in turn could lead to connectivity issues as described in #4733.

To fix that, this commit fills known hosts of the cluster parsed from REST API before passing it to ClusterService.PutCluster. The only other place where parseCluster is used is on cluster creation, but we don't have any discovered known hosts at this point, so there is no need to fill them.

In terms of testing, this commit extended test checking connectivity check on cluster update. The problem is that since the fix targeted just the API handler, it's difficult to test it reliably without mocks. In order to bypass, additional safety net which fills missing known hosts in ClusterService.PutCluster was added. With that, we can validate that passing nil Cluster.KnowHosts to
ClusterService.PutCluster results in not losing the already discovered known hosts. So even if the initial API handler fix does not work, this safety net should correct it.

Fixes #4733
