### PR TITLE
Update SM DB setup

### DIFF
--- a/dist/scripts/scyllamgr_setup
+++ b/dist/scripts/scyllamgr_setup
@@ -120,7 +120,7 @@ if command -v scylla_setup > /dev/null && [[ ${SETUP_SCYLLA} == 1 ]]; then
         f=/etc/sysconfig/scylla-server
     fi
     if [[ "$f" != "" ]]; then
-      sed -i -e 's/^SCYLLA_ARGS=.*/SCYLLA_ARGS="--memory 1G --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --network-stack posix"/g' ${f}
+      sed -i -e 's/^SCYLLA_ARGS=.*/SCYLLA_ARGS="--memory 1G --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --network-stack posix --auto-snapshot=false"/g' ${f}
     fi
 fi
 

--- a/dist/scripts/scyllamgr_setup
+++ b/dist/scripts/scyllamgr_setup
@@ -120,7 +120,7 @@ if command -v scylla_setup > /dev/null && [[ ${SETUP_SCYLLA} == 1 ]]; then
         f=/etc/sysconfig/scylla-server
     fi
     if [[ "$f" != "" ]]; then
-      sed -i -e 's/^SCYLLA_ARGS=.*/SCYLLA_ARGS="--memory 500M --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --network-stack posix"/g' ${f}
+      sed -i -e 's/^SCYLLA_ARGS=.*/SCYLLA_ARGS="--memory 1G --log-to-syslog 0 --log-to-stdout 1 --default-log-level info --network-stack posix"/g' ${f}
     fi
 fi
 


### PR DESCRIPTION
This PR changes 2 thins in the initial SM DB configuration:
- memory increased from 500M to 1G
- auto_snapshot is disabled

The auto_snapshot property is just not needed, as we don't store important user data and SM is the only automated user of of this DB.
In terms of increasing the memory, the original [issue](https://github.com/scylladb/scylla-manager/issues/4667) recommends to increase it to the minimal recommended production value of 2G, but I decided to make a smaller step first and bump it to 1G. That's because SM DB is not really supposed to store huge amounts of data.
Issue mentions the case of repairing a huge cluster, which indeed is a problem, but that should be fixed by optimizing SM DB usage during vnode repair, as the problem lays in the poorly written code rather than memory limitation on SM DB side. Increasing memory to 2G could not even be enough to fix it, although it would probably help.
On the other hand, it could hurt other, smaller setups, where this additional 1G of memory would be taken away from SM.
In general, the SM DB setup script is just a quick minimal way to configure SM DB, but if a different SM DB config is needed, it can be done either manually or by changing the setup script and running it again.
So for now the memory will be increased to 1G, we will observe how that impacts cloud deployments and increase it further if needed.

Tested it by downloading custom SM build with this changes, deploying it in a docker container, and querying scylla config/logs:
```
[root@17761274a3c6 /]# curl http:/localhost:10000/v2/config/auto_snapshot
false
...
[root@17761274a3c6 /]# journalctl -u scylla-server -b --no-pager | grep "parsed command line options"
Jun 09 08:11:22 17761274a3c6 scylla[506]: parsed command line options: [memory, (positional) 1G, log-to-syslog, (positional) 0, log-to-stdout, (positional) 1, default-log-level, (positional) info, network-stack, (positional) posix, auto-snapshot: false, developer-mode: 1, smp, (positional) 1]
Jun 09 08:18:57 17761274a3c6 scylla[931]: parsed command line options: [memory, (positional) 1G, log-to-syslog, (positional) 0, log-to-stdout, (positional) 1, default-log-level, (positional) info, network-stack, (positional) posix, auto-snapshot: false, developer-mode: 1, smp, (positional) 1]
```

Keeping the initial issue open https://github.com/scylladb/scylla-manager/issues/4667
Fixes https://scylladb.atlassian.net/browse/CLOUD-2227
Fixes https://scylladb.atlassian.net/browse/CLOUD-2228