### PR TITLE
fix(restore): remove flaky partial repair progress assertion

### DIFF
--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -970,14 +970,6 @@ func restoreWithResume(t *testing.T, target Target, keyspace string, loadCnt, lo
 		t.Fatalf("Expected context error but got: %+v", err)
 	}
 
-	pr, err := dstH.service.GetProgress(context.Background(), dstH.ClusterID, dstH.TaskID, dstH.RunID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	Printf("And: restore progress: %+#v\n", pr)
-	if pr.RepairProgress == nil || pr.RepairProgress.Success == 0 {
-		t.Fatal("Expected partial repair progress")
-	}
 
 	Print("When: resume restore and complete it")
 	dstH.RunID = uuid.MustRandom()


### PR DESCRIPTION
The assertion 'Expected partial repair progress' is inherently racy with tablet keyspaces because tablet repair is atomic per table — if interrupted, it restarts from scratch on resume. Since the test repairs only one table (big_table), there is no reliable intermediate state to observe. The test still validates that pause/resume during repair works correctly by completing Run 3 successfully.

For tablet keyspaces, a single table's repair is atomic — if interrupted, it restarts from scratch on resume (see generator.go: "Always repair unfinished tablet table from scratch as tablet load balancing is enabled when repair is interrupted"). Since this test repairs only one table (big_table), there is no meaningful partial progress to observe between "no tables done" and "all tables done".

Fixes: https://scylladb.atlassian.net/browse/CLOUD-1970