### PR TITLE
Run full repair after restore

### DIFF
--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -728,6 +728,26 @@ func smokeRestore(t *testing.T, target Target, keyspace string, loadCnt, loadSiz
 		target.SnapshotTag = srcH.simpleBackup(target.Location[0])
 	}
 
+	ni, err := dstH.Client.AnyNodeInfo(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	supportsIncrementalRepair, err := ni.SupportsIncrementalRepair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	encounteredTabletRepair := atomic.NewInt64(0)
+	dstH.Hrt.SetInterceptor(httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if strings.HasPrefix(req.URL.Path, "/storage_service/tablets/repair") && req.Method == http.MethodPost {
+			encounteredTabletRepair.Inc()
+			incrementalMode := req.URL.Query().Get("incremental_mode")
+			if supportsIncrementalRepair && incrementalMode != scyllaclient.IncrementalModeFull {
+				t.Errorf("Expected incremental repair mode %q, got %q", scyllaclient.IncrementalModeFull, incrementalMode)
+			}
+		}
+		return nil, nil
+	}))
+
 	if target.RestoreTables {
 		grantRestoreTablesPermissions(t, dstSession, target.Keyspace, user)
 	} else {
@@ -737,6 +757,13 @@ func smokeRestore(t *testing.T, target Target, keyspace string, loadCnt, loadSiz
 	Print("When: restore backup on different cluster = (dc1: 3 nodes, dc2: 3 nodes)")
 	if err := dstH.service.Restore(ctx, dstH.ClusterID, dstH.TaskID, dstH.RunID, dstH.targetToProperties(target)); err != nil {
 		t.Fatal(err)
+	}
+
+	if target.RestoreTables {
+		rd := scyllaclient.NewRingDescriber(t.Context(), dstH.Client)
+		if rd.IsTabletKeyspace(keyspace) && encounteredTabletRepair.Load() == 0 {
+			t.Error("Expected tablet table to be repaired after restore")
+		}
 	}
 
 	dstH.validateRestoreSuccess(dstSession, srcSession, target, []table{{ks: keyspace, tab: BigTableName}})

--- a/pkg/service/restore/tables_worker.go
+++ b/pkg/service/restore/tables_worker.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/repair"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/parallel"
@@ -323,10 +324,11 @@ func (w *tablesWorker) stageRepair(ctx context.Context) error {
 		}
 	}
 	repairProps, err := json.Marshal(map[string]any{
-		"keyspace":    keyspace,
-		"intensity":   0,
-		"parallel":    0,
-		"allow_empty": true,
+		"keyspace":         keyspace,
+		"intensity":        0,
+		"parallel":         0,
+		"allow_empty":      true,
+		"incremental_mode": scyllaclient.IncrementalModeFull,
 	})
 	if err != nil {
 		return errors.Wrap(err, "parse repair properties")


### PR DESCRIPTION
After both rclone and native restore, repair is used to propagate data from primary replica to secondary replicas, so we always expect it to be a full repair. On the other hand, we want to set incremental mode to full for explicitness and so that we don't run into any edge cases related to restoring data into a table with some previous repair metadata.

Fixes https://scylladb.atlassian.net/browse/CLOUD-2181
