### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -18,17 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Set up env
         run: make -C docs setupenv
       - name: Build docs

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Set up env
         run: make -C docs setupenv
       - name: Build docs

--- a/.github/workflows/integration-tests-2025.1.12-IPV4.yaml
+++ b/.github/workflows/integration-tests-2025.1.12-IPV4.yaml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -59,7 +59,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -74,7 +74,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Set IP_FAMILY and SSL_ENABLED var for all tests
               run: |
                 echo "IP_FAMILY=${{ env.ip-family }}" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests-2025.1.12-IPV6-tablets-nossl.yaml
+++ b/.github/workflows/integration-tests-2025.1.12-IPV6-tablets-nossl.yaml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -27,7 +27,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -44,7 +44,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -59,7 +59,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -74,7 +74,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Set IP_FAMILY and SSL_ENABLED var for all tests
               run: |
                 echo "IP_FAMILY=${{ env.ip-family }}" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests-2025.4.7-IPV4-native-rclone.yaml
+++ b/.github/workflows/integration-tests-2025.4.7-IPV4-native-rclone.yaml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -76,7 +76,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Set IP_FAMILY and SSL_ENABLED var for all tests
               run: |
                 echo "IP_FAMILY=${{ env.ip-family }}" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests-2025.4.7-IPV6-tablets-nossl-rclone-rclone-gcs.yaml
+++ b/.github/workflows/integration-tests-2025.4.7-IPV6-tablets-nossl-rclone-rclone-gcs.yaml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -30,7 +30,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -47,7 +47,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -62,7 +62,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -77,7 +77,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Set IP_FAMILY and SSL_ENABLED var for all tests
               run: |
                 echo "IP_FAMILY=${{ env.ip-family }}" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests-2026.1.2-IPV4-tablets-native-native.yaml
+++ b/.github/workflows/integration-tests-2026.1.2-IPV4-tablets-native-native.yaml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -76,7 +76,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Set IP_FAMILY and SSL_ENABLED var for all tests
               run: |
                 echo "IP_FAMILY=${{ env.ip-family }}" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests-2026.1.2-IPV6-nossl-rclone-rclone-localstorage.yaml
+++ b/.github/workflows/integration-tests-2026.1.2-IPV6-nossl-rclone-rclone-localstorage.yaml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -30,7 +30,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -47,7 +47,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -62,7 +62,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -77,7 +77,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Set IP_FAMILY and SSL_ENABLED var for all tests
               run: |
                 echo "IP_FAMILY=${{ env.ip-family }}" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests-2026.2.0-rc1-IPV4-tablets-rclone-native.yaml
+++ b/.github/workflows/integration-tests-2026.2.0-rc1-IPV4-tablets-rclone-native.yaml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -76,7 +76,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Set IP_FAMILY and SSL_ENABLED var for all tests
               run: |
                 echo "IP_FAMILY=${{ env.ip-family }}" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests-2026.2.0-rc1-IPV6-nossl-rclone-rclone.yaml
+++ b/.github/workflows/integration-tests-2026.2.0-rc1-IPV6-nossl-rclone-rclone.yaml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -76,7 +76,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Set IP_FAMILY and SSL_ENABLED var for all tests
               run: |
                 echo "IP_FAMILY=${{ env.ip-family }}" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests-latest-IPV4-native-native-gcs.yaml
+++ b/.github/workflows/integration-tests-latest-IPV4-native-native-gcs.yaml
@@ -15,7 +15,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -30,7 +30,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -47,7 +47,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -62,7 +62,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -77,7 +77,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Set IP_FAMILY and SSL_ENABLED var for all tests
               run: |
                 echo "IP_FAMILY=${{ env.ip-family }}" >> $GITHUB_ENV

--- a/.github/workflows/integration-tests-latest-IPV6-tablets-nossl-rclone-rclone.yaml
+++ b/.github/workflows/integration-tests-latest-IPV6-tablets-nossl-rclone-rclone.yaml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -29,7 +29,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -46,7 +46,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -61,7 +61,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Setup testing dependencies
               uses: ./.github/actions/test-setup
               with:
@@ -76,7 +76,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out code into the Go module directory
-              uses: actions/checkout@v6
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
             - name: Set IP_FAMILY and SSL_ENABLED var for all tests
               run: |
                 echo "IP_FAMILY=${{ env.ip-family }}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -21,12 +21,12 @@ jobs:
         run: echo "GOVERSION=$(cat .go-version)" >> $GITHUB_ENV
 
       - name: Set up go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: "${{env.GOVERSION}}"
 
       - name: Release
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: latest
           workdir: dist

--- a/.github/workflows/sanity-checks.yml
+++ b/.github/workflows/sanity-checks.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup testing dependencies
         uses: ./.github/actions/test-setup


### PR DESCRIPTION
## Summary
- Pin all external GitHub Actions to full commit SHAs to reduce supply chain attack surface
- Upgrade outdated actions to their latest versions

**This PR was generated automatically. Please verify that GitHub Actions work as expected with these changes before merging.**

Reference: https://github.com/scylladb/scylladb/pull/29421