### PR TITLE
docs(upgrade): fix Ubuntu tab indentation in upgrade server/client step

### DIFF
--- a/docs/source/upgrade/index.rst
+++ b/docs/source/upgrade/index.rst
@@ -93,7 +93,7 @@ Upgrade the ScyllaDB Manager Server and Client
 
                sudo curl -o /etc/yum.repos.d/scylla-manager.repo -L https://downloads.scylladb.com/rpm/centos/|CENTOS_SCYLLADB_REPO|
 
-          .. group-tab::  Ubuntu
+      .. group-tab:: Ubuntu
 
            .. code-block:: console
                :substitutions:


### PR DESCRIPTION
## Summary

- In the "Upgrade the ScyllaDB Manager Server and Client" section, the `Ubuntu` group-tab directive was indented inside the `Centos` tab block instead of being a sibling tab.
- This caused the rendered page to show both CentOS and Ubuntu commands under the CentOS tab, while the Ubuntu tab displayed nothing.
- Fixed by correcting the indentation of `.. group-tab:: Ubuntu` to be at the same level as `.. group-tab:: Centos`.

## Related

Reported issue on the page: https://manager.docs.scylladb.com/stable/upgrade/index.html#upgrade-the-scylladb-manager-server-and-client

CentOS selected:
<img width="1151" height="631" alt="image" src="https://github.com/user-attachments/assets/b5112a70-cdc5-4c1a-bc4e-147474fbf831" />

Ubuntu selected:
<img width="1154" height="459" alt="image" src="https://github.com/user-attachments/assets/1e1b72a7-6c81-402d-8bde-7a54ccd20930" />
