### PR TITLE
fix(1-1-restore): handle logical index names in desc schema

### DIFF
--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -277,6 +277,13 @@ func (ni *NodeInfo) SupportsNativeRestoreAPI() (bool, error) {
 	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2026.1")
 }
 
+// DescribeSchemaContainsLogicalIndexName returns whether node output of DESCRIBE SCHEMA
+// query contains logical index name (X) or the backing materialized view name (X_index).
+func (ni *NodeInfo) DescribeSchemaContainsLogicalIndexName() (bool, error) {
+	// Check ENT
+	return scyllaversion.CheckConstraint(ni.ScyllaVersion, ">= 2026.2")
+}
+
 // ScyllaObjectStorageEndpoint returns endpoint that should be used when calling /storage_service/<backup|restore> API.
 // It also validates that agent's and Scylla's configurations match.
 func (ni *NodeInfo) ScyllaObjectStorageEndpoint(provider backupspec.Provider) (string, error) {

--- a/pkg/service/one2onerestore/model.go
+++ b/pkg/service/one2onerestore/model.go
@@ -60,7 +60,8 @@ const (
 
 // View represents statement used for recreating restored (dropped) views.
 type View struct {
-	Keyspace    string                       `json:"keyspace" db:"keyspace_name"`
+	Keyspace string `json:"keyspace" db:"keyspace_name"`
+	// View name. For SIs, it is the name of the backing materialized view.
 	View        string                       `json:"view" db:"view_name"`
 	Type        ViewType                     `json:"type" db:"view_type"`
 	BaseTable   string                       `json:"base_table"`

--- a/pkg/service/one2onerestore/worker_views.go
+++ b/pkg/service/one2onerestore/worker_views.go
@@ -13,6 +13,7 @@ import (
 	"github.com/scylladb/gocqlx/v2/qb"
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/table"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/query"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 )
@@ -221,6 +222,15 @@ func (w *worker) viewsFromSchema(ctx context.Context, workload []hostWorkload) (
 		return nil, errors.Wrap(err, "raft read barrier")
 	}
 
+	ni, err := w.client.NodeInfo(ctx, host.Addr)
+	if err != nil {
+		return nil, errors.Wrap(err, "get node info")
+	}
+	logical, err := ni.DescribeSchemaContainsLogicalIndexName()
+	if err != nil {
+		return nil, errors.Wrap(err, "check if describe schema contains logical index name")
+	}
+
 	describedSchema, err := query.DescribeSchemaWithInternals(hostSession)
 	if err != nil {
 		return nil, errors.Wrap(err, "describe schema")
@@ -234,17 +244,21 @@ func (w *worker) viewsFromSchema(ctx context.Context, workload []hostWorkload) (
 			continue
 		}
 
+		name := stmt.Name
 		viewType := MaterializedView
 		if stmt.Type == "index" {
 			viewType = SecondaryIndex
+			if logical {
+				name = table.MaterializedViewBackingIndex(name)
+			}
 		}
-		baseTableName, err := w.getBaseTableName(stmt.Keyspace, stmt.Name)
+		baseTableName, err := w.getBaseTableName(stmt.Keyspace, name)
 		if err != nil {
-			return nil, errors.Wrapf(err, "get base table name for view %s.%s", stmt.Keyspace, stmt.Name)
+			return nil, errors.Wrapf(err, "get base table name for view %s.%s", stmt.Keyspace, name)
 		}
 		result = append(result, View{
 			Keyspace:    stmt.Keyspace,
-			View:        stmt.Name,
+			View:        name,
 			Type:        viewType,
 			BaseTable:   baseTableName,
 			CreateStmt:  stmt.CQLStmt,

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -32,3 +32,9 @@ var AuditTable = CQLTable{
 	Keyspace: AuditKeyspace,
 	Name:     "audit_log",
 }
+
+// MaterializedViewBackingIndex given the logical index name
+// returns the name of the materialized view backing the index.
+func MaterializedViewBackingIndex(indexName string) string {
+	return indexName + "_index"
+}


### PR DESCRIPTION
Scylla 2026.2 changes behavior of DESC SCHEMA query. Previously, it was returning backing materialized view name for the secondary indexes, not it returns its logical name. It is described in more detail in a comment under the PR that introduced this change:
https://github.com/scylladb/scylladb/pull/29083#issuecomment-4224170505

This commit is a simple fix ensuring compatibility with scylla 2026.2, but a full solution to the way in which SM interacts with different kind of view schema will be fixes as a part of CLOUD-1520.

Refs https://scylladb.atlassian.net/browse/CLOUD-1520
Fixes https://scylladb.atlassian.net/browse/CLOUD-1599
