### PR TITLE
scheduler_test: improve retry assertions stability

### DIFF
--- a/pkg/service/scheduler/service_integration_test.go
+++ b/pkg/service/scheduler/service_integration_test.go
@@ -770,7 +770,7 @@ func TestServiceScheduleIntegration(t *testing.T) {
 		Print("Given: task scheduled in future")
 		task := h.makeTaskWithStartDate(future)
 		task.Sched.NumRetries = 1
-		task.Sched.RetryWait = duration.Duration(10 * time.Millisecond)
+		task.Sched.RetryWait = duration.Duration(25 * time.Millisecond)
 		if err := h.service.PutTask(ctx, task); err != nil {
 			t.Fatal(err)
 		}
@@ -810,7 +810,7 @@ func TestServiceScheduleIntegration(t *testing.T) {
 		Print("Given: task scheduled in future")
 		task := h.makeTaskWithStartDate(now().Add(time.Second))
 		task.Sched.NumRetries = 1
-		task.Sched.RetryWait = duration.Duration(10 * time.Millisecond)
+		task.Sched.RetryWait = duration.Duration(25 * time.Millisecond)
 		if err := h.service.PutTask(ctx, task); err != nil {
 			t.Fatal(err)
 		}
@@ -851,7 +851,7 @@ func TestServiceScheduleIntegration(t *testing.T) {
 		Print("When: task is scheduled with retry once")
 		task := h.makeTaskWithStartDate(now())
 		task.Sched.NumRetries = 1
-		task.Sched.RetryWait = duration.Duration(10 * time.Millisecond)
+		task.Sched.RetryWait = duration.Duration(25 * time.Millisecond)
 		if err := h.service.PutTask(ctx, task); err != nil {
 			t.Fatal(err)
 		}
@@ -968,7 +968,7 @@ func TestServiceScheduleIntegration(t *testing.T) {
 		task := h.makeTask(scheduler.Schedule{
 			StartDate:  now(),
 			NumRetries: 1,
-			RetryWait:  duration.Duration(10 * time.Millisecond),
+			RetryWait:  duration.Duration(25 * time.Millisecond),
 		})
 		if err := h.service.PutTask(ctx, task); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Previously, both _interval and RetryWait were set to 10ms in many tests. This caused assertStatus flakiness in cases where:
- task was started
- expected status running
- task was injected with error
- expected status error

as the task might have been restarted before the
assertion could see the error status. This commit
makes increases RetryWait in those tests to 25ms,
so that the assertStatus using _interval=10ms has
greater changes of observing the error status.