### PR TITLE
Missing next activation backport

### DIFF
--- a/pkg/service/scheduler/model.go
+++ b/pkg/service/scheduler/model.go
@@ -298,6 +298,13 @@ func (t *Task) Validate() error {
 	return util.ErrValidate(errors.Wrap(errs, "invalid task"))
 }
 
+// InitProperties replaces nil properties with empty JSON object.
+func (t *Task) InitProperties() {
+	if len(t.Properties) == 0 || string(t.Properties) == "null" {
+		t.Properties = json.RawMessage("{}")
+	}
+}
+
 // Status specifies the status of a Task.
 type Status string
 

--- a/pkg/service/scheduler/service_list.go
+++ b/pkg/service/scheduler/service_list.go
@@ -88,6 +88,9 @@ func (s *Service) ListTasks(ctx context.Context, clusterID uuid.UUID, filter Lis
 			}
 		}
 	}
+	for _, task := range tasks {
+		task.InitProperties()
+	}
 
 	if filter.Short {
 		return tasks, nil


### PR DESCRIPTION
Backport to `branch-3.8` of changes made in https://github.com/scylladb/scylla-manager/pull/4762.
