### PR TITLE
managerclient: display retention lock cfg

### DIFF
--- a/v3/pkg/managerclient/go.mod
+++ b/v3/pkg/managerclient/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/lnquy/cron v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/scylladb/go-set v1.0.2
-	github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20251216101300-0a07cdbca348
-	github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20260108132715-a46b9332650a
+	github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20260522113449-181dd7c9c1b5
+	github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20260522113449-181dd7c9c1b5
 	github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4
 )
 

--- a/v3/pkg/managerclient/go.sum
+++ b/v3/pkg/managerclient/go.sum
@@ -84,10 +84,10 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
-github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20251216101300-0a07cdbca348 h1:TPde79tEMiwzjzMKZoMMtRY5ygbkPTIYwDp8kaZpMMo=
-github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20251216101300-0a07cdbca348/go.mod h1:5PVjJFtbO/R3rAJtgg/HNT7FbAcj+Hfn/g39HDBIa/k=
-github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20260108132715-a46b9332650a h1:GUHB5L8nftCAJzxoSBP5Ng1HkOtwohvBRxl4y9KXPqM=
-github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20260108132715-a46b9332650a/go.mod h1:JUyR1bNef5oN9cQpolZfj2lVDYaDMVFHqyHSDA5at7g=
+github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20260522113449-181dd7c9c1b5 h1:FL6f8hlCwAVnWq3w/VZS5YqmnVfJ5Y4+VY+MEy3BBrs=
+github.com/scylladb/scylla-manager/v3/pkg/util v0.0.0-20260522113449-181dd7c9c1b5/go.mod h1:5PVjJFtbO/R3rAJtgg/HNT7FbAcj+Hfn/g39HDBIa/k=
+github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20260522113449-181dd7c9c1b5 h1:5xmxBN/xrXN0lNuwuDwVL42A7OfwHhE3BHqK+Fq0Tbg=
+github.com/scylladb/scylla-manager/v3/swagger v0.0.0-20260522113449-181dd7c9c1b5/go.mod h1:JUyR1bNef5oN9cQpolZfj2lVDYaDMVFHqyHSDA5at7g=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4 h1:8qmTC5ByIXO3GP/IzBkxcZ/99VITvnIETDhdFz/om7A=
 github.com/scylladb/termtables v0.0.0-20191203121021-c4c0b6d42ff4/go.mod h1:C1a7PQSMz9NShzorzCiG2fk9+xuCgLkPeCvMHYR2OWg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/v3/pkg/managerclient/model.go
+++ b/v3/pkg/managerclient/model.go
@@ -382,6 +382,14 @@ Locations:
 {{- range .Location }}
   - {{ . }}
 {{- end }}
+{{ if .SkipSchema }}
+Skip Schema: snapshot won't contain schema that can be restored
+{{- end }}
+{{- if .PurgeOnly }}
+Purge only: backup task execution will only purge snapshots (according to retention policy)
+{{- end }}
+
+Backup Method: {{ .Method }}
 
 Bandwidth Limits:
 {{- if .RateLimit -}}
@@ -409,9 +417,14 @@ Upload Parallel Limits:
 {{- else }}
   - All hosts in parallel
 {{- end }}
+{{ if ne .Transfers -1 }}
+Transfers:	{{ .Transfers }}
+{{- else }}
+Transfers: defined in scylla-manager-agent.yaml config
+{{- end }}
 
 Retention Policy:
-{{ FormatRetentionPolicy .Retention .RetentionDays }}
+{{ FormatRetentionPolicy .Retention .RetentionDays .RetentionLockMode .OverrideRetentionLock }}
 `
 
 // Render implements Renderer interface.
@@ -1095,6 +1108,8 @@ Datacenters:	{{ range .Dcs }}
   - {{ . }}
 {{- end }}
 {{ end -}}
+Retention Lock:
+{{ FormatRetentionLock .RetentionLockMode .OverrideRetentionLock .RetentionDays -}}
 {{ else }}Progress:	0%
 {{ end }}
 {{- if .Errors -}}
@@ -1112,6 +1127,7 @@ func (bp BackupProgress) addHeader(w io.Writer) error {
 		"FormatError":          FormatError,
 		"FormatUploadProgress": FormatUploadProgress,
 		"status":               bp.status,
+		"FormatRetentionLock":  FormatRetentionLock,
 	}).Parse(backupProgressTemplate))
 	return temp.Execute(w, bp)
 }

--- a/v3/pkg/managerclient/utils.go
+++ b/v3/pkg/managerclient/utils.go
@@ -261,13 +261,13 @@ func FormatIntensity(v float64) string {
 }
 
 // FormatRetentionPolicy returns text representation of retention policy.
-func FormatRetentionPolicy(retention, retentionDays int64) string {
+func FormatRetentionPolicy(retention, retentionDays int64, retentionLockMode string, overrideRetention bool) string {
 	var res string
 	if retention == 0 && retentionDays == 0 {
-		res += "  - Scylla Manager will not purge any backups created by this task\n"
+		res += "  - ScyllaDB Manager will not purge any backups created by this task\n"
 	}
 	if retention > 0 {
-		res += "  - Last "
+		res += "  - Retain last "
 		if retention == 1 {
 			res += "backup\n"
 		} else {
@@ -275,14 +275,33 @@ func FormatRetentionPolicy(retention, retentionDays int64) string {
 		}
 	}
 	if retentionDays > 0 {
-		res += fmt.Sprintf("  - Backups not older than %d ", retentionDays)
-		if retentionDays == 1 {
-			res += "day\n"
-		} else {
-			res += "days\n"
-		}
+		res += fmt.Sprintf("  - Retain backups not older than %s\n", formatDays(retentionDays))
+	}
+	res += FormatRetentionLock(retentionLockMode, overrideRetention, retentionDays)
+
+	return res
+}
+
+// FormatRetentionLock returns text representation of retention lock configuration.
+func FormatRetentionLock(mode string, override bool, retentionDays int64) string {
+	if (mode == "" || mode == "disabled") && !override {
+		return fmt.Sprintf("  - Retention lock is not applied to snapshot files\n")
+	}
+	var res string
+	if mode != "" && mode != "disabled" {
+		res += fmt.Sprintf("  - Retention lock snapshot files with mode %q for %s\n", mode, formatDays(retentionDays))
+	}
+	if override {
+		res += fmt.Sprintf("  - Override retention lock configuration on existing snapshot files\n")
 	}
 	return res
+}
+
+func formatDays(days int64) string {
+	if days == 1 {
+		return fmt.Sprintf("%d day", days)
+	}
+	return fmt.Sprintf("%d days", days)
 }
 
 // FormatTablesProgress calculates percent of restored table bytes.


### PR DESCRIPTION
This PR adds the display of retention lock config to
- `sctool backup --dry-run`
- `sctool progress backup`
commands.
It also adds the display of previously missed backup params
like:
- --skip-schema
- --purge-only
- --method
- --transfers

This is a managerclient side of https://scylladb.atlassian.net/browse/CLOUD-1916.
For the changes to be visible, we need to bump main module managerclient dep, but here are the examples from local executions:

<details>

<Summary> sctool backup  --dry-run </Summary>

```
miles@fedora:~/scylla-manager$ ./sctool.dev backup -L gcs:backuptest-retention-lock --skip-schema  --dry-run -c myc
NOTICE: dry run mode, backup is not scheduled

Data Centers:
  - dc1
  - dc2

Keyspaces:
  - system_distributed all (4 tables)
  - system_distributed_everywhere all (1 table)
  - system_replicated_keys all (1 table)
  - system_traces all (5 tables)
  - audit all (1 table)

Disk size: ~647.534KiB

Locations:
  - gcs:backuptest-retention-lock

Skip Schema: snapshot won't contain schema that can be restored

Backup Method: rclone

Bandwidth Limits:
  - 100 MiB/s

Snapshot Parallel Limits:
  - All hosts in parallel

Upload Parallel Limits:
  - All hosts in parallel

Transfers: defined in scylla-manager-agent.yaml config

Retention Policy:
  - Retain last 3 backups
  - Retention lock is not applied to snapshot files
```

</details>

<details>

<Summary>  sctool backup --dry-run --retention-lock-mode unlocked --retention-days 10 --override-retention-lock </Summary>

```
miles@fedora:~/scylla-manager$ ./sctool.dev backup -L gcs:backuptest-retention-lock --skip-schema --retention-lock-mode unlocked --retention-days 10 --override-retention-lock --dry-run -c myc
NOTICE: dry run mode, backup is not scheduled

Data Centers:
  - dc1
  - dc2

Keyspaces:
  - system_distributed all (4 tables)
  - system_distributed_everywhere all (1 table)
  - system_replicated_keys all (1 table)
  - system_traces all (5 tables)
  - audit all (1 table)

Disk size: ~647.534KiB

Locations:
  - gcs:backuptest-retention-lock

Skip Schema: snapshot won't contain schema that can be restored

Backup Method:  rclone

Bandwidth Limits:
  - 100 MiB/s

Snapshot Parallel Limits:
  - All hosts in parallel

Upload Parallel Limits:
  - All hosts in parallel

Transfers: defined in scylla-manager-agent.yaml config

Retention Policy:
  - Retain backups not older than 10 days
  - Retention lock snapshot files with mode "unlocked" for 10 days
  - Override retention lock configuration on existing snapshot files
```

</details>

<details>

<Summary> sctool progress backup </Summary>

```
miles@fedora:~/scylla-manager$ ./sctool.dev progress -c myc backup/5ccf4c83-d4a9-4ce9-a1b5-1731929811af
Run:            bf99a022-5836-11f1-955f-b27a21e5ab4e
Status:         DONE
Start time:     25 May 26 14:39:19 CEST
End time:       25 May 26 14:39:27 CEST
Duration:       8s
Progress:       100%
Snapshot Tag:   sm_20260525123919UTC
Datacenters:    
  - dc1
  - dc2
Retention Lock:
  - Retention lock is not applied to snapshot files

╭────────────────┬──────────┬────────────┬────────────┬──────────────┬────────╮
│ Host           │ Progress │       Size │    Success │ Deduplicated │ Failed │
├────────────────┼──────────┼────────────┼────────────┼──────────────┼────────┤
│ 192.168.200.11 │     100% │ 433.906KiB │ 433.906KiB │   346.044KiB │     0B │
│ 192.168.200.12 │     100% │ 456.022KiB │ 456.022KiB │    91.005KiB │     0B │
│ 192.168.200.13 │     100% │ 507.165KiB │ 507.165KiB │    91.005KiB │     0B │
│ 192.168.200.21 │     100% │ 189.403KiB │ 189.403KiB │    16.230KiB │     0B │
│ 192.168.200.22 │     100% │ 246.450KiB │ 246.450KiB │           0B │     0B │
│ 192.168.200.23 │     100% │ 149.443KiB │ 149.443KiB │   143.759KiB │     0B │
╰────────────────┴──────────┴────────────┴────────────┴──────────────┴────────╯
```

</details>

<details>

<Summary>  sctool progress backup (--retention-lock-mode unlocked --retention-days 10 --override-retention-lock) </Summary>

```
miles@fedora:~/scylla-manager$ ./sctool.dev progress -c myc backup
Run:            8155b77e-5836-11f1-955e-b27a21e5ab4e
Status:         DONE
Start time:     25 May 26 14:37:34 CEST
End time:       25 May 26 14:37:46 CEST
Duration:       12s
Progress:       100%
Snapshot Tag:   sm_20260525123735UTC
Datacenters:    
  - dc1
  - dc2
Retention Lock:
  - Retention lock snapshot files with mode "unlocked" for 10 days
  - Override retention lock configuration on existing snapshot files

╭────────────────┬──────────┬────────────┬────────────┬──────────────┬────────╮
│ Host           │ Progress │       Size │    Success │ Deduplicated │ Failed │
├────────────────┼──────────┼────────────┼────────────┼──────────────┼────────┤
│ 192.168.200.11 │     100% │ 346.044KiB │ 346.044KiB │           0B │     0B │
│ 192.168.200.12 │     100% │ 381.327KiB │ 381.327KiB │           0B │     0B │
│ 192.168.200.13 │     100% │ 450.623KiB │ 450.623KiB │           0B │     0B │
│ 192.168.200.21 │     100% │ 200.416KiB │ 200.416KiB │           0B │     0B │
│ 192.168.200.22 │     100% │ 317.438KiB │ 317.438KiB │           0B │     0B │
│ 192.168.200.23 │     100% │ 155.083KiB │ 155.083KiB │           0B │     0B │
╰────────────────┴──────────┴────────────┴────────────┴──────────────┴────────╯
```

</details>

Refs https://scylladb.atlassian.net/browse/CLOUD-1916