### PR TITLE
Potential fix for code scanning alert no. 67: Insecure TLS configuration

### DIFF
--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -17,7 +17,6 @@ type TLSVersion string
 const (
 	TLSv13 TLSVersion = "TLSv1.3"
 	TLSv12 TLSVersion = "TLSv1.2"
-	TLSv10 TLSVersion = "TLSv1.0"
 )
 
 func (m TLSVersion) MarshalText() (text []byte, err error) {
@@ -30,8 +29,6 @@ func (m *TLSVersion) UnmarshalText(text []byte) error {
 		*m = TLSv13
 	case TLSv12:
 		*m = TLSv12
-	case TLSv10:
-		*m = TLSv10
 	default:
 		return errors.Errorf("unsupported TLS version %q", string(text))
 	}
@@ -58,31 +55,6 @@ func (m TLSVersion) TLSConfig() *tls.Config {
 				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			},
-		}
-	case TLSv10:
-		cfg = &tls.Config{
-			MinVersion:               tls.VersionTLS10,
-			PreferServerCipherSuites: true,
-			CipherSuites: []uint16{
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-				tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-				tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-				tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
-				tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-				tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
 			},
 		}
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/scylladb/scylla-manager/security/code-scanning/67](https://github.com/scylladb/scylla-manager/security/code-scanning/67)

General fix: enforce modern TLS defaults by allowing only TLS 1.2+ and removing insecure/legacy cipher suite options. For this file, the safest minimal change is to eliminate the `TLSv10` enum option from parsing and from `TLSConfig()` so insecure config cannot be constructed at all.

Best single fix in `pkg/config/tls.go`:
1. Remove `TLSv10` constant from the enum.
2. Remove `case TLSv10` from `UnmarshalText`, so user input cannot select it.
3. Remove `case TLSv10` block from `TLSConfig()`, including all insecure suites (this addresses all three alert variants in one change).
4. Keep TLSv12 and TLSv13 behavior unchanged.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
