### PR TITLE
SM 3.9: backport #4808

### DIFF
--- a/dist/.goreleaser-docker.yaml
+++ b/dist/.goreleaser-docker.yaml
@@ -101,6 +101,7 @@ docker_manifests:
     - "scylladb/scylla-manager:{{ .Version }}-aarch64"
     create_flags:
     - --insecure
+    - --amend
     push_flags:
     - --insecure
     skip_push: false
@@ -112,6 +113,7 @@ docker_manifests:
     - "scylladb/scylla-manager-agent:{{ .Version }}-aarch64"
     create_flags:
     - --insecure
+    - --amend
     push_flags:
     - --insecure
     skip_push: false
@@ -123,6 +125,7 @@ docker_manifests:
     - "scylladb/scylla-manager:{{ .Version }}-aarch64"
     create_flags:
     - --insecure
+    - --amend
     push_flags:
     - --insecure
     skip_push: .Env.SKIP_LATEST_RELEASE
@@ -134,6 +137,7 @@ docker_manifests:
     - "scylladb/scylla-manager-agent:{{ .Version }}-aarch64"
     create_flags:
     - --insecure
+    - --amend
     push_flags:
     - --insecure
     skip_push: .Env.SKIP_LATEST_RELEASE


### PR DESCRIPTION
Backports https://github.com/scylladb/scylla-manager/pull/4808.
Does not affect SM code, just the release pipeline.
