### PR TITLE
Replace nil properties with empty json

### DIFF
--- a/pkg/service/scheduler/model.go
+++ b/pkg/service/scheduler/model.go
@@ -259,13 +259,25 @@ type Task struct {
 	Deleted    bool              `json:"deleted,omitempty"`
 	Sched      Schedule          `json:"schedule"`
 	Properties json.RawMessage   `json:"properties,omitempty"`
-	Tags       []string
+	Tags       []string          `json:"tags,omitempty"`
 
 	Status       Status     `json:"status"`
 	SuccessCount int        `json:"success_count"`
 	ErrorCount   int        `json:"error_count"`
 	LastSuccess  *time.Time `json:"last_success"`
 	LastError    *time.Time `json:"last_error"`
+}
+
+// MarshalJSON is a wrapper around default JSON marshaller ensuring
+// that Task.Properties are marshaled as an empty JSON object instead
+// of null. This makes it easier and safer on SM client side.
+func (t Task) MarshalJSON() ([]byte, error) {
+	type Alias Task // To avoid infinite recursion
+	taskWithFilledProps := Alias(t)
+	if len(taskWithFilledProps.Properties) == 0 || string(taskWithFilledProps.Properties) == "null" {
+		taskWithFilledProps.Properties = json.RawMessage("{}")
+	}
+	return json.Marshal(taskWithFilledProps)
 }
 
 func (t *Task) String() string {


### PR DESCRIPTION
Task properties typing is problematic. Within SM server codebase, they are json.RawMessage. When returned to sctool or apps using SM client, they are interface{} which is carelessly cast to map[string]any. The problem is that nil task properties can't be cast to map[string]any. This results in unexpected errors and panics on sctool or apps using SM client side. Within SM codebase, we also make those such assumptions and sometimes ad-hoc replace nil properties with json.RawMessage("").

This commit doesn't fix anything on its own, but it makes it less likely that sctool or app using SM client breaks in those silly places.
