### PR TITLE
fix(repair): fix per-table duration inflation after run resume

### DIFF
--- a/pkg/service/repair/model.go
+++ b/pkg/service/repair/model.go
@@ -126,31 +126,18 @@ type RunProgress struct {
 	Success     int64
 	Error       int64
 
-	StartedAt         *time.Time
-	CompletedAt       *time.Time
+	StartedAt   *time.Time
+	CompletedAt *time.Time
+	// Duration is a legacy field kept for DB backward compatibility.
+	// It is no longer used for progress calculation - wall-clock time
+	// from StartedAt/CompletedAt is used instead.
 	Duration          time.Duration
 	DurationStartedAt *time.Time
-	runningJobCount   int
 }
 
 // Completed returns true if all token rages are processed.
 func (rp *RunProgress) Completed() bool {
 	return rp.TokenRanges == rp.Success+rp.Error
-}
-
-// CurrentDuration returns duration which includes elapsed time for uncompleted jobs.
-// now parameter is used as reference point.
-func (rp *RunProgress) CurrentDuration(now time.Time) time.Duration {
-	if isTimeSet(rp.StartedAt) && isTimeSet(rp.DurationStartedAt) {
-		return rp.Duration + now.Sub(*rp.DurationStartedAt)
-	}
-	return rp.Duration
-}
-
-// AddDuration resets running jobs timer and sums up running duration stats.
-func (rp *RunProgress) AddDuration(end time.Time) {
-	rp.Duration += end.Sub(*rp.DurationStartedAt)
-	rp.DurationStartedAt = nil
 }
 
 // RunState represents state of the repair.

--- a/pkg/service/repair/progress.go
+++ b/pkg/service/repair/progress.go
@@ -181,7 +181,10 @@ func (pm *dbProgressManager) initProgress(plan *plan) error {
 			}
 			cp := *rp
 			cp.RunID = pm.run.ID
+			cp.StartedAt = nil         // Reset so duration reflects current run only
+			cp.CompletedAt = nil       // Will be set when completed in this run
 			cp.DurationStartedAt = nil // Reset duration counter from previous run
+			cp.Duration = 0            // Don't inherit duration from previous runs
 			cp.Error = 0               // Failed ranges will be retried
 			pm.progress[pk] = &cp
 		})
@@ -279,12 +282,8 @@ func (pm *dbProgressManager) OnJobStart(ctx context.Context, j job) {
 		pm.mu.Lock()
 		rp := pm.progress[pk]
 
-		rp.runningJobCount++
 		if rp.StartedAt == nil {
 			rp.StartedAt = &start
-		}
-		if rp.DurationStartedAt == nil {
-			rp.DurationStartedAt = &start
 		}
 
 		q.BindStruct(rp)
@@ -319,11 +318,6 @@ func (pm *dbProgressManager) onJobEndProgress(ctx context.Context, result jobRes
 			rp.Success += int64(len(result.ranges))
 		} else {
 			rp.Error += int64(len(result.ranges))
-		}
-
-		rp.runningJobCount--
-		if rp.runningJobCount == 0 {
-			rp.AddDuration(end)
 		}
 
 		if rp.Completed() {
@@ -438,7 +432,7 @@ func (pm *dbProgressManager) AggregateProgress() (Progress, error) {
 			}
 		}
 		host.Tables = append(host.Tables, tp)
-		host.progress = mergeProgress(host.progress, prog)
+		host.progress = mergeProgress(host.progress, prog, now)
 		perHost[rp.Host] = host
 
 		tk := tableKey{keyspace: rp.Keyspace, table: rp.Table}
@@ -452,7 +446,7 @@ func (pm *dbProgressManager) AggregateProgress() (Progress, error) {
 				Table:    rp.Table,
 			}
 		}
-		tab.progress = mergeProgress(tab.progress, prog)
+		tab.progress = mergeProgress(tab.progress, prog, now)
 		perTable[tk] = tab
 	})
 	if err != nil {
@@ -473,7 +467,7 @@ func (pm *dbProgressManager) AggregateProgress() (Progress, error) {
 			return t1.Keyspace+t1.Table < t2.Keyspace+t2.Table
 		})
 
-		p.progress = mergeProgress(p.progress, hp.progress)
+		p.progress = mergeProgress(p.progress, hp.progress, now)
 		p.Hosts = append(p.Hosts, hp)
 	}
 	sort.Slice(p.Hosts, func(i, j int) bool {
@@ -481,7 +475,6 @@ func (pm *dbProgressManager) AggregateProgress() (Progress, error) {
 	})
 
 	for _, tp := range perTable {
-		tp.Duration = recalculateDuration(tp.progress, now)
 		p.Tables = append(p.Tables, tp)
 	}
 	sort.Slice(p.Tables, func(i, j int) bool {
@@ -493,7 +486,6 @@ func (pm *dbProgressManager) AggregateProgress() (Progress, error) {
 	if p.CompletedAt == &ancient {
 		p.CompletedAt = nil
 	}
-	p.Duration = recalculateDuration(p.progress, now)
 
 	if p.TokenRanges == 0 {
 		p.SuccessPercentage = -1
@@ -550,25 +542,27 @@ func recalculateDuration(pr progress, now time.Time) int64 {
 }
 
 func extractProgress(rp *RunProgress, now time.Time) progress {
-	return progress{
+	pr := progress{
 		Success:     rp.Success,
 		Error:       rp.Error,
 		TokenRanges: rp.TokenRanges,
 		StartedAt:   rp.StartedAt,
 		CompletedAt: rp.CompletedAt,
-		Duration:    rp.CurrentDuration(now).Milliseconds(),
 	}
+	pr.Duration = recalculateDuration(pr, now)
+	return pr
 }
 
-func mergeProgress(pr1, pr2 progress) progress {
-	return progress{
+func mergeProgress(pr1, pr2 progress, now time.Time) progress {
+	pr := progress{
 		TokenRanges: pr1.TokenRanges + pr2.TokenRanges,
 		Success:     pr1.Success + pr2.Success,
 		Error:       pr1.Error + pr2.Error,
 		StartedAt:   chooseStartedAt(pr1.StartedAt, pr2.StartedAt),
 		CompletedAt: chooseCompletedAt(pr1.CompletedAt, pr2.CompletedAt),
-		Duration:    pr1.Duration + pr2.Duration,
 	}
+	pr.Duration = recalculateDuration(pr, now)
+	return pr
 }
 
 // chooseStartedAt returns earlier time or nil if each is unset.

--- a/pkg/service/repair/progress.go
+++ b/pkg/service/repair/progress.go
@@ -157,6 +157,10 @@ func (pm *dbProgressManager) initProgress(plan *plan) error {
 		for _, tp := range kp.Tables {
 			for _, h := range plan.Hosts {
 				pk := newHostKsTable(h, kp.Keyspace, tp.Table)
+				// Skip progress entries for tables with no ranges to repair.
+				if _, ok := plan.Stats[pk]; !ok {
+					continue
+				}
 				pm.progress[newHostKsTable(h, kp.Keyspace, tp.Table)] = &RunProgress{
 					ClusterID:   pm.run.ClusterID,
 					TaskID:      pm.run.TaskID,
@@ -177,6 +181,10 @@ func (pm *dbProgressManager) initProgress(plan *plan) error {
 		err := pm.ForEachPrevRunProgress(func(rp *RunProgress) {
 			pk := newHostKsTable(rp.Host, rp.Keyspace, rp.Table)
 			if _, ok := pm.progress[pk]; !ok {
+				return
+			}
+			// Skip progress entries for tables with no ranges to repair.
+			if rp.TokenRanges == 0 {
 				return
 			}
 			cp := *rp
@@ -407,6 +415,15 @@ func (pm *dbProgressManager) AggregateProgress() (Progress, error) {
 	)
 
 	err := pm.ForEachRunProgress(func(rp *RunProgress) {
+		// Skip rows with no work from progress merging.
+		// Hosts with TokenRanges == 0 have nil StartedAt/CompletedAt,
+		// which would incorrectly make the merged CompletedAt nil
+		// (interpreted as "still in progress"), causing ever-growing
+		// duration for stopped/completed runs.
+		if rp.TokenRanges == 0 {
+			return
+		}
+
 		tableSize[tableKey{
 			keyspace: rp.Keyspace,
 			table:    rp.Table,

--- a/pkg/service/repair/progress_integration_test.go
+++ b/pkg/service/repair/progress_integration_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 //go:build all || integration
 
@@ -128,26 +128,19 @@ func TestProgressManagerIntegration(t *testing.T) {
 		pm.OnJobStart(ctx, j)
 		Print("Then: run progress is updated with starting times")
 		goldenProgress[0].StartedAt = &start
-		goldenProgress[0].DurationStartedAt = &start
 		goldenProgress[1].StartedAt = &start
-		goldenProgress[1].DurationStartedAt = &start
 
 		updatedProgress = getProgress(run, session)
 		if diff := cmp.Diff(goldenProgress, updatedProgress, opts); diff != "" {
 			t.Fatal(diff)
 		}
 
-		end := timeutc.Now()
 		Print("When: OnJobEnd is called on progress manager")
 		pm.OnJobEnd(ctx, jobResult{job: j})
 
-		Print("Then: progress is updated with success and duration")
+		Print("Then: progress is updated with success")
 		goldenProgress[0].Success = 1
 		goldenProgress[1].Success = 1
-		goldenProgress[0].Duration = end.Sub(start)
-		goldenProgress[1].Duration = end.Sub(start)
-		goldenProgress[0].DurationStartedAt = nil
-		goldenProgress[1].DurationStartedAt = nil
 		updatedProgress = getProgress(run, session)
 		if diff := cmp.Diff(goldenProgress, updatedProgress, opts); diff != "" {
 			t.Fatal(diff)
@@ -323,8 +316,335 @@ func TestAggregateProgressIntegration(t *testing.T) {
 	}
 }
 
+// TestRepairProgressDurationIntegration verifies that repair progress duration:
+// a) Uses wall-clock time (CompletedAt - StartedAt) at every level (host+table, host, table, overall)
+// b) Does not inherit duration from previous runs (fully/partially completed entries)
+// c) Ignores legacy Duration/DurationStartedAt fields stored in DB
+func TestRepairProgressDurationIntegration(t *testing.T) {
+	h1 := netip.MustParseAddr("192.168.100.11")
+	h2 := netip.MustParseAddr("192.168.100.12")
+
+	t.Run("wall-clock duration at all levels", func(t *testing.T) {
+		session := CreateScyllaManagerDBSession(t)
+		run := &Run{
+			ClusterID: uuid.NewTime(),
+			TaskID:    uuid.NewTime(),
+			ID:        uuid.NewTime(),
+			StartTime: timeutc.Now(),
+		}
+
+		// Setup: insert RunProgress entries with known timestamps.
+		// h1/k1/t1: 10:00:00 → 10:00:30 (30s)
+		// h1/k1/t2: 10:00:10 → 10:00:40 (30s)
+		// h2/k1/t1: 10:00:05 → 10:00:35 (30s)
+		base := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+		ts := func(sec int) *time.Time {
+			t := base.Add(time.Duration(sec) * time.Second)
+			return &t
+		}
+
+		rps := []*RunProgress{
+			{
+				ClusterID: run.ClusterID, TaskID: run.TaskID, RunID: run.ID,
+				Host: h1.String(), Keyspace: "k1", Table: "t1",
+				Size: 10, TokenRanges: 5, Success: 5,
+				StartedAt: ts(0), CompletedAt: ts(30),
+			},
+			{
+				ClusterID: run.ClusterID, TaskID: run.TaskID, RunID: run.ID,
+				Host: h1.String(), Keyspace: "k1", Table: "t2",
+				Size: 6, TokenRanges: 3, Success: 3,
+				StartedAt: ts(10), CompletedAt: ts(40),
+			},
+			{
+				ClusterID: run.ClusterID, TaskID: run.TaskID, RunID: run.ID,
+				Host: h2.String(), Keyspace: "k1", Table: "t1",
+				Size: 10, TokenRanges: 5, Success: 5,
+				StartedAt: ts(5), CompletedAt: ts(35),
+			},
+		}
+		saveProgress(rps, session)
+
+		pm := NewDBProgressManager(run, session, metrics.NewRepairMetrics(), log.NewDevelopment())
+		p, err := pm.AggregateProgress()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Host+Table level: each entry uses its own wall-clock
+		findHostTable := func(host, ks, tbl string) *TableProgress {
+			for i := range p.Hosts {
+				if p.Hosts[i].Host == host {
+					for j := range p.Hosts[i].Tables {
+						tp := &p.Hosts[i].Tables[j]
+						if tp.Keyspace == ks && tp.Table == tbl {
+							return tp
+						}
+					}
+				}
+			}
+			return nil
+		}
+
+		if d := findHostTable(h1.String(), "k1", "t1").Duration; d != 30000 {
+			t.Errorf("h1/k1/t1 duration: got %d, want 30000", d)
+		}
+		if d := findHostTable(h1.String(), "k1", "t2").Duration; d != 30000 {
+			t.Errorf("h1/k1/t2 duration: got %d, want 30000", d)
+		}
+		if d := findHostTable(h2.String(), "k1", "t1").Duration; d != 30000 {
+			t.Errorf("h2/k1/t1 duration: got %d, want 30000", d)
+		}
+
+		// Host level: wall-clock from min(StartedAt) to max(CompletedAt)
+		findHost := func(host string) *HostProgress {
+			for i := range p.Hosts {
+				if p.Hosts[i].Host == host {
+					return &p.Hosts[i]
+				}
+			}
+			return nil
+		}
+
+		// h1: min(0,10)=0 → max(30,40)=40 → 40s
+		if d := findHost(h1.String()).Duration; d != 40000 {
+			t.Errorf("h1 duration: got %d, want 40000", d)
+		}
+		// h2: 5 → 35 → 30s
+		if d := findHost(h2.String()).Duration; d != 30000 {
+			t.Errorf("h2 duration: got %d, want 30000", d)
+		}
+
+		// Table level: wall-clock from min(StartedAt) to max(CompletedAt) across hosts
+		findTable := func(ks, tbl string) *TableProgress {
+			for i := range p.Tables {
+				if p.Tables[i].Keyspace == ks && p.Tables[i].Table == tbl {
+					return &p.Tables[i]
+				}
+			}
+			return nil
+		}
+
+		// k1.t1: min(0,5)=0 → max(30,35)=35 → 35s
+		if d := findTable("k1", "t1").Duration; d != 35000 {
+			t.Errorf("k1/t1 duration: got %d, want 35000", d)
+		}
+		// k1.t2: 10 → 40 → 30s
+		if d := findTable("k1", "t2").Duration; d != 30000 {
+			t.Errorf("k1/t2 duration: got %d, want 30000", d)
+		}
+
+		// Overall: min(0,5,10)=0 → max(30,35,40)=40 → 40s
+		if d := p.Duration; d != 40000 {
+			t.Errorf("overall duration: got %d, want 40000", d)
+		}
+	})
+
+	t.Run("resumed run does not inherit duration from previous run", func(t *testing.T) {
+		session := CreateScyllaManagerDBSession(t)
+
+		prevRun := &Run{
+			ClusterID: uuid.NewTime(),
+			TaskID:    uuid.NewTime(),
+			ID:        uuid.NewTime(),
+			StartTime: timeutc.Now(),
+		}
+		run := &Run{
+			ClusterID: prevRun.ClusterID,
+			TaskID:    prevRun.TaskID,
+			ID:        uuid.NewTime(),
+			StartTime: timeutc.Now(),
+		}
+
+		// Previous run progress:
+		// h1/k1/t1: fully completed
+		// h1/k1/t2: partially completed (1 of 2 ranges done)
+		// h2/k1/t1: fully completed
+		base := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+		prevStart := base
+		prevEnd := base.Add(30 * time.Second)
+
+		if err := table.RepairRun.InsertQuery(session).BindStruct(prevRun).Exec(); err != nil {
+			t.Fatal(err)
+		}
+		prevProgress := []*RunProgress{
+			{
+				ClusterID: prevRun.ClusterID, TaskID: prevRun.TaskID, RunID: prevRun.ID,
+				Host: h1.String(), Keyspace: "k1", Table: "t1",
+				Size: 10, TokenRanges: 5, Success: 5,
+				StartedAt: &prevStart, CompletedAt: &prevEnd,
+			},
+			{
+				ClusterID: prevRun.ClusterID, TaskID: prevRun.TaskID, RunID: prevRun.ID,
+				Host: h1.String(), Keyspace: "k1", Table: "t2",
+				Size: 6, TokenRanges: 2, Success: 1,
+				StartedAt: &prevStart,
+			},
+			{
+				ClusterID: prevRun.ClusterID, TaskID: prevRun.TaskID, RunID: prevRun.ID,
+				Host: h2.String(), Keyspace: "k1", Table: "t1",
+				Size: 10, TokenRanges: 5, Success: 5,
+				StartedAt: &prevStart, CompletedAt: &prevEnd,
+			},
+		}
+		saveProgress(prevProgress, session)
+
+		// Save previous run state (h1/k1/t1 and h2/k1/t1 fully done)
+		for _, rs := range []*RunState{
+			{
+				ClusterID: prevRun.ClusterID, TaskID: prevRun.TaskID, RunID: prevRun.ID,
+				Keyspace: "k1", Table: "t1",
+				SuccessRanges: []scyllaclient.TokenRange{{StartToken: 0, EndToken: 100}},
+			},
+			{
+				ClusterID: prevRun.ClusterID, TaskID: prevRun.TaskID, RunID: prevRun.ID,
+				Keyspace: "k1", Table: "t2",
+				SuccessRanges: []scyllaclient.TokenRange{{StartToken: 0, EndToken: 50}},
+			},
+		} {
+			if err := table.RepairRunState.InsertQuery(session).BindStruct(rs).ExecRelease(); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Init current run with plan covering same tables
+		p := &plan{
+			Hosts: []string{h1.String(), h2.String()},
+			Stats: map[scyllaclient.HostKeyspaceTable]tableStats{
+				newHostKsTable(h1.String(), "k1", "t1"): {Size: 10, Ranges: 5},
+				newHostKsTable(h1.String(), "k1", "t2"): {Size: 6, Ranges: 2},
+				newHostKsTable(h2.String(), "k1", "t1"): {Size: 10, Ranges: 5},
+			},
+			Keyspaces: []keyspacePlan{
+				{
+					Keyspace: "k1",
+					Tables:   []tablePlan{{Table: "t1", RangesCnt: 5}, {Table: "t2", RangesCnt: 2}},
+				},
+			},
+		}
+
+		pm := NewDBProgressManager(run, session, metrics.NewRepairMetrics(), log.NewDevelopment())
+		if err := pm.Init(p, prevRun.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		// Simulate job for h1/k1/t2 (the partially completed entry)
+		ctx := context.Background()
+		j := job{
+			keyspace:   "k1",
+			table:      "t2",
+			master:     h1,
+			replicaSet: []netip.Addr{h1},
+			ranges:     []scyllaclient.TokenRange{{StartToken: 50, EndToken: 100}},
+		}
+		pm.OnJobStart(ctx, j)
+		time.Sleep(10 * time.Millisecond)
+		pm.OnJobEnd(ctx, jobResult{job: j})
+
+		// Aggregate and verify
+		prog, err := pm.AggregateProgress()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		findHostTable := func(host, ks, tbl string) *TableProgress {
+			for i := range prog.Hosts {
+				if prog.Hosts[i].Host == host {
+					for j := range prog.Hosts[i].Tables {
+						tp := &prog.Hosts[i].Tables[j]
+						if tp.Keyspace == ks && tp.Table == tbl {
+							return tp
+						}
+					}
+				}
+			}
+			return nil
+		}
+
+		// h1/k1/t1: fully done in prev run, no work this run → duration 0, nil timestamps
+		ht := findHostTable(h1.String(), "k1", "t1")
+		if ht.Duration != 0 {
+			t.Errorf("h1/k1/t1 (done in prev run) duration: got %d, want 0", ht.Duration)
+		}
+		if ht.StartedAt != nil {
+			t.Errorf("h1/k1/t1 StartedAt should be nil, got %v", ht.StartedAt)
+		}
+
+		// h2/k1/t1: fully done in prev run → duration 0
+		ht = findHostTable(h2.String(), "k1", "t1")
+		if ht.Duration != 0 {
+			t.Errorf("h2/k1/t1 (done in prev run) duration: got %d, want 0", ht.Duration)
+		}
+
+		// h1/k1/t2: had work this run → duration > 0, reflecting current run only
+		ht = findHostTable(h1.String(), "k1", "t2")
+		if ht.Duration <= 0 {
+			t.Errorf("h1/k1/t2 (retried this run) duration: got %d, want > 0", ht.Duration)
+		}
+		// Duration should be small (around 10ms), not 30s from previous run
+		if ht.Duration > 5000 {
+			t.Errorf("h1/k1/t2 duration too large (inherited from prev run?): got %dms", ht.Duration)
+		}
+
+		// Host h2: all entries done from prev run → duration 0
+		findHost := func(host string) *HostProgress {
+			for i := range prog.Hosts {
+				if prog.Hosts[i].Host == host {
+					return &prog.Hosts[i]
+				}
+			}
+			return nil
+		}
+		if d := findHost(h2.String()).Duration; d != 0 {
+			t.Errorf("h2 (all done in prev run) duration: got %d, want 0", d)
+		}
+	})
+
+	t.Run("legacy Duration and DurationStartedAt fields in DB are ignored", func(t *testing.T) {
+		session := CreateScyllaManagerDBSession(t)
+		run := &Run{
+			ClusterID: uuid.NewTime(),
+			TaskID:    uuid.NewTime(),
+			ID:        uuid.NewTime(),
+			StartTime: timeutc.Now(),
+		}
+
+		// Insert entry with large legacy Duration field but known wall-clock timestamps
+		base := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+		start := base
+		end := base.Add(30 * time.Second)
+		legacyDurationStart := base.Add(-1 * time.Hour)
+
+		rps := []*RunProgress{
+			{
+				ClusterID: run.ClusterID, TaskID: run.TaskID, RunID: run.ID,
+				Host: h1.String(), Keyspace: "k1", Table: "t1",
+				Size: 10, TokenRanges: 5, Success: 5,
+				StartedAt: &start, CompletedAt: &end,
+				Duration:          999 * time.Second,
+				DurationStartedAt: &legacyDurationStart,
+			},
+		}
+		saveProgress(rps, session)
+
+		pm := NewDBProgressManager(run, session, metrics.NewRepairMetrics(), log.NewDevelopment())
+		p, err := pm.AggregateProgress()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Duration should be 30s (wall-clock), not 999s (legacy field)
+		if p.Duration != 30000 {
+			t.Errorf("overall duration: got %d, want 30000 (legacy Duration field should be ignored)", p.Duration)
+		}
+		if p.Hosts[0].Duration != 30000 {
+			t.Errorf("host duration: got %d, want 30000", p.Hosts[0].Duration)
+		}
+	})
+}
+
 func getProgress(run *Run, session gocqlx.Session) []RunProgress {
-	var rp = make([]RunProgress, 0)
+	rp := make([]RunProgress, 0)
 
 	if err := table.RepairRunProgress.SelectQuery(session).BindMap(qb.M{
 		"cluster_id": run.ClusterID,
@@ -349,7 +669,7 @@ func saveProgress(rps []*RunProgress, session gocqlx.Session) {
 }
 
 func getState(run *Run, session gocqlx.Session) []*RunState {
-	var rs = make([]*RunState, 0)
+	rs := make([]*RunState, 0)
 
 	if err := table.RepairRunState.SelectQuery(session).BindMap(qb.M{
 		"cluster_id": run.ClusterID,

--- a/pkg/service/repair/testdata/AggregateProgressIntegration/multiple_progress_multi_host.golden.json
+++ b/pkg/service/repair/testdata/AggregateProgressIntegration/multiple_progress_multi_host.golden.json
@@ -47,7 +47,7 @@
       "error": 0,
       "started_at": "2019-01-01T00:00:00Z",
       "completed_at": "2019-01-01T00:02:00Z",
-      "duration_ms": 179000,
+      "duration_ms": 120000,
       "host": "h2",
       "tables": [
         {

--- a/pkg/service/repair/testdata/AggregateProgressIntegration/weighted_progress.golden.json
+++ b/pkg/service/repair/testdata/AggregateProgressIntegration/weighted_progress.golden.json
@@ -47,7 +47,7 @@
       "error": 3,
       "started_at": "2019-01-01T00:00:00Z",
       "completed_at": "2019-01-01T00:02:00Z",
-      "duration_ms": 179000,
+      "duration_ms": 120000,
       "host": "h2",
       "tables": [
         {

--- a/v3/pkg/managerclient/model.go
+++ b/v3/pkg/managerclient/model.go
@@ -787,7 +787,7 @@ func (rp RepairProgress) addRepairTableProgress(d *table.Table) {
 			p = FormatRepairProgress(t.TokenRanges, t.Success, t.Error)
 		}
 
-		d.AddRow(t.Keyspace, t.Table, p, FormatMsDuration(t.DurationMs))
+		d.AddRow(t.Keyspace, t.Table, p, FormatRepairDuration(t.DurationMs, t.TokenRanges, t.Success))
 	}
 }
 
@@ -800,7 +800,7 @@ func (rp RepairProgress) addRepairTableDetailedProgress(d *table.Table, t *model
 		t.Error,
 		FormatTimePointer(t.StartedAt),
 		FormatTimePointer(t.CompletedAt),
-		FormatMsDuration(t.DurationMs),
+		FormatRepairDuration(t.DurationMs, t.TokenRanges, t.Success),
 	)
 }
 

--- a/v3/pkg/managerclient/utils.go
+++ b/v3/pkg/managerclient/utils.go
@@ -198,6 +198,16 @@ func FormatMsDuration(d int64) string {
 	return (time.Duration(d)*time.Millisecond + time.Second - 1).Truncate(time.Second).String()
 }
 
+// FormatRepairDuration returns duration string for repair progress entries.
+// For entries that were fully completed in a previous run (0 duration, 100% success),
+// it returns "done" instead of "0s".
+func FormatRepairDuration(durationMs, tokenRanges, success int64) string {
+	if durationMs == 0 && tokenRanges > 0 && success == tokenRanges {
+		return "done"
+	}
+	return FormatMsDuration(durationMs)
+}
+
 func isZero(t strfmt.DateTime) bool {
 	return time.Time(t).IsZero()
 }

--- a/v3/swagger/gen/scylla-manager/models/repair_progress.go
+++ b/v3/swagger/gen/scylla-manager/models/repair_progress.go
@@ -26,7 +26,7 @@ type RepairProgress struct {
 	// dcs
 	Dcs []string `json:"dcs"`
 
-	// duration ms
+	// Wall-clock duration in milliseconds for the current task run.
 	DurationMs int64 `json:"duration_ms,omitempty"`
 
 	// error

--- a/v3/swagger/gen/scylla-manager/models/table_repair_progress.go
+++ b/v3/swagger/gen/scylla-manager/models/table_repair_progress.go
@@ -21,7 +21,7 @@ type TableRepairProgress struct {
 	// Format: date-time
 	CompletedAt *strfmt.DateTime `json:"completed_at,omitempty"`
 
-	// duration ms
+	// Wall-clock duration in milliseconds for the current task run. A value of 0 with full progress indicates that the repair was completed in a previous run.
 	DurationMs int64 `json:"duration_ms,omitempty"`
 
 	// error

--- a/v3/swagger/scylla-manager.json
+++ b/v3/swagger/scylla-manager.json
@@ -193,6 +193,7 @@
           "x-nullable": true
         },
         "duration_ms": {
+          "description": "Wall-clock duration in milliseconds for the current task run.",
           "type": "integer"
         },
         "dcs": {
@@ -266,6 +267,7 @@
           "x-nullable": true
         },
         "duration_ms": {
+          "description": "Wall-clock duration in milliseconds for the current task run. A value of 0 with full progress indicates that the repair was completed in a previous run.",
           "type": "integer"
         },
         "keyspace": {


### PR DESCRIPTION
[refactor(repair): repair run progress duration](https://github.com/scylladb/scylla-manager/pull/4865/changes/6bbe2d87440a6b023fda97a8f8f920b2ec84201d)
This refactors repair run progress duration. Previously, duration was
calculated differently on different aggregation levels and some of them
were including duration inherited from previous runs and some were not.

This PR introduces following rules:
- Progress duration is per task run (not per task execution, so no need
  to inherit duration from previous task runs)
- Duration should be a wall-clock time (not a job execution duration)

Relates: CLOUD-2473

---

[fix(repair): skip rows with no work from progress merging](https://github.com/scylladb/scylla-manager/pull/4865/changes/e83688ad71551ebca18abd9cf508fce1bf4b5158)
Relates: CLOUD-2473

---

[refactor(managerclient): repair duration rendering](https://github.com/scylladb/scylla-manager/pull/4865/changes/bc2f35fefe4142a84043078c2d90a79aa2035b73)
This changes how repair run progress duration is rendered:
As repair run progress is per task run now (previously it was per task
execution in some cases), it's possible that some progress entries will
have progress 100%, but zero duration, meaning that they were fully
repaired in the previous task run and current task run spent 0s on them.
To make it more clear, in such cases duration will rendered as "done".

Relates: CLOUD-2473

Examples: 
```bash 

# Repair was stopped and resumed:

❯ ./sctool.dev info -c my-cluster repair/82701d59-da9f-4792-8394-76d73af3b59a
Name:   repair/82701d59-da9f-4792-8394-76d73af3b59a
Cron:   {"spec":"","start_date":"0001-01-01T00:00:00Z"} (no activations scheduled)
Tz:     Europe/Warsaw
Retry:  3 (initial backoff 10m)
╭──────────────────────────────────────┬─────────────────────────┬──────────┬─────────╮
│ ID                                   │ Start time              │ Duration │ Status  │
├──────────────────────────────────────┼─────────────────────────┼──────────┼─────────┤
│ 319aaab3-7ed2-11f1-ab6e-124ac6f7831c │ 13 Jul 26 17:47:46 CEST │ 7s       │ DONE    │
│ 156d8636-7ed2-11f1-ab6d-124ac6f7831c │ 13 Jul 26 17:46:59 CEST │ 7s       │ STOPPED │
╰──────────────────────────────────────┴─────────────────────────┴──────────┴─────────╯

# Then final repair run progress has entries inherited from initial run, but they doesn't affect duration:

❯ ./sctool.dev progress -c my-cluster repair/82701d59-da9f-4792-8394-76d73af3b59a
Run:            319aaab3-7ed2-11f1-ab6e-124ac6f7831c
Status:         DONE
Start time:     13 Jul 26 17:47:46 CEST
End time:       13 Jul 26 17:47:54 CEST
Duration:       7s
Progress:       100%
Intensity:      1
Parallel:       0
Datacenters:
  - dc1
  - dc2

╭───────────────────────────────┬────────────────────────────────┬──────────┬──────────╮
│ Keyspace                      │                          Table │ Progress │ Duration │
├───────────────────────────────┼────────────────────────────────┼──────────┼──────────┤
│ audit                         │                      audit_log │ 100%     │ done     │
├───────────────────────────────┼────────────────────────────────┼──────────┼──────────┤
│ system_distributed_everywhere │ cdc_generation_descriptions_v2 │ 100%     │ done     │
├───────────────────────────────┼────────────────────────────────┼──────────┼──────────┤
│ system_distributed            │      cdc_generation_timestamps │ 100%     │ done     │
│ system_distributed            │    cdc_streams_descriptions_v2 │ 100%     │ done     │
│ system_distributed            │                 service_levels │ 100%     │ done     │
│ system_distributed            │              view_build_status │ 100%     │ done     │
├───────────────────────────────┼────────────────────────────────┼──────────┼──────────┤
│ system_replicated_keys        │                 encrypted_keys │ 100%     │ done     │
├───────────────────────────────┼────────────────────────────────┼──────────┼──────────┤
│ test_tablet_ks                │                           tab1 │ 100%     │ 7s       │
│ test_tablet_ks                │                           tab2 │ 100%     │ done     │
├───────────────────────────────┼────────────────────────────────┼──────────┼──────────┤
│ test_vnode_ks                 │                           tab1 │ 100%     │ done     │
│ test_vnode_ks                 │                           tab2 │ 100%     │ done     │
╰───────────────────────────────┴────────────────────────────────┴──────────┴──────────╯

# Initial repair run progress:
❯ ./sctool.dev progress -c my-cluster repair/82701d59-da9f-4792-8394-76d73af3b59a --run 156d8636-7ed2-11f1-ab6d-124ac6f7831c
Run:            156d8636-7ed2-11f1-ab6d-124ac6f7831c
Status:         STOPPED
Cause:          scheduler and all tasks were stopped
Start time:     13 Jul 26 17:46:59 CEST
End time:       13 Jul 26 17:47:07 CEST
Duration:       7s
Progress:       51%
Intensity:      1
Parallel:       0
Datacenters:
  - dc1
  - dc2

╭───────────────────────────────┬────────────────────────────────┬──────────┬───────────╮
│ Keyspace                      │                          Table │ Progress │ Duration  │
├───────────────────────────────┼────────────────────────────────┼──────────┼───────────┤
│ audit                         │                      audit_log │ 100%     │ 17h17m57s │
├───────────────────────────────┼────────────────────────────────┼──────────┼───────────┤
│ system_distributed_everywhere │ cdc_generation_descriptions_v2 │ 100%     │ 1s        │
├───────────────────────────────┼────────────────────────────────┼──────────┼───────────┤
│ system_distributed            │      cdc_generation_timestamps │ 100%     │ 1s        │
│ system_distributed            │    cdc_streams_descriptions_v2 │ 100%     │ 1s        │
│ system_distributed            │                 service_levels │ 100%     │ 1s        │
│ system_distributed            │              view_build_status │ 100%     │ 1s        │
├───────────────────────────────┼────────────────────────────────┼──────────┼───────────┤
│ system_replicated_keys        │                 encrypted_keys │ 100%     │ 1s        │
├───────────────────────────────┼────────────────────────────────┼──────────┼───────────┤
│ test_tablet_ks                │                           tab1 │ 0%       │ 0s        │
│ test_tablet_ks                │                           tab2 │ 100%     │ 7s        │
├───────────────────────────────┼────────────────────────────────┼──────────┼───────────┤
│ test_vnode_ks                 │                           tab1 │ 100%     │ 1s        │
│ test_vnode_ks                 │                           tab2 │ 100%     │ 1s        │
╰───────────────────────────────┴────────────────────────────────┴──────────┴───────────╯

```

**Note**:  `audit_log` duration was growing non stop, so I guess I found another bug, fix is there - [fix(repair): skip rows with no work from progress merging](https://github.com/scylladb/scylla-manager/pull/4865/changes/e83688ad71551ebca18abd9cf508fce1bf4b5158)

---

[chore(swagger/sm): update repair progress duration_ms field description](https://github.com/scylladb/scylla-manager/pull/4865/changes/effb877480d4673cf1ed8fc648dbc37c76525279)
Relates: CLOUD-2473

---

Please make sure that:
- Code is split to commits that address a single change
- Commit messages are informative
- Commit titles have module prefix
- Commit titles have issue nr. suffix
