### PR TITLE
backupspec: add localstorage backup provider

### DIFF
--- a/backupspec/location.go
+++ b/backupspec/location.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 package backupspec
 
@@ -16,12 +16,13 @@ type Provider string
 
 // Provider enumeration.
 const (
-	S3    = Provider("s3")
-	GCS   = Provider("gcs")
-	Azure = Provider("azure")
+	S3           = Provider("s3")
+	GCS          = Provider("gcs")
+	Azure        = Provider("azure")
+	LocalStorage = Provider("localstorage")
 )
 
-var providers = []Provider{S3, GCS, Azure}
+var providers = []Provider{S3, GCS, Azure, LocalStorage}
 
 // Providers returns a list of all supported providers as a list of strings.
 func Providers() []string {

--- a/backupspec/location_test.go
+++ b/backupspec/location_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 package backupspec
 
@@ -38,6 +38,20 @@ func TestNewLocation(t *testing.T) {
 			Provider: S3,
 			Bucket:   "bucket",
 		},
+		{
+			Name:     "Valid localstorage with prefix",
+			Location: "dc1:localstorage:bucket",
+			DC:       "dc1",
+			Provider: LocalStorage,
+			Bucket:   "bucket",
+		},
+		{
+			Name:     "Valid localstorage without prefix",
+			Location: "localstorage:bucket",
+			DC:       "",
+			Provider: LocalStorage,
+			Bucket:   "bucket",
+		},
 	}
 
 	for i := 0; i < len(table); i++ {
@@ -69,7 +83,7 @@ func TestNewLocation(t *testing.T) {
 func TestProviderMarshalUnmarshalText(t *testing.T) {
 	t.Parallel()
 
-	for _, k := range []Provider{S3} {
+	for _, k := range []Provider{S3, GCS, Azure, LocalStorage} {
 		b, err := k.MarshalText()
 		if err != nil {
 			t.Error(k, err)
@@ -103,6 +117,21 @@ func TestLocationMarshalUnmarshalText(t *testing.T) {
 			Name: "without dc",
 			Location: Location{
 				Provider: S3,
+				Path:     "my-bucket.domain",
+			},
+		},
+		{
+			Name: "localstorage with dc",
+			Location: Location{
+				DC:       "dc",
+				Provider: LocalStorage,
+				Path:     "my-bucket.domain",
+			},
+		},
+		{
+			Name: "localstorage without dc",
+			Location: Location{
+				Provider: LocalStorage,
 				Path:     "my-bucket.domain",
 			},
 		},


### PR DESCRIPTION
This commit simply adds localstorage to the list of allowed providers in backupspec module. This is needed for CLOUD-428 and needs to be merged in a separate PR, as it modifies separate go module.

Refs https://scylladb.atlassian.net/browse/CLOUD-428
