### PR TITLE
Limit rclone batches to MaxSStableComponentCountInReqBody

### DIFF
--- a/pkg/service/restore/batch.go
+++ b/pkg/service/restore/batch.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2024 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 package restore
 
@@ -64,6 +64,10 @@ type batchDispatcher struct {
 	// batches contain N*node_shard_cnt SSTables of total
 	// size up to 100% of node expected workload.
 	batchSize int
+	// If greater than zero, rclone batch can contain up to rcloneBatchFileCountLimit files.
+	// This is a soft limit which can be exceeded so that batch contains at lest shard cnt
+	// sstables or less than shard cnt sstables would be left in the pool after batch dispatch.
+	rcloneBatchFileCountLimit int
 	// Equals total_backup_size/($\sum_{node} shard_cnt(node)$)
 	expectedShardWorkload int64
 	hostInfo              map[string]hostBatchInfo
@@ -89,6 +93,11 @@ func newBatchDispatcher(workload Workload, batchSize int, hostInfo map[string]ho
 		hostInfo:              hostInfo,
 		method:                method,
 	}
+}
+
+func (bd *batchDispatcher) withRcloneBatchFileCountLimit(limit int) *batchDispatcher {
+	bd.rcloneBatchFileCountLimit = limit
+	return bd
 }
 
 // Describes current state of SSTables that are yet to be batched.
@@ -364,56 +373,78 @@ func (bd *batchDispatcher) createBatch(dirIdx int, host string) (batch, bool) {
 		batchMethod = MethodNative
 	}
 
+	// Set batch limits.
+	// The files count limit comes from rclone server limitation,
+	// but it's not a hard limit and can be crossed to a small degree.
+	// Size and SST cnt limits come from batching strategy controlled
+	// with --batch-size and batch restoration method. They can also
+	// be slightly extended if needed.
+	var fileCntLimit int
+	var sizeLimit int64
+	var sstCntLimit int
+	if batchMethod == MethodRclone && bd.rcloneBatchFileCountLimit > 0 {
+		fileCntLimit = bd.rcloneBatchFileCountLimit
+	}
+	switch {
+	case batchMethod == MethodNative:
+		sizeLimit = bd.getSizeBasedLimit(host, 100, 5)
+	case bd.batchSize == maxBatchSize:
+		sizeLimit = bd.getSizeBasedLimit(host, 5, 5)
+	default:
+		sstCntLimit = bd.getSstCntBasedLimit(host)
+	}
+
+	getNextShardCntSSTables := func(i int) (fileCnt int, size int64, sstCnt int) {
+		for j := range hi.shardCnt {
+			idx := i + int(j)
+			if idx >= len(sstables) {
+				return
+			}
+			fileCnt += len(sstables[idx].Files)
+			size += sstables[idx].Size
+			sstCnt++
+		}
+		return
+	}
+
 	var i int
 	var size int64
-	if bd.batchSize == maxBatchSize || batchMethod == MethodNative {
-		// Create batch containing multiple of node shard count sstables
-		// and size up to a percentage of expected node workload.
-		// For rclone restore with --batch-size=0, aim for 5% of expected node workload.
-		// For native restore, aim for 100% of expected node workload.
-		expectedNodeWorkload := bd.expectedShardWorkload * int64(hi.shardCnt)
-		sizeLimit := expectedNodeWorkload / 20
-		if batchMethod == MethodNative {
-			// For 5% rclone batches, we expect imbalance in workload distribution
-			// to be less significant even in the more problematic scenarios.
-			// The risk of noticeable imbalance in 100% native batches is much higher,
-			// so we fall back to 5% batches when node already restored its expected workload.
-			alreadyAssigned := bd.workloadProgress.hostAssignedBytes[host]
-			remainingExpected := max(expectedNodeWorkload-alreadyAssigned, 0)
-			sizeLimit = max(remainingExpected, sizeLimit)
+	var fileCnt int
+	for {
+		nextFileCnt, nextSize, nextSstCnt := getNextShardCntSSTables(i)
+		if nextSstCnt == 0 {
+			break
 		}
-		for {
-			for range hi.shardCnt {
-				if i >= len(sstables) {
-					break
-				}
-				size += sstables[i].Size
-				i++
-			}
-			if i >= len(sstables) {
+		// Don't validate the first shard cnt sstables,
+		// so that setting strange limits doesn't result
+		// in hanging on empty batch creation.
+		if i > 0 {
+			if fileCntLimit > 0 && fileCnt+nextFileCnt > fileCntLimit {
 				break
 			}
-			if size > sizeLimit {
+			if sizeLimit > 0 && size+nextSize > sizeLimit {
+				break
+			}
+			if sstCntLimit > 0 && i+nextSstCnt > sstCntLimit {
 				break
 			}
 		}
-	} else {
-		// Create batch containing node_shard_count*batch_size sstables.
-		i = min(bd.batchSize*int(hi.shardCnt), len(sstables))
-		for j := range i {
-			size += sstables[j].Size
-		}
+
+		fileCnt += nextFileCnt
+		size += nextSize
+		i += nextSstCnt
 	}
 
 	if i == 0 {
 		return batch{}, false
 	}
 	// Extend batch if it was to leave less than
-	// 1 sstable per shard for the next one.
+	// 1 sstable per shard for the next one
+	// (ignore the limits).
 	if len(sstables)-i < int(hi.shardCnt) {
-		for ; i < len(sstables); i++ {
-			size += sstables[i].Size
-		}
+		_, nextSize, nextSstCnt := getNextShardCntSSTables(i)
+		size += nextSize
+		i += nextSstCnt
 	}
 
 	rdp.RemainingSSTables[batchT] = sstables[i:]
@@ -430,6 +461,38 @@ func (bd *batchDispatcher) createBatch(dirIdx int, host string) (batch, bool) {
 		Size:             size,
 		SSTables:         sstables[:i],
 	}, true
+}
+
+func (bd *batchDispatcher) getSizeBasedLimit(host string, targetPercentage, overworkPercentage int) (sizeLimit int64) {
+	// Create batch containing multiple of node shard count sstables
+	// and size up to a targetPercentage of expected node workload.
+	// To reduce the imbalance between node workloads, batches are
+	// created with targetPercentage up until node crosses its total
+	// expected workload. After that, batches are created according
+	// to overworkPercentage.
+	hi := bd.hostInfo[host]
+	if hi.shardCnt == 0 {
+		hi.shardCnt = 1
+	}
+	expectedNodeWorkload := bd.expectedShardWorkload * int64(hi.shardCnt)
+	overworkSizeLimit := expectedNodeWorkload * int64(overworkPercentage) / 100
+
+	maxTargetSizeLimit := expectedNodeWorkload * int64(targetPercentage) / 100
+	alreadyAssigned := bd.workloadProgress.hostAssignedBytes[host]
+	remainingExpected := max(expectedNodeWorkload-alreadyAssigned, 0)
+	targetSizeLimit := min(remainingExpected, maxTargetSizeLimit)
+
+	return max(overworkSizeLimit, targetSizeLimit)
+}
+
+func (bd *batchDispatcher) getSstCntBasedLimit(host string) (sstCntLimit int) {
+	// Create batch containing node_shard_count*batch_size sstables.
+	hi := bd.hostInfo[host]
+	if hi.shardCnt == 0 {
+		hi.shardCnt = 1
+	}
+
+	return bd.batchSize * int(hi.shardCnt)
 }
 
 // ReportSuccess notifies batchDispatcher that given batch was restored successfully.

--- a/pkg/service/restore/batch_test.go
+++ b/pkg/service/restore/batch_test.go
@@ -270,6 +270,163 @@ func TestBatchDispatcherHostWithoutNativeRestore(t *testing.T) {
 	}
 }
 
+func TestBatchDispatcherRcloneBatchFileCountLimit(t *testing.T) {
+	l := backupspec.Location{
+		Provider: "s3",
+		Path:     "l",
+	}
+	newRawWorkload := func(sstables []RemoteSSTable) []RemoteDirWorkload {
+		var size int64
+		for _, sst := range sstables {
+			size += sst.Size
+		}
+		return []RemoteDirWorkload{
+			{
+				ManifestInfo: &backupspec.ManifestInfo{
+					Location: l,
+					DC:       "dc1",
+				},
+				TableName: TableName{
+					Keyspace: "ks1",
+					Table:    "t1",
+				},
+				RemoteSSTableDir: "a",
+				Size:             size,
+				SSTables:         sstables,
+			},
+		}
+	}
+	defaultSSTables := func() []RemoteSSTable {
+		return []RemoteSSTable{
+			{Size: 40, SSTable: SSTable{ID: sstable.ID{Type: sstable.UUID}, Files: []string{"a-1", "a-2", "a-3"}}},
+			{Size: 30, SSTable: SSTable{ID: sstable.ID{Type: sstable.UUID}, Files: []string{"b-1", "b-2"}}},
+			{Size: 20, SSTable: SSTable{ID: sstable.ID{Type: sstable.UUID}, Files: []string{"c-1"}}},
+			{Size: 10, SSTable: SSTable{ID: sstable.ID{Type: sstable.UUID}, Files: []string{"d-1", "d-2"}}},
+			{Size: 10, SSTable: SSTable{ID: sstable.ID{Type: sstable.UUID}, Files: []string{"e-1"}}},
+			{Size: 10, SSTable: SSTable{ID: sstable.ID{Type: sstable.UUID}, Files: []string{"f-1"}}},
+			{Size: 10, SSTable: SSTable{ID: sstable.ID{Type: sstable.UUID}, Files: []string{"g-1"}}},
+		}
+	}
+	smallSSTables := func(cnt int) []RemoteSSTable {
+		sstables := make([]RemoteSSTable, cnt)
+		for i := range sstables {
+			sstables[i] = RemoteSSTable{
+				SSTable: SSTable{ID: sstable.ID{Type: sstable.UUID}, Files: []string{"f"}},
+				Size:    1,
+			}
+		}
+		return sstables
+	}
+	locationInfo := []LocationInfo{
+		{
+			Location: l,
+			DCHosts:  map[string][]string{"dc1": {"h1"}},
+		},
+	}
+
+	testCases := []struct {
+		name                 string
+		sstables             []RemoteSSTable
+		shardCnt             uint
+		batchSize            int
+		method               Method
+		rcloneFileCountLimit int
+
+		expectedSSTableCnt int
+	}{
+		{
+			name:                 "regular rclone batch",
+			sstables:             defaultSSTables(),
+			shardCnt:             3,
+			batchSize:            1,
+			method:               MethodRclone,
+			rcloneFileCountLimit: 0,
+			expectedSSTableCnt:   3,
+		},
+		{
+			name:                 "first shard group may exceed rclone limit",
+			sstables:             defaultSSTables(),
+			shardCnt:             3,
+			batchSize:            10000,
+			method:               MethodRclone,
+			rcloneFileCountLimit: 2,
+			expectedSSTableCnt:   3,
+		},
+		{
+			name:                 "rclone file count limits large batch size",
+			sstables:             defaultSSTables(),
+			shardCnt:             1,
+			batchSize:            10000,
+			method:               MethodRclone,
+			rcloneFileCountLimit: 5,
+			expectedSSTableCnt:   2,
+		},
+		{
+			name:                 "size based rclone batch",
+			sstables:             smallSSTables(40),
+			shardCnt:             1,
+			batchSize:            maxBatchSize,
+			method:               MethodRclone,
+			rcloneFileCountLimit: 0,
+			expectedSSTableCnt:   2,
+		},
+		{
+			name:                 "rclone file count limits size based batch",
+			sstables:             smallSSTables(40),
+			shardCnt:             1,
+			batchSize:            maxBatchSize,
+			method:               MethodRclone,
+			rcloneFileCountLimit: 1,
+			expectedSSTableCnt:   1,
+		},
+		{
+			name:                 "regular native batch is not throttled",
+			sstables:             defaultSSTables(),
+			shardCnt:             3,
+			batchSize:            1,
+			method:               MethodNative,
+			rcloneFileCountLimit: 2,
+			expectedSSTableCnt:   7,
+		},
+		{
+			name:                 "size based native batch is not throttled",
+			sstables:             defaultSSTables(),
+			shardCnt:             3,
+			batchSize:            maxBatchSize,
+			method:               MethodNative,
+			rcloneFileCountLimit: 2,
+			expectedSSTableCnt:   7,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			workload := aggregateWorkload(newRawWorkload(tc.sstables))
+			hostInfo := map[string]hostBatchInfo{
+				"h1": {shardCnt: tc.shardCnt, nativeRestoreSupport: true},
+			}
+			bd := newBatchDispatcher(workload, tc.batchSize, hostInfo, locationInfo, tc.method).
+				withRcloneBatchFileCountLimit(tc.rcloneFileCountLimit)
+
+			b, ok := bd.dispatchBatch("h1")
+			if !ok {
+				t.Fatal("Expected batch")
+			}
+
+			if len(b.SSTables) != tc.expectedSSTableCnt {
+				t.Fatalf("Expected %d sstables, got %d", tc.expectedSSTableCnt, len(b.SSTables))
+			}
+			var files int
+			for _, sst := range b.SSTables {
+				files += len(sst.Files)
+			}
+			if b.method == MethodRclone && tc.rcloneFileCountLimit > 0 && len(b.SSTables) > int(tc.shardCnt) && files > tc.rcloneFileCountLimit {
+				t.Fatalf("Expected at most %d files, got %d", tc.rcloneFileCountLimit, files)
+			}
+		})
+	}
+}
+
 // TestBatchDispatcherIntegerID validates that sstables with
 // integer based IDs use 5% limit when maxBatchSize is used.
 func TestBatchDispatcherIntegerID(t *testing.T) {
@@ -407,11 +564,9 @@ func TestBatchDispatcherMultiHostNative(t *testing.T) {
 
 	// Host h1 with 2 shards gets the first batch.
 	// SSTables sorted descending: [100, 90, 80, 70, 60, 50, 50].
-	// Since 2 first sstables are smaller than expected workload,
-	// the next 2 are also added to the batch. This might seem like
-	// a poor batching strategy, but that's because sstable count
-	// is relatively small to the shard count, which is not the case
-	// in the real life scenarios.
+	// The first shard-count SSTables are always batched. The next
+	// shard-count group would exceed h1 expected workload, so it is
+	// left for another host.
 	b1, ok := bd.dispatchBatch("h1")
 	if !ok {
 		t.Fatal("Expected batch for h1")
@@ -419,17 +574,18 @@ func TestBatchDispatcherMultiHostNative(t *testing.T) {
 	if b1.method != MethodNative {
 		t.Errorf("Expected method %q, got %q", MethodNative, b1.method)
 	}
-	if len(b1.SSTables) != 4 {
-		t.Errorf("Expected 4 sstables for h1, got %d", len(b1.SSTables))
+	if len(b1.SSTables) != 2 {
+		t.Errorf("Expected 2 sstables for h1, got %d", len(b1.SSTables))
 	}
-	if b1.Size != 340 {
-		t.Errorf("Expected batch size 340, got %d", b1.Size)
+	if b1.Size != 190 {
+		t.Errorf("Expected batch size 190, got %d", b1.Size)
 	}
 	bd.ReportSuccess(b1)
 
 	// Host h2 with 3 shards gets the second batch.
-	// Remaining SSTables: [60, 50, 50].
-	// It takes all 3 remaining sstables.
+	// Remaining SSTables: [80, 70, 60, 50, 50].
+	// It gets the first shard-count group and then the leftovers are
+	// added to avoid leaving less than one SSTable per shard.
 	b2, ok := bd.dispatchBatch("h2")
 	if !ok {
 		t.Fatal("Expected batch for h2")
@@ -437,13 +593,22 @@ func TestBatchDispatcherMultiHostNative(t *testing.T) {
 	if b2.method != MethodNative {
 		t.Errorf("Expected method %q, got %q", MethodNative, b2.method)
 	}
-	if len(b2.SSTables) != 3 {
-		t.Errorf("Expected 3 SSTables for h2, got %d", len(b2.SSTables))
+	if len(b2.SSTables) != 5 {
+		t.Errorf("Expected 5 SSTables for h2, got %d", len(b2.SSTables))
 	}
-	if b2.Size != 160 {
-		t.Errorf("Expected batch size 160, got %d", b2.Size)
+	if b2.Size != 310 {
+		t.Errorf("Expected batch size 310, got %d", b2.Size)
 	}
 	bd.ReportSuccess(b2)
+	if b1.Size <= 0 || b1.Size > 200 {
+		t.Errorf("Expected h1 workload to fit its expected 200 bytes, got %d", b1.Size)
+	}
+	if b2.Size <= 0 || b2.Size < 300 {
+		t.Errorf("Expected h2 workload to use remaining expected capacity, got %d", b2.Size)
+	}
+	if b1.Size+b2.Size != 500 {
+		t.Errorf("Expected total dispatched size 500, got %d", b1.Size+b2.Size)
+	}
 
 	_, ok = bd.dispatchBatch("h1")
 	if ok {

--- a/pkg/service/restore/tables_worker.go
+++ b/pkg/service/restore/tables_worker.go
@@ -247,7 +247,8 @@ func (w *tablesWorker) stageRestoreData(ctx context.Context) error {
 			nativeRestoreSupport: hi.NativeRestoreSupport,
 		}
 	}
-	bd := newBatchDispatcher(workload, w.target.BatchSize, hbi, w.target.locationInfo, w.target.Method)
+	bd := newBatchDispatcher(workload, w.target.BatchSize, hbi, w.target.locationInfo, w.target.Method).
+		withRcloneBatchFileCountLimit(scyllaclient.MaxSStableComponentCountInReqBody)
 
 	f := func(n int) error {
 		host := hosts[n]


### PR DESCRIPTION
As described in scyllaclient.MaxSStableComponentCountInReqBody comment, rclone server reject huge req body payloads, so we need to limit rclone batch sizes accordingly.

Fixes #4659
