### PR TITLE
Add handler for operations/retention-lock agent endpoint 

### DIFF
--- a/pkg/rclone/rcserver/internal/rclone_supported_calls.go
+++ b/pkg/rclone/rcserver/internal/rclone_supported_calls.go
@@ -24,6 +24,7 @@ var RcloneSupportedCalls = strset.New(
 	"operations/list",
 	"operations/movefile",
 	"operations/purge",
+	"operations/retention-lock",
 	"sync/copydir",
 	"sync/copypaths",
 	"sync/movedir",

--- a/pkg/rclone/rcserver/rc.go
+++ b/pkg/rclone/rcserver/rc.go
@@ -8,9 +8,12 @@ import (
 	"io"
 	"os"
 	"path"
+	"runtime"
 	"strconv"
+	stdsync "sync"
 	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rclone/rclone/fs"
@@ -595,6 +598,107 @@ func setGuardedConfig(in rc.Params) error {
 	return nil
 }
 
+// rcRetentionLock sets object retention lock on multiple paths in parallel.
+// Progress is reported via the accounting transfer mechanism, where each
+// object is represented as a 1-byte transfer. This allows reusing the
+// existing job/progress endpoint to track per-object completion.
+func rcRetentionLock(ctx context.Context, in rc.Params) (out rc.Params, err error) {
+	// Parse input
+	f, remote, err := rc.GetFsAndRemote(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	rl, ok := f.(fs.RetentionLocker)
+	if !ok {
+		return nil, errors.Errorf("backend %q does not support retention lock", f.Name())
+	}
+	paths, err := getStringSlice(in, "paths")
+	if err != nil {
+		return nil, err
+	}
+	if len(paths) == 0 {
+		return nil, errors.New("empty paths")
+	}
+	locked, err := in.GetBool("locked")
+	if err != nil {
+		if rc.NotErrParamNotFound(err) {
+			return nil, err
+		}
+		locked = false
+	}
+	untilStr, err := in.GetString("until")
+	if err != nil {
+		return nil, err
+	}
+	untilDt, err := strfmt.ParseDateTime(untilStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse until timestamp")
+	}
+	until := time.Time(untilDt)
+	overrideLock, err := in.GetBool("override_lock")
+	if err != nil {
+		if rc.NotErrParamNotFound(err) {
+			return nil, err
+		}
+		overrideLock = false
+	}
+
+	stats := accounting.Stats(ctx)
+	workerCnt := min(2*runtime.NumCPU(), len(paths))
+	jobCh := make(chan string, workerCnt)
+	// We do best effort approach, where we proceed with setting
+	// retention locks even if we encountered errors for some paths,
+	// similar to how upload works. To not overclutter returned error
+	// we return only the first encountered one.
+	var (
+		wg       stdsync.WaitGroup
+		firstErr error
+		once     stdsync.Once
+	)
+	setErr := func(err error) {
+		once.Do(func() { firstErr = err })
+	}
+
+	for range workerCnt {
+		wg.Go(func() {
+			for p := range jobCh {
+				if ctx.Err() != nil {
+					setErr(ctx.Err())
+					break
+				}
+				tr := stats.NewTransferRemoteSize(p, 1)
+				acc := tr.Account(ctx, nil)
+				err := rl.RetentionLock(ctx, path.Join(remote, p), locked, until, overrideLock)
+				if err == nil {
+					acc.DryRun(1)
+				} else {
+					setErr(err)
+				}
+				tr.Done(ctx, err)
+			}
+		})
+	}
+
+	for _, p := range paths {
+		select {
+		case <-ctx.Done():
+		case jobCh <- p:
+		}
+		if ctx.Err() != nil {
+			setErr(ctx.Err())
+			break
+		}
+	}
+	close(jobCh)
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, errors.Wrapf(firstErr, "failed to set retention lock on %d out of %d objects",
+			stats.Aggregated().Failed, len(paths))
+	}
+	return make(rc.Params), nil
+}
+
 // rcDeletePaths returns rc function that deletes paths from remote.
 func rcDeletePaths(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	f, remote, err := rc.GetFsAndRemote(ctx, in)
@@ -752,6 +856,21 @@ func init() {
 - fs - a remote name string eg "s3:"
 - remote - a directory path within that remote
 - paths - slice of paths to be deleted from remote directory`,
+	})
+
+	rc.Add(rc.Call{
+		Path:         "operations/retention-lock",
+		AuthRequired: true,
+		Fn:           rcRetentionLock,
+		Title:        "Set object retention lock on multiple paths",
+		Help: `This takes the following parameters:
+
+- fs - a remote name string eg "gcs:"
+- remote - a directory path within that remote
+- paths - slice of paths to set retention lock on
+- locked - true for locked mode (cannot be overridden), false for unlocked mode
+- until - RFC3339 timestamp until which the objects are retained
+- override_lock - whether to override existing retention policy`,
 	})
 }
 


### PR DESCRIPTION
This commit adds rcRetentionLock, which is a handler for the new operations/retention-lock endpoint. It also adds it to the list of supported rclone calls.

False boolean params might be omitted when sending them via swagger generated client, so we need to treat their absence as false values.

This endpoint uses best effort approach, as it's used for ensuring backup files safety, so even in case of an error, it should try to lock as many files as possible. In terms of not transient errors (e.g., permission errors), in https://scylladb.atlassian.net/browse/CLOUD-1968 we will extend permission checking procedure to verify that files can be locked before proceeding with the actual backup.

This endpoint locks files in parallel (up to 2*runtime.NumCPU()), so no additional per agent parallelization on SM side is needed.

Stats are populated so that each "byte" of progress represent one locked file when querying job/progress endpoint.

Fixes https://scylladb.atlassian.net/browse/CLOUD-1912
