### PR TITLE
Make backup GetTarget safe to run in parallel

### DIFF
--- a/pkg/config/server/server_test.go
+++ b/pkg/config/server/server_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 package server_test
 
@@ -86,6 +86,7 @@ func TestConfigModification(t *testing.T) {
 			DiskSpaceFreeMinPercent:   1,
 			LongPollingTimeoutSeconds: 5,
 			AgeMax:                    24 * time.Hour,
+			PermissionCheckFilesTTL:   5 * time.Minute,
 		},
 		Restore: restore.Config{
 			DiskSpaceFreeMinPercent:   1,

--- a/pkg/service/backup/config.go
+++ b/pkg/service/backup/config.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 package backup
 
@@ -15,6 +15,10 @@ type Config struct {
 	DiskSpaceFreeMinPercent   int           `yaml:"disk_space_free_min_percent"`
 	LongPollingTimeoutSeconds int           `yaml:"long_polling_timeout_seconds"`
 	AgeMax                    time.Duration `yaml:"age_max"`
+	// PermissionCheckFilesTTL defines the time after which leftover
+	// permission check files are considered stale and can be deleted.
+	// Setting it to zero disables the cleanup.
+	PermissionCheckFilesTTL time.Duration `yaml:"permission_check_files_ttl"`
 }
 
 func DefaultConfig() Config {
@@ -22,6 +26,7 @@ func DefaultConfig() Config {
 		DiskSpaceFreeMinPercent:   10,
 		LongPollingTimeoutSeconds: 10,
 		AgeMax:                    24 * time.Hour,
+		PermissionCheckFilesTTL:   5 * time.Minute,
 	}
 }
 
@@ -36,6 +41,9 @@ func (c *Config) Validate() error {
 	}
 	if c.AgeMax < 0 {
 		err = multierr.Append(err, errors.New("invalid age_max, must be >= 0"))
+	}
+	if c.PermissionCheckFilesTTL < 0 {
+		err = multierr.Append(err, errors.New("invalid permission_check_files_ttl, must be >= 0"))
 	}
 
 	return err

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/netip"
 	"path"
 	"slices"
@@ -16,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gocql/gocql"
 	"github.com/pkg/errors"
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/go-set/strset"
@@ -285,15 +285,16 @@ func (s *Service) checkLocationsAvailableFromNodes(ctx context.Context, client *
 	// When checking permissions related to retention lock, it's expected
 	// that some files might be left locked for a short retention period.
 	// They might also be left due to missing permissions or any other
-	// unexpected error. We need to clean them up on the next permission check,
-	// so that they don't accumulate over time.
-	// Since the same bucket is used by multiple SM agents, the cleanup
-	// needs to be performed separately, so that it does not interfere
-	// with some agents still ongoing permission checks.
-	// Since multiple clusters can be backed up to the same bucket,
-	// only the files related to current cluster permission checks
-	// should be cleaned up.
-	permissionCheckPath := path.Join(".permission-check", "cluster", clusterID.String())
+	// unexpected error. We need to clean them up, so that they don't
+	// accumulate over time. Since the same bucket is used by multiple
+	// SM agents, the cleanup needs to be performed separately,
+	// so that it does not interfere with some agents still ongoing
+	// permission checks. Since permission check is performed during
+	// task creation, update, execution, dry run, it needs to handle
+	// concurrent execution. To do that, timestamp is added to the permission
+	// check files path, so that the cleanup can only target stale files.
+	permissionCheckBasePath := path.Join(".permission-check", "cluster", clusterID.String())
+	permissionCheckPath := path.Join(permissionCheckBasePath, uuid.NewTime().String())
 
 	// Cleanup leftover permission check files
 	cleanedUpDCs := map[string]struct{}{}
@@ -308,14 +309,7 @@ func (s *Service) checkLocationsAvailableFromNodes(ctx context.Context, client *
 			l = dcl[""]
 		}
 
-		err := client.RcloneDeleteDir(ctx, n.Addr, l.RemotePath(permissionCheckPath))
-		if err != nil && scyllaclient.StatusCodeOf(err) != http.StatusNotFound {
-			s.logger.Info(ctx, "Failed to cleanup permission check dir",
-				"host", n.Addr,
-				"location", l,
-				"error", err,
-			)
-		}
+		s.cleanupPermissionCheckFiles(ctx, client, n.Addr, l.RemotePath(permissionCheckBasePath))
 	}
 
 	f := func(i int) error {
@@ -342,6 +336,48 @@ func (s *Service) checkLocationsAvailableFromNodes(ctx context.Context, client *
 
 	// Run checkHostLocation in parallel
 	return util.ErrValidate(parallel.Run(len(nodes), parallel.NoLimit, f, notify))
+}
+
+func (s *Service) cleanupPermissionCheckFiles(ctx context.Context, client *scyllaclient.Client, host, remotePath string) {
+	if s.config.PermissionCheckFilesTTL == 0 {
+		// Cleanup is disabled, nothing to do
+		return
+	}
+
+	opts := &scyllaclient.RcloneListDirOpts{
+		Recurse:   true,
+		FilesOnly: true,
+	}
+	err := client.RcloneListDirIter(ctx, host, remotePath, opts, func(item *scyllaclient.RcloneListDirItem) {
+		rawTimeUUID, _, _ := strings.Cut(item.Path, "/")
+		id, err := gocql.ParseUUID(rawTimeUUID)
+		if err != nil {
+			s.logger.Error(ctx, "Failed to extract permission check file timestamp, skipping",
+				"host", host,
+				"file", path.Join(remotePath, item.Path),
+				"error", err,
+			)
+			return
+		}
+
+		if timeutc.Since(id.Time()) > s.config.PermissionCheckFilesTTL {
+			if err := client.RcloneDeleteFile(ctx, host, path.Join(remotePath, item.Path)); err != nil {
+				s.logger.Info(ctx, "Failed to cleanup stale permission check file, skipping",
+					"host", host,
+					"file", path.Join(remotePath, item.Path),
+					"error", err,
+				)
+			}
+		}
+	})
+	if err != nil {
+		s.logger.Error(ctx, "Failed to list permission check files, skipping",
+			"host", host,
+			"path", remotePath,
+			"error", err,
+		)
+		return
+	}
 }
 
 func (s *Service) checkHostLocation(ctx context.Context, client *scyllaclient.Client,

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/agent/models"
 	"go.uber.org/atomic"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/scylladb/scylla-manager/v3/pkg/metrics"
 	"github.com/scylladb/scylla-manager/v3/pkg/schema/table"
@@ -499,6 +500,100 @@ func TestGetTargetIntegration(t *testing.T) {
 				t.Fatal(diff)
 			}
 		})
+	}
+}
+
+func TestGetTargetInParallelIntegration(t *testing.T) {
+	// This test verifies that GetTarget can be successfully called in parallel.
+	// The main pain point are the leftover permission check files that needs
+	// to be cleaned up at some point. This test simulates leftover permission
+	// check files (with known and unknown format), executes regular GetTarget
+	// and GetTarget with retention lock configuration in parallel, and validates
+	// that all (except the file with unknown format) files are eventually cleaned up.
+	const testBucket = "backuptest-get-target-in-parallel"
+	GCSInitBucket(t, testBucket)
+
+	var (
+		session  = CreateSessionWithoutMigration(t)
+		location = backupspec.Location{Provider: backupspec.GCS, Path: testBucket}
+		cfg      = defaultConfig()
+		h        = newBackupTestHelper(t, session, cfg, location, nil)
+		ctx      = t.Context()
+	)
+	ni, err := h.Client.AnyNodeInfo(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Prepare additional service using altered config
+	cleanupCfg := defaultConfig()
+	cleanupCfg.PermissionCheckFilesTTL = time.Nanosecond
+	cleanupH := newBackupTestHelper(t, session, cleanupCfg, location, nil)
+	cleanupH.ClusterID = h.ClusterID
+
+	// Prepare different backup properties
+	props := defaultTestProperties(location, "")
+	if CheckConstraint(t, ni.ScyllaVersion, "< 2026.1") {
+		props["method"] = "rclone"
+	}
+	rawProps, err := json.Marshal(props)
+	if err != nil {
+		t.Fatal(err)
+	}
+	props["retention_days"] = 1
+	props["retention_lock_mode"] = backup.RetentionLockUnlocked
+	rawRetentionLockProps, err := json.Marshal(props)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getProps := func(i int) json.RawMessage {
+		if i%2 == 0 {
+			return rawRetentionLockProps
+		}
+		return rawProps
+	}
+
+	Print("Given: initial leftover permission check files")
+	basePath := path.Join(".permission-check", "cluster", h.ClusterID.String())
+	initialFile := path.Join(uuid.NewTime().String(), "test", "file")
+	if err := h.Client.RclonePut(ctx, ManagedClusterHost(), location.RemotePath(path.Join(basePath, initialFile)), bytes.NewBuffer([]byte{0})); err != nil {
+		t.Fatal(err)
+	}
+	initialFileUnknownFormat := path.Join("unknown", "test", "file")
+	if err := h.Client.RclonePut(ctx, ManagedClusterHost(), location.RemotePath(path.Join(basePath, initialFileUnknownFormat)), bytes.NewBuffer([]byte{0})); err != nil {
+		t.Fatal(err)
+	}
+
+	Print("When: call GetTarget in parallel")
+	eg := errgroup.Group{}
+	for i := range 5 {
+		eg.Go(func() error {
+			_, err := h.service.GetTarget(ctx, h.ClusterID, getProps(i))
+			return err
+		})
+	}
+
+	Print("Then: all calls to GetTarget succeeded")
+	if err := eg.Wait(); err != nil {
+		t.Fatal(err)
+	}
+
+	Print("When: call GetTarget with instant permission check files cleanup")
+	if _, err := cleanupH.service.GetTarget(ctx, h.ClusterID, rawProps); err != nil {
+		t.Fatal(err)
+	}
+
+	Print("Then: all permission check files (apart from initial unknown) are cleaned up")
+	leftoverFiles, err := h.Client.RcloneListDir(ctx, ManagedClusterHost(), location.RemotePath(basePath), &scyllaclient.RcloneListDirOpts{
+		Recurse:   true,
+		FilesOnly: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(leftoverFiles) != 1 || leftoverFiles[0].Path != initialFileUnknownFormat {
+		t.Fatalf("Expected only the initial unknown permission check file to be present after cleanup, got: %v", leftoverFiles)
 	}
 }
 


### PR DESCRIPTION
This PR makes backup permission check procedure
safe for concurrent calls. Previously, I assumed that
only a single backup task can run in parallel for
a given cluster, but the permission check is also
invoked during dry run, task creation, task update.
Because of that, it was possible that permission check
from task update deleted permission check files from
backup task execution or the other way around.
This PR adds and uses the permission_check_files_ttl config
option to clean up only the stale leftover permission
check files and allow GetTarget to be safely executed
in parallel.

Fixes https://scylladb.atlassian.net/browse/CLOUD-2276
