### PR TITLE
Fix repair worker pool cleanup

### DIFF
--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -784,6 +784,11 @@ func (c *Client) ActiveRepairs(ctx context.Context, hosts []string) ([]*models.T
 	return c.activeScyllaTasks(ctx, ScyllaTaskModuleRepair, ScyllaTaskTypeRepair, hosts)
 }
 
+// ActiveTabletRepairs returns scheduled or running ScyllaTaskTypeUserRepair tasks.
+func (c *Client) ActiveTabletRepairs(ctx context.Context) ([]*models.TaskStats, error) {
+	return c.activeScyllaTasks(ctx, ScyllaTaskModuleTablets, ScyllaTaskTypeUserRepair, nil)
+}
+
 func (c *Client) activeScyllaTasks(ctx context.Context, module ScyllaTaskModule, taskType ScyllaTaskType, hosts []string) ([]*models.TaskStats, error) {
 	if len(hosts) == 0 {
 		hosts = []string{""}
@@ -817,6 +822,14 @@ func (c *Client) activeScyllaTasks(ctx context.Context, module ScyllaTaskModule,
 // It ignores abort errors, as they might mean that task finished naturally.
 func (c *Client) KillAllRepairs(ctx context.Context, hosts ...string) error {
 	return c.abortActiveScyllaTasks(ctx, ScyllaTaskModuleRepair, ScyllaTaskTypeRepair, hosts...)
+}
+
+// KillAllTabletRepairs forces a termination of all ScyllaTaskTypeUserRepair tasks.
+// It ignores abort errors, as they might mean that task finished naturally.
+// Note that ScyllaTaskTypeUserRepair should be killed before ScyllaTaskTypeRepair,
+// as ScyllaTaskTypeUserRepair could respawn ScyllaTaskTypeRepair.
+func (c *Client) KillAllTabletRepairs(ctx context.Context) error {
+	return c.abortActiveScyllaTasks(ctx, ScyllaTaskModuleTablets, ScyllaTaskTypeUserRepair)
 }
 
 func (c *Client) abortActiveScyllaTasks(ctx context.Context, module ScyllaTaskModule, taskType ScyllaTaskType, hosts ...string) error {

--- a/pkg/scyllaclient/client_scylla.go
+++ b/pkg/scyllaclient/client_scylla.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -29,6 +30,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/client/operations"
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/models"
 	"go.uber.org/multierr"
+	"golang.org/x/sync/errgroup"
 )
 
 // ErrHostInvalidResponse is to indicate that one of the root-causes is the invalid response from scylla-server.
@@ -777,88 +779,86 @@ func (c *Client) longPollingTimeout(waitSeconds int) time.Duration {
 	return time.Second*time.Duration(waitSeconds) + c.config.Timeout
 }
 
-// ActiveRepairs returns a subset of hosts that are coordinators of a repair.
-func (c *Client) ActiveRepairs(ctx context.Context, hosts []string) ([]string, error) {
-	type hostError struct {
-		host   string
-		active bool
-		err    error
-	}
-	out := make(chan hostError, runtime.NumCPU()+1)
+// ActiveRepairs returns scheduled or running ScyllaTaskTypeRepair tasks.
+func (c *Client) ActiveRepairs(ctx context.Context, hosts []string) ([]*models.TaskStats, error) {
+	return c.activeScyllaTasks(ctx, ScyllaTaskModuleRepair, ScyllaTaskTypeRepair, hosts)
+}
 
-	for _, h := range hosts {
-		go func() {
-			a, err := c.hasActiveRepair(ctx, h)
-			out <- hostError{
-				host:   h,
-				active: a,
-				err:    errors.Wrapf(err, "host %s", h),
+func (c *Client) activeScyllaTasks(ctx context.Context, module ScyllaTaskModule, taskType ScyllaTaskType, hosts []string) ([]*models.TaskStats, error) {
+	if len(hosts) == 0 {
+		hosts = []string{""}
+	}
+	out := make([]*models.TaskStats, 0)
+	mu := sync.Mutex{}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(runtime.NumCPU())
+	for _, host := range hosts {
+		eg.Go(func() error {
+			tasks, err := c.ScyllaListTasks(egCtx, host, module)
+			if err != nil {
+				return errors.Wrapf(err, "%s: list repair module tasks", host)
 			}
-		}()
-	}
+			tasks = filterActiveScyllaTasks(tasks, taskType)
 
-	var (
-		active []string
-		errs   error
-	)
-	for range hosts {
-		v := <-out
-		if v.err != nil {
-			errs = multierr.Append(errs, v.err)
-		}
-		if v.active {
-			active = append(active, v.host)
-		}
-	}
-	return active, errs
-}
-
-func (c *Client) hasActiveRepair(ctx context.Context, host string) (bool, error) {
-	const wait = 50 * time.Millisecond
-	for range 10 {
-		resp, err := c.scyllaOps.StorageServiceActiveRepairGet(&operations.StorageServiceActiveRepairGetParams{
-			Context: forceHost(ctx, host),
+			mu.Lock()
+			out = append(out, tasks...)
+			mu.Unlock()
+			return nil
 		})
-		if err != nil {
-			return false, err
-		}
-		if len(resp.Payload) > 0 {
-			return true, nil
-		}
-		// wait before trying again
-		t := time.NewTimer(wait)
-		select {
-		case <-ctx.Done():
-			t.Stop()
-			return false, ctx.Err()
-		case <-t.C:
-		}
 	}
-	return false, nil
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
-// KillAllRepairs forces a termination of all repairs running on a host, the
-// operation is not retried to avoid side effects of a deferred kill.
+// KillAllRepairs forces a termination of all ScyllaTaskTypeRepair tasks.
+// It ignores abort errors, as they might mean that task finished naturally.
 func (c *Client) KillAllRepairs(ctx context.Context, hosts ...string) error {
-	ctx = noRetry(ctx)
+	return c.abortActiveScyllaTasks(ctx, ScyllaTaskModuleRepair, ScyllaTaskTypeRepair, hosts...)
+}
 
-	f := func(i int) error {
-		host := hosts[i]
-		_, err := c.scyllaOps.StorageServiceForceTerminateRepairPost(&operations.StorageServiceForceTerminateRepairPostParams{
-			Context: forceHost(ctx, host),
+func (c *Client) abortActiveScyllaTasks(ctx context.Context, module ScyllaTaskModule, taskType ScyllaTaskType, hosts ...string) error {
+	if len(hosts) == 0 {
+		hosts = []string{""}
+	}
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(runtime.NumCPU())
+	for _, host := range hosts {
+		eg.Go(func() error {
+			tasks, err := c.ScyllaListTasks(egCtx, host, module)
+			if err != nil {
+				return errors.Wrapf(err, "%s: list repair module tasks", host)
+			}
+			tasks = filterActiveScyllaTasks(tasks, taskType)
+
+			for _, task := range tasks {
+				if err := c.ScyllaAbortTask(egCtx, host, task.TaskID); err != nil {
+					c.client.logger.Error(egCtx, "Failed to abort task",
+						"host", host,
+						"task_id", task.TaskID,
+						"error", err,
+					)
+				}
+			}
+			return nil
 		})
-		return err
 	}
+	return eg.Wait()
+}
 
-	notify := func(i int, err error) {
-		host := hosts[i]
-		c.logger.Error(ctx, "Failed to terminate repair",
-			"host", host,
-			"error", err,
-		)
+func filterActiveScyllaTasks(tasks []*models.TaskStats, taskType ScyllaTaskType) []*models.TaskStats {
+	out := make([]*models.TaskStats, 0, len(tasks))
+	for _, task := range tasks {
+		if task == nil || ScyllaTaskType(task.Type) != taskType ||
+			ScyllaTaskState(task.State) == ScyllaTaskStateDone ||
+			ScyllaTaskState(task.State) == ScyllaTaskStateFailed {
+			continue
+		}
+		out = append(out, task)
 	}
-
-	return parallel.Run(len(hosts), parallel.NoLimit, f, notify)
+	return out
 }
 
 const snapshotTimeout = 30 * time.Minute

--- a/pkg/scyllaclient/client_scylla_test.go
+++ b/pkg/scyllaclient/client_scylla_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient/scyllaclienttest"
 	agentModels "github.com/scylladb/scylla-manager/v3/swagger/gen/agent/models"
+	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/models"
 )
 
 func TestClientClusterName(t *testing.T) {
@@ -291,8 +292,12 @@ func TestClientActiveRepairs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(v, []string{scyllaclienttest.TestHost}); diff != "" {
-		t.Fatal(v)
+	golden := []*models.TaskStats{
+		{Type: string(scyllaclient.ScyllaTaskTypeRepair), TaskID: "e91bc9fa-d14e-11ee-b5c8-0242ac120002", State: string(scyllaclient.ScyllaTaskStateCreated)},
+		{Type: string(scyllaclient.ScyllaTaskTypeRepair), TaskID: "ef4a7cb4-d14e-11ee-b5c8-0242ac120002", State: string(scyllaclient.ScyllaTaskStateRunning)},
+	}
+	if diff := cmp.Diff(v, golden); diff != "" {
+		t.Fatal(diff)
 	}
 }
 

--- a/pkg/scyllaclient/testdata/scylla_api/storage_service_active_repair.json
+++ b/pkg/scyllaclient/testdata/scylla_api/storage_service_active_repair.json
@@ -1,5 +1,22 @@
 [
-  1,
-  2,
-  3
+  {
+    "type": "repair",
+    "task_id": "e91bc9fa-d14e-11ee-b5c8-0242ac120002",
+    "state": "created"
+  },
+  {
+    "type": "repair",
+    "task_id": "ef4a7cb4-d14e-11ee-b5c8-0242ac120002",
+    "state": "running"
+  },
+  {
+    "type": "repair",
+    "task_id": "f33c9620-d14e-11ee-b5c8-0242ac120002",
+    "state": "done"
+  },
+  {
+    "type": "upload",
+    "task_id": "f87da416-d14e-11ee-b5c8-0242ac120002",
+    "state": "running"
+  }
 ]

--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -53,7 +53,6 @@ type generatorTools struct {
 type submitter[T, R any] interface {
 	Submit(task T)
 	Results() chan R
-	Close()
 }
 
 // jobType describes how worker should handle given repair job.
@@ -157,7 +156,6 @@ func (g *generator) Run(ctx context.Context) (err error) {
 	}
 
 	g.logger.Info(ctx, "Close generator")
-	g.submitter.Close() // Free workers waiting on next
 	return errors.Wrap(genErr, "see more errors in logs")
 }
 

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -138,12 +139,13 @@ const (
 )
 
 const (
-	repairAsyncEndpoint          = "/storage_service/repair_async"
-	repairStatusEndpoint         = "/storage_service/repair_status"
-	tabletRepairEndpoint         = "/storage_service/tablets/repair"
-	waitTaskEndpoint             = "/task_manager/wait_task"
-	forceTerminateRepairEndpoint = "/storage_service/force_terminate_repair"
-	tabletBalancingEndpoint      = "/storage_service/tablets/balancing"
+	repairAsyncEndpoint     = "/storage_service/repair_async"
+	repairStatusEndpoint    = "/storage_service/repair_status"
+	tabletRepairEndpoint    = "/storage_service/tablets/repair"
+	waitTaskEndpoint        = "/task_manager/wait_task"
+	tabletBalancingEndpoint = "/storage_service/tablets/balancing"
+	listModuleTasksEndpoint = "/task_manager/list_module_tasks"
+	abortTaskEndpoint       = "/task_manager/abort_task"
 )
 
 func isRepairAsyncReq(req *http.Request) bool {
@@ -170,8 +172,12 @@ func isRepairStatusReq(req *http.Request) bool {
 	return isRepairAsyncStatusReq(req) || isTabletRepairStatusReq(req)
 }
 
-func isForceTerminateRepairReq(req *http.Request) bool {
-	return strings.HasPrefix(req.URL.Path, forceTerminateRepairEndpoint) && req.Method == http.MethodPost
+func isListModuleTasksReq(req *http.Request, module scyllaclient.ScyllaTaskModule) bool {
+	return strings.HasPrefix(req.URL.Path, listModuleTasksEndpoint+"/"+string(module)) && req.Method == http.MethodGet
+}
+
+func isAbortTaskReq(req *http.Request) bool {
+	return strings.HasPrefix(req.URL.Path, abortTaskEndpoint) && req.Method == http.MethodPost
 }
 
 func isTabletBalancingReq(req *http.Request) bool {
@@ -606,16 +612,46 @@ func repairMockAndBlockInterceptor(t *testing.T, ctx context.Context, blockAfter
 
 func repairRunningInterceptor() (http.RoundTripper, chan struct{}) {
 	done := make(chan struct{})
+	closeDone := sync.OnceFunc(func() {
+		close(done)
+	})
 	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		if isRepairReq(req) {
-			select {
-			case <-done:
-			default:
-				close(done)
-			}
+			closeDone()
 		}
 		return nil, nil
 	}), done
+}
+
+func listModuleTasksMockInterceptor(t *testing.T, module scyllaclient.ScyllaTaskModule, taskType scyllaclient.ScyllaTaskType) http.RoundTripper {
+	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if !isListModuleTasksReq(req, module) {
+			return nil, nil
+		}
+
+		tasks := []*models.TaskStats{{
+			TaskID: uuid.MustRandom().String(),
+			Type:   string(taskType),
+			State:  string(scyllaclient.ScyllaTaskStateRunning),
+		}}
+		body, err := json.Marshal(tasks)
+		if err != nil {
+			t.Error(err)
+			return nil, err
+		}
+		resp := httpx.MakeResponse(req, http.StatusOK)
+		resp.Body = io.NopCloser(bytes.NewBuffer(body))
+		return resp, nil
+	})
+}
+
+func abortTaskMockInterceptor() http.RoundTripper {
+	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if !isAbortTaskReq(req) {
+			return nil, nil
+		}
+		return httpx.MakeResponse(req, http.StatusOK), nil
+	})
 }
 
 func repairReqAssertHostInterceptor(t *testing.T, host netip.Addr) http.RoundTripper {

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -342,22 +342,13 @@ func (s *Service) Repair(ctx context.Context, clusterID, taskID, runID uuid.UUID
 	defer cancel()
 
 	// Create worker pool
-	workers := workerpool.New[*worker, job, jobResult](gracefulCtx, func(_ context.Context, i int) *worker {
-		return &worker{
-			config:     s.config,
-			target:     target,
-			client:     client,
-			apiSupport: p.apiSupport,
-			stopTrying: make(map[string]struct{}),
-			progress:   pm,
-			logger:     s.logger.Named(fmt.Sprintf("worker %d", i)),
-		}
-	}, chanSize)
+	workers, workersCleanup := s.newWorkerPool(gracefulCtx, target, client, p.apiSupport, pm)
+	defer workersCleanup()
 
 	// Give intensity handler the ability to set pool size
-	ih, cleanup := s.newIntensityHandler(ctx, clusterID, taskID, runID,
+	ih, ihCleanup := s.newIntensityHandler(ctx, clusterID, taskID, runID,
 		p.MaxHostIntensity, p.MaxParallel, workers)
-	defer cleanup()
+	defer ihCleanup()
 
 	// Set controlled parameters
 	ih.SetParallel(ctx, run.Parallel)
@@ -395,10 +386,24 @@ func (s *Service) Repair(ctx context.Context, clusterID, taskID, runID uuid.UUID
 		return errors.Wrap(err, "ensure no active repairs")
 	}
 
-	if err = gen.Run(gracefulCtx); (err != nil && target.FailFast) || ctx.Err() != nil {
+	// Start generator which in turn feeds tasks to worker pool.
+	err = gen.Run(gracefulCtx)
+	// When generator returned, either all repair jobs has already finished,
+	// or the graceful ctx was canceled. Either way, we no longer need the
+	// worker pool, so it should be cleaned up before we potentially try
+	// to kill any ongoing repair jobs.
+	workersCleanup()
+	// When both generator and worker pool has returned, graceful ctx
+	// is no longer needed and can be cleaned up.
+	close(done)
+	// When worker pool has returned, no new repair jobs are going
+	// to be scheduled, so the ongoing repair jobs can be cleaned
+	// up if needed. This aims mostly at vnode repair jobs, as tablet
+	// repair tasks should be aborted on ctx err
+	// via the task manager (scylla service).
+	if (err != nil && target.FailFast) || ctx.Err() != nil {
 		s.killAllRepairs(ctx, client, p.Hosts)
 	}
-	close(done)
 
 	// Check if repair has ended successfully
 	if err == nil && ctx.Err() == nil {
@@ -469,6 +474,44 @@ func (s *Service) killAllRepairs(ctx context.Context, client *scyllaclient.Clien
 	if err := client.KillAllRepairs(killCtx, hosts...); err != nil {
 		s.logger.Error(killCtx, "Failed to kill repairs", "hosts", hosts, "error", err)
 	}
+}
+
+// newWorkerPool initialized workers used for performing repair jobs.
+// Returned cleanup function is idempotent and ensures that the worker
+// pool is closed and tries to wait for all workers to exit the pool.
+// In the rare case where workers don't exit the pool even after a short
+// time after the pool was closed and their context was canceled,
+// it logs an error and proceeds without making the caller hang.
+func (s *Service) newWorkerPool(ctx context.Context, target Target, client *scyllaclient.Client, apiSupport apiSupport, pm ProgressManager,
+) (wp *workerpool.Pool[*worker, job, jobResult], cleanup func()) {
+	workers := workerpool.New[*worker, job, jobResult](ctx, func(_ context.Context, i int) *worker {
+		return &worker{
+			config:     s.config,
+			target:     target,
+			client:     client,
+			apiSupport: apiSupport,
+			stopTrying: make(map[string]struct{}),
+			progress:   pm,
+			logger:     s.logger.Named(fmt.Sprintf("worker %d", i)),
+		}
+	}, chanSize)
+	return workers, sync.OnceFunc(func() {
+		workers.Close()
+		done := make(chan struct{})
+		go func() {
+			workers.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-ctx.Done():
+			select {
+			case <-done:
+			case <-time.After(min(s.config.GracefulStopTimeout, 5*time.Second)):
+				s.logger.Error(ctx, "Failed to wait for worker pool cleanup even after graceful ctx cancel")
+			}
+		}
+	})
 }
 
 func (s *Service) newIntensityHandler(ctx context.Context, clusterID, taskID, runID uuid.UUID,

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -455,6 +455,9 @@ func (s *Service) ensureNoActiveRepairs(ctx context.Context, client *scyllaclien
 func (s *Service) killAllRepairs(ctx context.Context, client *scyllaclient.Client, hosts []string) {
 	killCtx := log.CopyTraceID(context.Background(), ctx)
 	killCtx = scyllaclient.Interactive(killCtx)
+	if err := client.KillAllTabletRepairs(killCtx); err != nil {
+		s.logger.Error(killCtx, "Failed to kill tablet repairs", "error", err)
+	}
 	if err := client.KillAllRepairs(killCtx, hosts...); err != nil {
 		s.logger.Error(killCtx, "Failed to kill repairs", "hosts", hosts, "error", err)
 	}

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -33,7 +33,6 @@ import (
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/models"
 	"go.uber.org/atomic"
 	"go.uber.org/multierr"
-	"golang.org/x/sync/errgroup"
 )
 
 // Service orchestrates cluster repairs.
@@ -431,43 +430,24 @@ func (s *Service) Repair(ctx context.Context, clusterID, taskID, runID uuid.UUID
 // To check that, SM uses newer scylla API providing information
 // about listed repair tasks keyspace scope.
 func (s *Service) ensureNoActiveRepairs(ctx context.Context, client *scyllaclient.Client, p *plan, ksRep scyllaclient.KeyspaceReplication) error {
-	if ksRep != scyllaclient.ReplicationVnode {
-		if active, err := client.ActiveRepairs(ctx, p.Hosts); err != nil {
-			s.logger.Error(ctx, "Active repair check failed", "error", err)
-		} else if len(active) > 0 {
-			taskIDs := slices2.Map(active, func(t *models.TaskStats) string {
-				return t.TaskID
-			})
-			return errors.Errorf("cluster is currently being repaired by tasks: %s", strings.Join(taskIDs, ", "))
-		}
+	tasks, err := client.ActiveRepairs(ctx, p.Hosts)
+	if err != nil {
+		s.logger.Error(ctx, "Active repair check failed, skipping", "error", err)
 		return nil
 	}
 
-	rd := scyllaclient.NewRingDescriber(ctx, client)
-	eg, egCtx := errgroup.WithContext(ctx)
-	for _, host := range p.Hosts {
-		eg.Go(func() error {
-			tasks, err := client.ScyllaListTasks(egCtx, host, scyllaclient.ScyllaTaskModuleRepair)
-			if err != nil {
-				s.logger.Error(ctx, "Active repair check failed, skipping", "host", host, "error", err)
-				return nil
-			}
-			for _, task := range tasks {
-				if task == nil || scyllaclient.ScyllaTaskType(task.Type) != scyllaclient.ScyllaTaskTypeRepair ||
-					scyllaclient.ScyllaTaskState(task.State) == scyllaclient.ScyllaTaskStateDone ||
-					scyllaclient.ScyllaTaskState(task.State) == scyllaclient.ScyllaTaskStateFailed {
-					continue
-				}
-				if !rd.IsTabletKeyspace(task.Keyspace) {
-					return errors.Errorf("vnode keyspace %q is already repaired with task %v on host %s", task.Keyspace, task.TaskID, host)
-				}
-			}
-			return nil
+	if ksRep != scyllaclient.ReplicationVnode && len(tasks) > 0 {
+		taskIDs := slices2.Map(tasks, func(t *models.TaskStats) string {
+			return t.TaskID
 		})
+		return errors.Errorf("cluster is currently being repaired by tasks: %s", strings.Join(taskIDs, ", "))
 	}
 
-	if err := eg.Wait(); err != nil {
-		return errors.Wrap(err, "check active repairs")
+	rd := scyllaclient.NewRingDescriber(ctx, client)
+	for _, task := range tasks {
+		if !rd.IsTabletKeyspace(task.Keyspace) {
+			return errors.Errorf("vnode keyspace %q is already repaired with task %v", task.Keyspace, task.TaskID)
+		}
 	}
 	return nil
 }

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -30,6 +30,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/workerpool"
 	slices2 "github.com/scylladb/scylla-manager/v3/pkg/util2/slices"
+	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/models"
 	"go.uber.org/atomic"
 	"go.uber.org/multierr"
 	"golang.org/x/sync/errgroup"
@@ -434,7 +435,10 @@ func (s *Service) ensureNoActiveRepairs(ctx context.Context, client *scyllaclien
 		if active, err := client.ActiveRepairs(ctx, p.Hosts); err != nil {
 			s.logger.Error(ctx, "Active repair check failed", "error", err)
 		} else if len(active) > 0 {
-			return errors.Errorf("%s are repairing", strings.Join(active, ", "))
+			taskIDs := slices2.Map(active, func(t *models.TaskStats) string {
+				return t.TaskID
+			})
+			return errors.Errorf("cluster is currently being repaired by tasks: %s", strings.Join(taskIDs, ", "))
 		}
 		return nil
 	}

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1608,12 +1608,8 @@ func TestServiceRepairIntegration(t *testing.T) {
 
 			h := newRepairTestHelper(t, session, defaultConfig())
 			Print("When: run repair")
-			var killRepairCalled int32
 			i, running := repairRunningInterceptor()
-			h.Hrt.SetInterceptor(combineInterceptors(
-				countInterceptor(&killRepairCalled, isForceTerminateRepairReq),
-				i,
-			))
+			h.Hrt.SetInterceptor(i)
 			h.runRepair(ctx, props)
 
 			Print("When: repair is running")
@@ -1623,9 +1619,13 @@ func TestServiceRepairIntegration(t *testing.T) {
 			cancel()
 			h.assertError(shortWait)
 
-			Print("Then: repairs on all hosts are killed")
-			if int(killRepairCalled) != len(ManagedClusterHosts()) {
-				t.Errorf("not all repairs were killed")
+			Print("Then: there are no active repairs")
+			active, err := h.Client.ActiveRepairs(t.Context(), ManagedClusterHosts())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(active) > 0 {
+				t.Fatalf("Expected no active repairs after repair task was paused, found %d", len(active))
 			}
 		})
 
@@ -1637,19 +1637,41 @@ func TestServiceRepairIntegration(t *testing.T) {
 			props["fail_fast"] = true
 
 			Print("When: run repair")
-			var killRepairCalled int32
+			// Combination of those interceptors allows us to wait for moment
+			// of repair execution after the active repairs have already been
+			// checked by the actual repairs haven't started yet.
+			i, running := repairRunningInterceptor()
+			holdCtx, holdCancel := context.WithCancel(ctx)
+			h.Hrt.SetInterceptor(combineInterceptors(i, repairMockAndBlockInterceptor(t, holdCtx, 0)))
+			h.runRepair(ctx, props)
+
+			Print("When: repair is running")
+			chanClosedWithin(t, running, shortWait)
+
+			var listRepairCalled, abortRepairCalled int32
 			h.Hrt.SetInterceptor(combineInterceptors(
-				countInterceptor(&killRepairCalled, isForceTerminateRepairReq),
+				// Count interceptors
+				countInterceptor(&listRepairCalled, func(req *http.Request) bool {
+					return isListModuleTasksReq(req, scyllaclient.ScyllaTaskModuleRepair)
+				}),
+				countInterceptor(&abortRepairCalled, isAbortTaskReq),
+				// Mock list/kill active repairs interceptors
+				listModuleTasksMockInterceptor(t, scyllaclient.ScyllaTaskModuleRepair, scyllaclient.ScyllaTaskTypeRepair),
+				abortTaskMockInterceptor(),
+				// Mock repair failure interceptor
 				repairMockInterceptor(t, repairStatusFailed),
 			))
-			h.runRepair(ctx, props)
+			holdCancel()
 
 			Print("Then: repair finish with error")
 			h.assertError(longWait)
 
-			Print("Then: repairs on all hosts are killed")
-			if int(killRepairCalled) != len(ManagedClusterHosts()) {
-				t.Errorf("not all repairs were killed")
+			Print("Then: active repairs were listed and killed")
+			if int(listRepairCalled) != len(ManagedClusterHosts()) {
+				t.Errorf("repairs were listed %d times, expected %d", listRepairCalled, len(ManagedClusterHosts()))
+			}
+			if int(abortRepairCalled) != len(ManagedClusterHosts()) {
+				t.Errorf("repairs were killed %d times, expected %d", abortRepairCalled, len(ManagedClusterHosts())+1)
 			}
 		})
 	})

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1620,7 +1620,14 @@ func TestServiceRepairIntegration(t *testing.T) {
 			h.assertError(shortWait)
 
 			Print("Then: there are no active repairs")
-			active, err := h.Client.ActiveRepairs(t.Context(), ManagedClusterHosts())
+			active, err := h.Client.ActiveTabletRepairs(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(active) > 0 {
+				t.Fatalf("Expected no active tablet repairs after repair task was paused, found %d", len(active))
+			}
+			active, err = h.Client.ActiveRepairs(t.Context(), ManagedClusterHosts())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1648,15 +1655,19 @@ func TestServiceRepairIntegration(t *testing.T) {
 			Print("When: repair is running")
 			chanClosedWithin(t, running, shortWait)
 
-			var listRepairCalled, abortRepairCalled int32
+			var listRepairCalled, listTabletRepairCalled, abortRepairCalled int32
 			h.Hrt.SetInterceptor(combineInterceptors(
 				// Count interceptors
 				countInterceptor(&listRepairCalled, func(req *http.Request) bool {
 					return isListModuleTasksReq(req, scyllaclient.ScyllaTaskModuleRepair)
 				}),
+				countInterceptor(&listTabletRepairCalled, func(req *http.Request) bool {
+					return isListModuleTasksReq(req, scyllaclient.ScyllaTaskModuleTablets)
+				}),
 				countInterceptor(&abortRepairCalled, isAbortTaskReq),
 				// Mock list/kill active repairs interceptors
 				listModuleTasksMockInterceptor(t, scyllaclient.ScyllaTaskModuleRepair, scyllaclient.ScyllaTaskTypeRepair),
+				listModuleTasksMockInterceptor(t, scyllaclient.ScyllaTaskModuleTablets, scyllaclient.ScyllaTaskTypeUserRepair),
 				abortTaskMockInterceptor(),
 				// Mock repair failure interceptor
 				repairMockInterceptor(t, repairStatusFailed),
@@ -1667,10 +1678,13 @@ func TestServiceRepairIntegration(t *testing.T) {
 			h.assertError(longWait)
 
 			Print("Then: active repairs were listed and killed")
+			if int(listTabletRepairCalled) != 1 {
+				t.Errorf("tablet repairs were listed %d times, expected 1", listTabletRepairCalled)
+			}
 			if int(listRepairCalled) != len(ManagedClusterHosts()) {
 				t.Errorf("repairs were listed %d times, expected %d", listRepairCalled, len(ManagedClusterHosts()))
 			}
-			if int(abortRepairCalled) != len(ManagedClusterHosts()) {
+			if int(abortRepairCalled) != len(ManagedClusterHosts())+1 {
 				t.Errorf("repairs were killed %d times, expected %d", abortRepairCalled, len(ManagedClusterHosts())+1)
 			}
 		})

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1165,6 +1165,22 @@ func TestServiceRepairIntegration(t *testing.T) {
 
 		Print("Then: status is StatusStopped")
 		h.assertStopped(shortWait)
+
+		Print("And: there are no active repairs")
+		active, err := h.Client.ActiveTabletRepairs(t.Context())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(active) > 0 {
+			t.Fatalf("Expected no active tablet repairs after repair task was paused, found %d", len(active))
+		}
+		active, err = h.Client.ActiveRepairs(t.Context(), ManagedClusterHosts())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(active) > 0 {
+			t.Fatalf("Expected no active repairs after repair task was paused, found %d", len(active))
+		}
 	})
 
 	t.Run("repair restart", func(t *testing.T) {
@@ -1191,7 +1207,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		Print("And: run repair")
 		ctx, cancel = context.WithCancel(context.Background())
 		defer cancel()
-		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, ctx, 0))
 		h.runRepair(ctx, multipleUnits(nil))
 
 		Print("Then: repair is running")
@@ -1267,7 +1283,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		Print("And: resume repair")
 		ctx = context.Background()
 		holdCtx, holdCancel := context.WithCancel(ctx)
-		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 1))
+		h.Hrt.SetInterceptor(repairMockAndBlockInterceptor(t, holdCtx, 0))
 		h.runRepair(ctx, props)
 
 		Print("Then: resumed repair is running")

--- a/pkg/service/repair/tablet/worker.go
+++ b/pkg/service/repair/tablet/worker.go
@@ -50,7 +50,9 @@ func (w *worker) repairAll(ctx context.Context, target Target) error {
 	// ends with an error. On the other hand, this is just best effort, because we can't
 	// ensure that new scylla tablet repair tasks won't be created in the meantime or that
 	// the task that we were trying to abort has just finished on its own.
-	w.abortAllRepairTasks(ctx)
+	if err := w.client.KillAllTabletRepairs(ctx); err != nil {
+		w.logger.Error(ctx, "Failed to abort tablet repair tasks", "error", err)
+	}
 
 	for ks, tabs := range target.KsTabs {
 		for _, tab := range tabs {
@@ -69,22 +71,6 @@ func (w *worker) init(ctx context.Context, target Target) {
 			w.logger.Info(ctx, "Plan to repair table", "keyspace", ks, "table", tab)
 			pr := newRunProgress(w.clusterID, w.taskID, w.runID, ks, tab)
 			w.upsertTableProgress(ctx, pr)
-		}
-	}
-}
-
-func (w *worker) abortAllRepairTasks(ctx context.Context) {
-	tasks, err := w.client.ScyllaListTasks(ctx, "", scyllaclient.ScyllaTaskModuleTablets)
-	if err != nil {
-		w.logger.Error(ctx, "Failed to list scylla tablet tasks", "error", err)
-		return
-	}
-	for _, t := range tasks {
-		if t == nil {
-			continue
-		}
-		if scyllaclient.ScyllaTaskType(t.Type) == scyllaclient.ScyllaTaskTypeUserRepair {
-			w.abortRepairTask(ctx, t.TaskID)
 		}
 	}
 }


### PR DESCRIPTION
This PR targets repair test flakiness related to leaking repair jobs across different subtests.
The two main changes are:
- fixing repair worker pool cleanup
- when killing all repairs, abort cluster wide tablet repair tasks first

I rerun CI for this PR multiple times and no more flakes were observed.

This PR additionally performs slight refactor of code related to listing and killing active repairs.
Since all currently supported scylla versions support task manager (scylla svc), we no longer
need to list and kill active repairs with the legacy endpoints. Instead, we can simplify the 
implementation and use just the task manager API, which supports both regular node level
repairs (both vnode and tablet) and the cluster level tablet repairs. 

Fixes https://scylladb.atlassian.net/browse/CLOUD-1969