### PR TITLE
fix(dist): use '.' instead of '-' in unstable version separators

### DIFF
--- a/dist/.goreleaser.yaml
+++ b/dist/.goreleaser.yaml
@@ -16,7 +16,7 @@ changelog:
       - '^testing:'
 
 snapshot:
-    version_template: '{{ .Version }}-SNAPSHOT'
+    version_template: '{{ .Version }}.SNAPSHOT'
 
 builds:
   - id: server

--- a/dist/Makefile
+++ b/dist/Makefile
@@ -8,7 +8,7 @@ endif
 
 ifeq ($(PUBLISH),0)
 publish = --skip=publish
-VERSION_NAME := $(VERSION)-$(RELEASE)
+VERSION_NAME := $(VERSION).$(RELEASE)
 else
 VERSION_NAME := v$(VERSION)
 endif


### PR DESCRIPTION
Since the goreleaser v2 / nfpm upgrade commit: https://github.com/scylladb/scylla-manager/commit/2348ea18c7dc5a5a230be1647ce138b2c9302f98 the illegal `'-'` separators in unstable Manager package versions are sanitized to `'_'`, producing versions like `3.4.0~dev_0.20240827.13eef6aac_SNAPSHOT` in the RPM repodata (primary.xml), which broke Manager version parsing in SCT.

SCT already normalizes `_`→`.` in commit: https://github.com/scylladb/scylla-cluster-tests/commit/7d2d0bba6b6a20bea344cd326b5ed5d37d74fea4

Fixing it by replace the `-` separators with `.` in:
- `dist/Makefile` - `VERSION_NAME` (the tag / `.Version` source)
- `dist/.goreleaser.yaml` - the snapshot `version_template`
RPM/DEB version contains no underscores.
    
Fixes: https://scylladb.atlassian.net/browse/RELENG-47

## Verification


| # | Check | Command / Source | Result |
|---|-------|------------------|--------|
| 1 | Snapshot build from branch | https://jenkins.scylladb.com/job/manager-master/job/releng-testing/job/manager-build/342/| ✅ SUCCESS - `version=3.12.0-dev.0.20260619.4a68c7707.SNAPSHOT` |
| 2 | RPM `primary.xml` version | `repodata/*-primary.xml.gz` of the published centos repo | ✅ `ver=3.12.0~dev.0.20260619.4a68c7707.SNAPSHOT` (server/client/agent) - **no underscores** |
| 3 | DEB `Packages` version | `dists/stable/main/binary-amd64/Packages` of the published unified-deb repo | ✅ `Version: 3.12.0~dev.0.20260619.4a68c7707.SNAPSHOT` (server/client/agent) - **no underscores** |
| 4 | Rocky 9 install + version parse | https://jenkins.scylladb.com/job/manager-master/job/releng-testing/job/rocky9-installation-test/52/ | ✅ SUCCESS - server (RPM) + agent (DEB) install; `sctool` reports `Client/Server version: 3.12.0-dev.0.20260619.4a68c7707.SNAPSHOT`; parsed with no errors |

**Before:** `3.4.0~dev_0.20240827.13eef6aac_SNAPSHOT` - underscores broke SCT parsing.
**After:** `3.12.0~dev.0.20260619.4a68c7707.SNAPSHOT` - dot separators, no underscores.



Before vs After comparison
| Field | Before (broken) | After (fixed) |
|-------|----------------|---------------|
| Git tag | \`3.12.0-dev-0.20260619.462bd80\` | \`3.12.0-dev.0.20260619.462bd80\` |
| Goreleaser version | \`3.12.0-dev-0.20260619.462bd80-SNAPSHOT\` | \`3.12.0-dev.0.20260619.462bd80.SNAPSHOT\` |
| RPM ver= | \`3.12.0~dev_0.20260619.462bd80_SNAPSHOT\` | \`3.12.0~dev.0.20260619.462bd80.SNAPSHOT\` |
| RPM rel= | \`1\` | \`1\` **(unchanged)** |
| .version file | \`3.12.0-dev\` | \`3.12.0-dev\` **(unchanged)** |
| .release file | \`0.20260619.462bd80\` | \`0.20260619.462bd80\` **(unchanged)** |
| RPM filename | \`...-3.12.0-dev-...-SNAPSHOT_linux.x86_64.rpm\` | \`...-3.12.0-dev.....SNAPSHOT_linux.x86_64.rpm\` |