### PR TITLE
FIx SM CI: adjust to new snapshot sstable table

### DIFF
--- a/pkg/service/backup/model.go
+++ b/pkg/service/backup/model.go
@@ -527,6 +527,17 @@ func (lf lwtFilter) filter(ks, tab string, _ scyllaclient.Ring) bool {
 	return t != table.LWTSystemTable && !strings.HasSuffix(tab, table.LWTStateTableSuffix)
 }
 
+// Filter out internal scylla tables used for storing scylla orchestrated backup state.
+type scyllaBackupFilter struct{}
+
+func (sf scyllaBackupFilter) filter(ks, tab string, _ scyllaclient.Ring) bool {
+	t := table.CQLTable{
+		Keyspace: ks,
+		Name:     tab,
+	}
+	return !slices.Contains(table.ScyllaBackupTables, t)
+}
+
 // tableValidator checks if it's safe to back up table.
 type tabValidator interface {
 	validate(ks, tab string, ring scyllaclient.Ring) error

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -188,6 +188,7 @@ func (s *Service) targetFromProperties(ctx context.Context, clusterID uuid.UUID,
 		dcFilter{dcs: strset.New(dcs...)},
 		localDataFilter{keyspaces: ks},
 		lwtFilter{},
+		scyllaBackupFilter{},
 	}
 
 	// Try to add view filter - possible only when credentials are set

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -489,6 +489,7 @@ func TestGetTargetIntegration(t *testing.T) {
 				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
 				cmpopts.SortSlices(func(a, b backup.Unit) bool { return a.Keyspace < b.Keyspace }),
 				cmpopts.IgnoreUnexported(backup.Target{}),
+				cmpopts.IgnoreFields(backup.Unit{}, "AllTables"),
 				cmpopts.IgnoreSliceElements(func(u backup.Unit) bool {
 					return u.Keyspace == "system_replicated_keys" || u.Keyspace == "system_auth" || u.Keyspace == "system_distributed_everywhere"
 				}),

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -456,7 +456,7 @@ func TestServiceGetTargetIntegration(t *testing.T) {
 				cmpopts.IgnoreSliceElements(func(u repair.Unit) bool {
 					return u.Keyspace == "system_replicated_keys" || u.Keyspace == "system_auth" || u.Keyspace == "system_distributed_everywhere"
 				}),
-				cmpopts.IgnoreSliceElements(func(t string) bool { return t == "dicts" || t == "service_levels" }),
+				cmpopts.IgnoreSliceElements(func(t string) bool { return t == "dicts" || t == "service_levels" || t == "snapshot_sstables" }),
 				cmpopts.IgnoreFields(repair.Target{}, "Host")); diff != "" {
 				t.Fatal(diff)
 			}

--- a/pkg/table/table.go
+++ b/pkg/table/table.go
@@ -22,6 +22,13 @@ var LWTSystemTable = CQLTable{
 	Name:     "paxos",
 }
 
+// ScyllaBackupTables lists internal scylla tables used for storing
+// scylla orchestrated backup state. These tables should be excluded
+// from SM backup/restore procedures.
+var ScyllaBackupTables = []CQLTable{
+	{Keyspace: "system_distributed", Name: "snapshot_sstables"},
+}
+
 // AuditKeyspace stores audit data. It lacks "system" prefix
 // and can be altered by users, but it's still an internal keyspace.
 // See https://docs.scylladb.com/manual/stable/operating-scylla/security/auditing.html.


### PR DESCRIPTION
This PR fixes SM CI executed against new scylla-nightly:latest image.
