### PR TITLE
Don't list entire bucket when resolving hosts

### DIFF
--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -610,7 +610,7 @@ func (s *Service) resolveHosts(ctx context.Context, client *scyllaclient.Client,
 		}
 
 		for _, h := range checklist {
-			_, err := client.RcloneListDir(ctx, h, l.RemotePath(""), nil)
+			_, err := client.RcloneListDir(ctx, h, l.RemotePath("backup"), nil)
 			if err != nil {
 				s.logger.Debug(ctx, "Location check FAILED", "host", h, "location", l, "error", err)
 			} else {


### PR DESCRIPTION
When establishing which host has access to which location, SM performs simple non-recursive listing of bucket root dir. In the majority of the cases, this is a low-cost way of checking listing permissions. The problem is that the bucket root dir can theoretically contain many other user dirs/objects, as SM controls just the /backup directory. To avoid timeouts when listing bucket root dir with thousands of dirs/objects, we can list the SM controlled /backup dir containing just the 3 sub-dirs (/meta, /schema, /sst). Even if the /backup dir does not exist, we ignore the not found error and treat is as empty listing, as it already proves that we have access to this bucket (otherwise we would get the permission denied error).
