### PR TITLE
Fix missing next activation

### DIFF
--- a/pkg/service/scheduler/model.go
+++ b/pkg/service/scheduler/model.go
@@ -298,6 +298,13 @@ func (t *Task) Validate() error {
 	return util.ErrValidate(errors.Wrap(errs, "invalid task"))
 }
 
+// InitProperties replaces nil properties with empty JSON object.
+func (t *Task) InitProperties() {
+	if len(t.Properties) == 0 || string(t.Properties) == "null" {
+		t.Properties = json.RawMessage("{}")
+	}
+}
+
 // Status specifies the status of a Task.
 type Status string
 

--- a/pkg/service/scheduler/service_list.go
+++ b/pkg/service/scheduler/service_list.go
@@ -88,6 +88,9 @@ func (s *Service) ListTasks(ctx context.Context, clusterID uuid.UUID, filter Lis
 			}
 		}
 	}
+	for _, task := range tasks {
+		task.InitProperties()
+	}
 
 	if filter.Short {
 		return tasks, nil


### PR DESCRIPTION
Recent [PR](https://github.com/scylladb/scylla-manager/pull/4758) introduced custom marshaling of `scheduler.Task` type which was supposed to replace nil task properties with empty JSON object, so that handling untyped task properties on client side is less fragile. The problem is that types which embed `scheduler.Task` (e.g. `scheduler.TaskListItem`) inherit this custom marshaling, which results in them being marshaled as `scheduler.Task` without any of their additional fields.

As I'm not sure how to gracefully "uninherit" custom marshaling from `scheduler.Task` in the types embedding it, and because this failure was only caught by tests outside of SM CI, I decided to revert the change with custom marshalin and get back to naive band-aid approach which replaces nil task properties with empty JSON object when putting/getting/listing tasks with scheduler svc.
