### PR TITLE
Match OSE against given provider

### DIFF
--- a/pkg/scyllaclient/client_agent.go
+++ b/pkg/scyllaclient/client_agent.go
@@ -4,7 +4,6 @@ package scyllaclient
 
 import (
 	"context"
-	stdErr "errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -219,25 +218,17 @@ func (ni *NodeInfo) ScyllaObjectStorageEndpoint(provider backupspec.Provider) (s
 	if len(ni.ObjectStorageEndpoints) == 0 {
 		return "", errors.New("no object storage endpoint configured")
 	}
-	var (
-		match         bool
-		unknownOSEErr error
-	)
+	match := false
 	for _, ose := range ni.ObjectStorageEndpoints {
 		switch {
-		case isS3ObjectStorageEndpoint(ose):
+		case provider == backupspec.S3 && isS3ObjectStorageEndpoint(ose):
 			match = equalS3ObjectStorageEndpoints(ni.RcloneBackendConfig.S3, ose)
-		case isGSObjectStorageEndpoint(ose):
+		case provider == backupspec.GCS && isGSObjectStorageEndpoint(ose):
 			match = equalGSObjectStorageEndpoints(ni.RcloneBackendConfig.Gcs, ose)
-		default:
-			unknownOSEErr = stdErr.Join(unknownOSEErr, errors.Errorf("object storage endpoint %q has unknown type %q", ose.Name, ose.Type))
 		}
 		if match {
 			return ose.Name, nil
 		}
-	}
-	if unknownOSEErr != nil {
-		return "", unknownOSEErr
 	}
 	return "", errors.Errorf("scylla and scylla-manager-agent backup configurations don't match. "+
 		"Please make sure that the same endpoint is set in both `scylla-manager-agent.yaml` %s config "+

--- a/pkg/scyllaclient/client_agent_test.go
+++ b/pkg/scyllaclient/client_agent_test.go
@@ -708,6 +708,52 @@ func TestScyllaObjectStorageEndpoint(t *testing.T) {
 			},
 			endpoint: "https://[2001:0DB9:200::99]:9000",
 		},
+		{
+			name:     "both gcs and s3 endpoints",
+			provider: backupspec.S3,
+			rclone: models.NodeInfoRcloneBackendConfig{
+				Gcs: models.NodeInfoRcloneBackendConfigGcs{
+					Endpoint: "http://192.168.200.97:4443",
+				},
+				S3: models.NodeInfoRcloneBackendConfigS3{
+					Endpoint: "https://192.168.200.99:9000",
+				},
+			},
+			scylla: []models.ObjectStorageEndpoint{
+				{
+					Name: "http://192.168.200.97:4443",
+					Type: "gs",
+				},
+				{
+					Name: "https://192.168.200.99:9000",
+					Type: "s3",
+				},
+			},
+			endpoint: "https://192.168.200.99:9000",
+		},
+		{
+			name:     "both gcs and s3 endpoints (reordered)",
+			provider: backupspec.S3,
+			rclone: models.NodeInfoRcloneBackendConfig{
+				Gcs: models.NodeInfoRcloneBackendConfigGcs{
+					Endpoint: "http://192.168.200.97:4443",
+				},
+				S3: models.NodeInfoRcloneBackendConfigS3{
+					Endpoint: "https://192.168.200.99:9000",
+				},
+			},
+			scylla: []models.ObjectStorageEndpoint{
+				{
+					Name: "https://192.168.200.99:9000",
+					Type: "s3",
+				},
+				{
+					Name: "http://192.168.200.97:4443",
+					Type: "gs",
+				},
+			},
+			endpoint: "https://192.168.200.99:9000",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
ScyllaObjectStorageEndpoint didn't work correctly when there were multiple object storage endpoints with different types (s3/gcs) configured in scylla.yaml. That's because it was looking for any matching endpoint instead of a matching endpoint for given provider.
