### PR TITLE
fix: add --amend flag to docker manifest create for idempotent re-runs

### DIFF
--- a/dist/.goreleaser-docker.yaml
+++ b/dist/.goreleaser-docker.yaml
@@ -101,6 +101,7 @@ docker_manifests:
     - "scylladb/scylla-manager:{{ .Version }}-aarch64"
     create_flags:
     - --insecure
+    - --amend
     push_flags:
     - --insecure
     skip_push: false
@@ -112,6 +113,7 @@ docker_manifests:
     - "scylladb/scylla-manager-agent:{{ .Version }}-aarch64"
     create_flags:
     - --insecure
+    - --amend
     push_flags:
     - --insecure
     skip_push: false
@@ -123,6 +125,7 @@ docker_manifests:
     - "scylladb/scylla-manager:{{ .Version }}-aarch64"
     create_flags:
     - --insecure
+    - --amend
     push_flags:
     - --insecure
     skip_push: .Env.SKIP_LATEST_RELEASE
@@ -134,6 +137,7 @@ docker_manifests:
     - "scylladb/scylla-manager-agent:{{ .Version }}-aarch64"
     create_flags:
     - --insecure
+    - --amend
     push_flags:
     - --insecure
     skip_push: .Env.SKIP_LATEST_RELEASE


### PR DESCRIPTION
## Summary

- Adds `--amend` flag to all `docker_manifests` `create_flags` in `dist/.goreleaser-docker.yaml`
- Fixes docker manifest creation failure when the promote job is re-run for the same version

## Problem

When the promote job runs more than once for the same version (e.g. `3.9.1`), the arch-specific tags like `scylladb/scylla-manager:3.9.1-x86_64` already point to manifest lists from the previous run. `docker manifest create` fails with:

```
docker.io/scylladb/scylla-manager:3.9.1-x86_64@sha256:... is a manifest list
```

because it expects plain single-arch image manifests, not manifest lists.

## Fix

Adding `--amend` to `create_flags` makes `docker manifest create` idempotent — it amends existing manifest lists instead of failing when the source tags are already manifest lists.

Ref: Jenkins build https://jenkins.scylladb.com/view/scylla-manager/job/manager-3.9/job/manager-promote/6/console