### PR TITLE
Fix CheckPermissions for NFS

### DIFF
--- a/pkg/rclone/operations/operations.go
+++ b/pkg/rclone/operations/operations.go
@@ -4,6 +4,7 @@ package operations
 
 import (
 	"context"
+	stderr "errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -110,7 +111,7 @@ func CheckPermissions(ctx context.Context, l fs.Fs) error {
 		}
 	}
 
-	// Cat remote file.
+	// Create, cat and remove remote file.
 	{
 		o, err := l.NewObject(ctx, filepath.Join(testDirName, testFileName))
 		if err != nil {
@@ -120,15 +121,21 @@ func CheckPermissions(ctx context.Context, l fs.Fs) error {
 		if err != nil {
 			return asOperationError("open", l, err)
 		}
-		defer r.Close()
-		if _, err := io.Copy(io.Discard, r); err != nil {
-			return asOperationError("copy", l, err)
+		_, readErr := io.Copy(io.Discard, r)
+		if err := stderr.Join(readErr, r.Close()); err != nil {
+			return asOperationError("read", l, err)
+		}
+		if err := o.Remove(ctx); err != nil {
+			return asOperationError("remove", l, err)
 		}
 	}
 
-	// Remove remote dir.
+	// Cleanup.
 	if err := operations.Purge(ctx, l, testDirName); err != nil {
-		return asOperationError("purge", l, err)
+		// As we already verified all permissions needed by SM to perform
+		// a successful backup, we can just log an error here to allow
+		// backup to proceed in case of unexpected and not critical error.
+		fs.Errorf(l, "failed to remove test directory %q: %v", testDirName, err)
 	}
 
 	return nil


### PR DESCRIPTION
4f1adf6f introduced explicit cleanup of test dirs in CheckPermissions. The problem was that the Purge happened while the file descriptor from the "cat" verification was still held. On a regular filesystem this is not an issue, as Purge would still just remove the dir with its contents and make the file descriptor broken. The situation is different with NFS, as when another process tries to remove file with open descriptor, NFS will perform a "silly rename" and create an ephemeral .nfsXXX file so that the descriptor is not broken. So when rclone runs Purge, it first removes all its files, this results in creation of .nfsXXX files and when it proceeds with dir removal, it fails with "directory not empty".

This commit fixes the bug related to holding the file descriptor for too long. It also explicitly checks the permission to remove a file and performs the cleanup without failing the CheckPermissions if just the cleanup failed, as it is not critical.
