### PR TITLE
Preserve cron timezone on task reschedule

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 package scheduler
 
@@ -140,6 +140,7 @@ func (s *Scheduler[K]) reschedule(ctx *RunContext[K], initialActivation time.Tim
 	now := s.now()
 	if d.Location != nil {
 		now = now.In(d.Location)
+		initialActivation = initialActivation.In(d.Location)
 	}
 	next := d.Trigger.Next(now)
 


### PR DESCRIPTION
This problem arisen from the fact that we rely
on the timezone of the time passed to cron trigger for correct calculation of next activation.
We might want to improve that by switching to set
timezone as a part of cron specification, but this is also confusing when we take into consideration
our separate timezone flag (#3818).

In this case, it wasn't done for the time of initial activation kept always in UTC+0 timezone. This resulted in switching from correct timezone to UTC+0 timezone on task reschedule.

Refs #3818
Fixes #4743