### PR TITLE
Bump rclone fork to v1.54.0-patched-2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -167,6 +167,6 @@ require (
 
 replace (
 	github.com/gocql/gocql => github.com/scylladb/gocql v1.18.3
-	github.com/rclone/rclone => github.com/scylladb/rclone v1.54.0-patched-1
+	github.com/rclone/rclone => github.com/scylladb/rclone v1.54.0-patched-2
 	google.golang.org/api => github.com/scylladb/google-api-go-client v0.277.0-patched
 )

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/scylladb/gocqlx/v2 v2.8.0 h1:f/oIgoEPjKDKd+RIoeHqexsIQVIbalVmT+axwvUq
 github.com/scylladb/gocqlx/v2 v2.8.0/go.mod h1:4/+cga34PVqjhgSoo5Nr2fX1MQIqZB5eCE5DK4xeDig=
 github.com/scylladb/google-api-go-client v0.277.0-patched h1:TLf3ViOvLnnygprH943bxt0KZz8XL6PtnhUJrkWLKXU=
 github.com/scylladb/google-api-go-client v0.277.0-patched/go.mod h1:B9TqLBwJqVjp1mtt7WeoQwWRwvu/400y5lETOql+giQ=
-github.com/scylladb/rclone v1.54.0-patched-1 h1:5V0DTfVzxeeKs2XLOBaM62i5C/ba+u0MQyY0e1Y+820=
-github.com/scylladb/rclone v1.54.0-patched-1/go.mod h1:zD5R3V3oc9XCuQ91jP5G7kwp6PWHNuH9f7tPvJDJttk=
+github.com/scylladb/rclone v1.54.0-patched-2 h1:QA3xAiaDlP+KKaN+/wk/9I/1x2x+Dm0vLQSXs50qR30=
+github.com/scylladb/rclone v1.54.0-patched-2/go.mod h1:zD5R3V3oc9XCuQ91jP5G7kwp6PWHNuH9f7tPvJDJttk=
 github.com/scylladb/scylla-manager/backupspec v1.0.3-0.20260407094300-c4d92171ff7c h1:fDDwLj/GSc8DgiaLTGhSfDlfkrLhxiatGdLYAwrHQYE=
 github.com/scylladb/scylla-manager/backupspec v1.0.3-0.20260407094300-c4d92171ff7c/go.mod h1:q6WQ90LXFM+69NXr9jZertopfiPjJfCTsR3/Fg5/200=
 github.com/scylladb/scylla-manager/v3/pkg/managerclient v0.0.0-20260527104540-b3e9f76ffdee h1:9GNZOVrqceICpr+ZfCqB6A2r9CtOrNANvUpN19dmAsE=

--- a/pkg/rclone/operations/operations.go
+++ b/pkg/rclone/operations/operations.go
@@ -151,7 +151,7 @@ func CheckPermissions(ctx context.Context, l fs.Fs, remote string, locked, overr
 // checkRetentionLock verifies retention lock and optional override lock
 // permissions by re-copying the test file and applying retention policies.
 func checkRetentionLock(ctx context.Context, l, localFs fs.Fs, remote string, overrideLock bool) error {
-	rl, ok := l.(fs.RetentionLocker)
+	rs, ok := l.(fs.ObjectRetentionSetter)
 	if !ok {
 		return asOperationError("retention-lock", l, errors.Errorf("backend %q does not support retention lock", l.Name()))
 	}
@@ -164,14 +164,19 @@ func checkRetentionLock(ctx context.Context, l, localFs fs.Fs, remote string, ov
 	// Apply retention lock (unlocked, now+1m).
 	// Time is rounded as retention periods are calculated according to
 	// snapshot tags, which have a second level precision.
-	retainUntil := timeutc.Now().Round(time.Second).Add(time.Minute)
-	if err := rl.RetentionLock(ctx, remote, false, retainUntil, false); err != nil {
+	info := fs.ObjectRetentionInfo{
+		RetainUntil: timeutc.Now().Round(time.Second).Add(time.Minute),
+		Mode:        fs.RetentionModeUnlocked,
+	}
+
+	if err := rs.SetObjectRetention(ctx, remote, info, false); err != nil {
 		return asOperationError("retention-lock", l, err)
 	}
 
 	// Override retention lock (locked).
+	info.Mode = fs.RetentionModeLocked
 	if overrideLock {
-		if err := rl.RetentionLock(ctx, remote, true, retainUntil, true); err != nil {
+		if err := rs.SetObjectRetention(ctx, remote, info, true); err != nil {
 			return asOperationError("override-lock", l, err)
 		}
 	}

--- a/pkg/rclone/rcserver/rc.go
+++ b/pkg/rclone/rcserver/rc.go
@@ -633,7 +633,7 @@ func rcRetentionLock(ctx context.Context, in rc.Params) (out rc.Params, err erro
 	if err != nil {
 		return nil, err
 	}
-	rl, ok := f.(fs.RetentionLocker)
+	rs, ok := f.(fs.ObjectRetentionSetter)
 	if !ok {
 		return nil, errors.Errorf("backend %q does not support retention lock", f.Name())
 	}
@@ -667,6 +667,13 @@ func rcRetentionLock(ctx context.Context, in rc.Params) (out rc.Params, err erro
 		}
 		overrideLock = false
 	}
+	info := fs.ObjectRetentionInfo{
+		RetainUntil: until,
+		Mode:        fs.RetentionModeUnlocked,
+	}
+	if locked {
+		info.Mode = fs.RetentionModeLocked
+	}
 
 	stats := accounting.Stats(ctx)
 	workerCnt := min(2*runtime.NumCPU(), len(paths))
@@ -693,7 +700,7 @@ func rcRetentionLock(ctx context.Context, in rc.Params) (out rc.Params, err erro
 				}
 				tr := stats.NewTransferRemoteSize(p, 1)
 				acc := tr.Account(ctx, nil)
-				err := rl.RetentionLock(ctx, path.Join(remote, p), locked, until, overrideLock)
+				err := rs.SetObjectRetention(ctx, path.Join(remote, p), info, overrideLock)
 				if err == nil {
 					acc.DryRun(1)
 				} else {

--- a/vendor/github.com/rclone/rclone/backend/googlecloudstorage/googlecloudstorage.go
+++ b/vendor/github.com/rclone/rclone/backend/googlecloudstorage/googlecloudstorage.go
@@ -349,13 +349,15 @@ type Fs struct {
 //
 // Will definitely have info but maybe not meta
 type Object struct {
-	fs       *Fs       // what this object is part of
-	remote   string    // The remote path
-	url      string    // download path
-	md5sum   string    // The MD5Sum of the object
-	bytes    int64     // Bytes in the object
-	modTime  time.Time // Modified time of the object
-	mimeType string
+	fs             *Fs       // what this object is part of
+	remote         string    // The remote path
+	url            string    // download path
+	md5sum         string    // The MD5Sum of the object
+	bytes          int64     // Bytes in the object
+	modTime        time.Time // Modified time of the object
+	mimeType       string
+	retentionInfo  fs.ObjectRetentionInfo // Object retention info returned with object metadata
+	eventBasedHold bool                   // Whether object has event based hold applied
 }
 
 // ------------------------------------------------------------
@@ -572,7 +574,7 @@ type listFn func(remote string, object *storage.Object, isDirectory bool) error
 //
 // dir is the starting directory, "" for root
 //
-// Set recurse to read sub directories
+// # Set recurse to read sub directories
 //
 // The remote has prefix removed from it and if addBucket is set
 // then it adds the bucket to the start.
@@ -790,7 +792,7 @@ func (f *Fs) ListR(ctx context.Context, dir string, callback fs.ListRCallback) (
 
 // Put the object into the bucket
 //
-// Copy the reader in to the new object which is returned
+// # Copy the reader in to the new object which is returned
 //
 // The new object may have been created if an error is returned
 func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
@@ -887,9 +889,9 @@ func (f *Fs) Precision() time.Duration {
 
 // Copy src to this remote using server-side copy operations.
 //
-// This is stored with the remote path given
+// # This is stored with the remote path given
 //
-// It returns the destination Object and a possible error
+// # It returns the destination Object and a possible error
 //
 // Will only be called if src.Fs().Name() == f.Name()
 //
@@ -942,21 +944,30 @@ func (f *Fs) Hashes() hash.Set {
 	return hash.Set(hash.MD5)
 }
 
-// RetentionLock sets object retention lock on the specified remote using Objects.Patch.
-func (f *Fs) RetentionLock(ctx context.Context, remote string, locked bool, until time.Time, overrideLock bool) error {
+// ObjectRetentionInfo returns cached object retention state.
+func (o *Object) ObjectRetentionInfo(_ context.Context) (fs.ObjectRetentionInfo, error) {
+	return o.retentionInfo, nil
+}
+
+// SetObjectRetention sets object retention lock on the specified remote using Objects.Patch.
+func (f *Fs) SetObjectRetention(ctx context.Context, remote string, info fs.ObjectRetentionInfo, overrideLock bool) error {
 	bucket, bucketPath := f.split(remote)
-	mode := "Unlocked"
-	if locked {
-		mode = "Locked"
+	gcsMode, err := gcsRetentionMode(info.Mode)
+	if err != nil {
+		return err
 	}
 	obj := &storage.Object{
 		Retention: &storage.ObjectRetention{
-			Mode:            mode,
-			RetainUntilTime: until.Format(time.RFC3339),
+			Mode:            gcsMode,
+			RetainUntilTime: info.RetainUntil.Format(time.RFC3339),
 		},
 	}
+	if info.Mode == fs.RetentionModeNone {
+		obj.Retention = nil
+		obj.NullFields = []string{"Retention"}
+	}
 	var result *storage.Object
-	err := f.pacer.Call(func() (bool, error) {
+	err = f.pacer.Call(func() (bool, error) {
 		var err error
 		result, err = f.svc.Objects.Patch(bucket, bucketPath, obj).
 			OverrideUnlockedRetention(overrideLock).
@@ -966,22 +977,75 @@ func (f *Fs) RetentionLock(ctx context.Context, remote string, locked bool, unti
 		return shouldRetry(err)
 	})
 	if err != nil {
-		return errors.Wrapf(err, "lock remote %q with mode %q, until %v, overrideLock %v ", remote, mode, until, overrideLock)
+		return errors.Wrapf(err, "lock remote %q with mode %q, until %v, overrideLock %v ", remote, gcsMode, info.RetainUntil, overrideLock)
+	}
+	if info.Mode == fs.RetentionModeNone {
+		if result.Retention == nil || result.Retention.Mode == "" {
+			return nil
+		}
+		return errors.Errorf("requested mode %q but server returned %q", gcsMode, result.Retention.Mode)
 	}
 	if result.Retention == nil {
 		return errors.New("server returned no retention configuration")
 	}
-	if result.Retention.Mode != mode {
-		return errors.Errorf(" requested mode %q but server returned %q", mode, result.Retention.Mode)
-	}
-	returnedUntil, err := time.Parse(time.RFC3339, result.Retention.RetainUntilTime)
-	if err != nil {
-		return errors.Errorf("could not parse server retainUntilTime %q: %v", result.Retention.RetainUntilTime, err)
-	}
-	if !returnedUntil.Equal(until) {
-		return errors.Errorf("requested retainUntilTime %q but server returned %q", until.Format(time.RFC3339), result.Retention.RetainUntilTime)
+	if result.Retention.Mode != gcsMode {
+		return errors.Errorf("requested mode %q but server returned %q", gcsMode, result.Retention.Mode)
 	}
 	return nil
+}
+
+// EventBasedHold returns cached event based hold state.
+func (o *Object) EventBasedHold(_ context.Context) (bool, error) {
+	return o.eventBasedHold, nil
+}
+
+// SetEventBasedHold sets or clears event based hold on the specified remote using Objects.Patch.
+func (f *Fs) SetEventBasedHold(ctx context.Context, remote string, hold bool) error {
+	bucket, bucketPath := f.split(remote)
+	obj := &storage.Object{
+		EventBasedHold: hold,
+		ForceSendFields: []string{
+			"EventBasedHold", // To ensure that clearing event based hold goes through
+		},
+	}
+	err := f.pacer.Call(func() (bool, error) {
+		var err error
+		_, err = f.svc.Objects.Patch(bucket, bucketPath, obj).
+			Fields("eventBasedHold"). // Just to limit server response size
+			Context(ctx).
+			Do()
+		return shouldRetry(err)
+	})
+	if err != nil {
+		return errors.Wrapf(err, "set event based hold on remote %q to %v", remote, hold)
+	}
+	return nil
+}
+
+func gcsRetentionMode(mode fs.RetentionMode) (string, error) {
+	switch mode {
+	case fs.RetentionModeNone:
+		return "", nil
+	case fs.RetentionModeUnlocked:
+		return "Unlocked", nil
+	case fs.RetentionModeLocked:
+		return "Locked", nil
+	default:
+		return "", errors.Errorf("unsupported fs retention mode %q", mode)
+	}
+}
+
+func fsRetentionMode(mode string) (fs.RetentionMode, error) {
+	switch mode {
+	case "":
+		return fs.RetentionModeNone, nil
+	case "Unlocked":
+		return fs.RetentionModeUnlocked, nil
+	case "Locked":
+		return fs.RetentionModeLocked, nil
+	default:
+		return "", errors.Errorf("unsupported gcs retention mode %q", mode)
+	}
 }
 
 // ------------------------------------------------------------
@@ -1023,6 +1087,11 @@ func (o *Object) setMetaData(info *storage.Object) {
 	o.bytes = int64(info.Size)
 	o.mimeType = info.ContentType
 
+	// Set retention info
+	o.setRetentionMetaData(info)
+	// Set event based hold info
+	o.eventBasedHold = info.EventBasedHold
+
 	// Read md5sum
 	md5sumData, err := base64.StdEncoding.DecodeString(info.Md5Hash)
 	if err != nil {
@@ -1048,6 +1117,40 @@ func (o *Object) setMetaData(info *storage.Object) {
 		fs.Logf(o, "Bad time decode: %v", err)
 	} else {
 		o.modTime = modTime
+	}
+}
+
+func (o *Object) setRetentionMetaData(info *storage.Object) {
+	o.retentionInfo = fs.ObjectRetentionInfo{}
+	// Check common/bucket retention period
+	if info.RetentionExpirationTime != "" {
+		retainUntil, err := time.Parse(time.RFC3339, info.RetentionExpirationTime)
+		if err != nil {
+			fs.Logf(o, "Can't decode retentionExpirationTime %v: %v", info.RetentionExpirationTime, err)
+			return
+		}
+		o.retentionInfo.RetainUntil = retainUntil
+		// Retention lock coming from bucket level configuration can't be overridden.
+		// Assume that it comes from bucket configuration and check object configuration in the next step.
+		o.retentionInfo.Mode = fs.RetentionModeLocked
+	}
+	// Check object retention period
+	if info.Retention != nil && info.Retention.RetainUntilTime != "" && info.Retention.Mode != "" {
+		objectRetainUntil, err := time.Parse(time.RFC3339, info.Retention.RetainUntilTime)
+		if err != nil {
+			fs.Logf(o, "Can't decode retainUntilTime %v: %v", info.Retention.RetainUntilTime, err)
+			return
+		}
+		// Check if the object configuration is the dominating one
+		if !objectRetainUntil.Before(o.retentionInfo.RetainUntil) {
+			o.retentionInfo.RetainUntil = objectRetainUntil
+			mode, err := fsRetentionMode(info.Retention.Mode)
+			if err != nil {
+				fs.Logf(o, "Can't decode mode %v: %v", info.Retention.Mode, err)
+				return
+			}
+			o.retentionInfo.Mode = mode
+		}
 	}
 }
 
@@ -1261,11 +1364,14 @@ func (o *Object) MimeType(ctx context.Context) string {
 
 // Check the interfaces are satisfied
 var (
-	_ fs.Fs              = &Fs{}
-	_ fs.Copier          = &Fs{}
-	_ fs.PutStreamer     = &Fs{}
-	_ fs.ListRer         = &Fs{}
-	_ fs.RetentionLocker = &Fs{}
-	_ fs.Object          = &Object{}
-	_ fs.MimeTyper       = &Object{}
+	_ fs.Fs                    = &Fs{}
+	_ fs.Copier                = &Fs{}
+	_ fs.PutStreamer           = &Fs{}
+	_ fs.ListRer               = &Fs{}
+	_ fs.ObjectRetentionSetter = &Fs{}
+	_ fs.EventBasedHoldSetter  = &Fs{}
+	_ fs.Object                = &Object{}
+	_ fs.ObjectRetentionInfoer = &Object{}
+	_ fs.EventBasedHolder      = &Object{}
+	_ fs.MimeTyper             = &Object{}
 )

--- a/vendor/github.com/rclone/rclone/fs/fs.go
+++ b/vendor/github.com/rclone/rclone/fs/fs.go
@@ -1045,15 +1045,47 @@ type ListRer interface {
 	ListR(ctx context.Context, dir string, callback ListRCallback) error
 }
 
-// RetentionLocker is an optional interface for Fs
-type RetentionLocker interface {
-	// RetentionLock sets object retention lock on the specified remote.
-	// locked=true means the retention cannot be overridden (e.g., Locked mode),
-	// locked=false means the retention can be overridden with special
-	// permissions (e.g., Unlocked mode).
-	// until is the timestamp until which the object is retained.
-	// overrideLock allows overriding existing retention policy (e.g., OverrideUnlockedRetention).
-	RetentionLock(ctx context.Context, remote string, locked bool, until time.Time, overrideLock bool) error
+// RetentionMode describes object retention mode.
+type RetentionMode string
+
+const (
+	// RetentionModeNone means no retention is set.
+	RetentionModeNone RetentionMode = ""
+	// RetentionModeUnlocked means retention can be overridden with special permissions.
+	RetentionModeUnlocked RetentionMode = "unlocked"
+	// RetentionModeLocked means retention cannot be overridden.
+	RetentionModeLocked RetentionMode = "locked"
+)
+
+// ObjectRetentionInfo describes object retention state.
+type ObjectRetentionInfo struct {
+	RetainUntil time.Time
+	Mode        RetentionMode
+}
+
+// ObjectRetentionInfoer is an optional interface for Object.
+type ObjectRetentionInfoer interface {
+	// ObjectRetentionInfo returns object retention state.
+	ObjectRetentionInfo(ctx context.Context) (ObjectRetentionInfo, error)
+}
+
+// ObjectRetentionSetter is an optional interface for Fs.
+type ObjectRetentionSetter interface {
+	// SetObjectRetention sets object retention on the specified remote.
+	// overrideLock allows overriding RetentionModeUnlocked.
+	SetObjectRetention(ctx context.Context, remote string, info ObjectRetentionInfo, overrideLock bool) error
+}
+
+// EventBasedHolder is an optional interface for Object.
+type EventBasedHolder interface {
+	// EventBasedHold returns whether the object is under event based hold.
+	EventBasedHold(ctx context.Context) (bool, error)
+}
+
+// EventBasedHoldSetter is an optional interface for Fs.
+type EventBasedHoldSetter interface {
+	// SetEventBasedHold sets or clears event based hold.
+	SetEventBasedHold(ctx context.Context, remote string, hold bool) error
 }
 
 // RangeSeeker is the interface that wraps the RangeSeek method.

--- a/vendor/github.com/rclone/rclone/fs/operations/lsjson.go
+++ b/vendor/github.com/rclone/rclone/fs/operations/lsjson.go
@@ -14,19 +14,22 @@ import (
 
 // ListJSONItem in the struct which gets marshalled for each line
 type ListJSONItem struct {
-	Path          string
-	Name          string
-	EncryptedPath string `json:",omitempty"`
-	Encrypted     string `json:",omitempty"`
-	Size          int64
-	MimeType      string    `json:",omitempty"`
-	ModTime       Timestamp //`json:",omitempty"`
-	IsDir         bool
-	Hashes        map[string]string `json:",omitempty"`
-	ID            string            `json:",omitempty"`
-	OrigID        string            `json:",omitempty"`
-	Tier          string            `json:",omitempty"`
-	IsBucket      bool              `json:",omitempty"`
+	Path           string
+	Name           string
+	EncryptedPath  string `json:",omitempty"`
+	Encrypted      string `json:",omitempty"`
+	Size           int64
+	MimeType       string    `json:",omitempty"`
+	ModTime        Timestamp //`json:",omitempty"`
+	IsDir          bool
+	Hashes         map[string]string `json:",omitempty"`
+	RetentionMode  string            `json:",omitempty"`
+	RetainUntil    *time.Time        `json:",omitempty"`
+	EventBasedHold bool              `json:",omitempty"`
+	ID             string            `json:",omitempty"`
+	OrigID         string            `json:",omitempty"`
+	Tier           string            `json:",omitempty"`
+	IsBucket       bool              `json:",omitempty"`
 }
 
 // Timestamp a time in the provided format
@@ -70,15 +73,17 @@ func formatForPrecision(precision time.Duration) string {
 
 // ListJSONOpt describes the options for ListJSON
 type ListJSONOpt struct {
-	Recurse       bool     `json:"recurse"`
-	NoModTime     bool     `json:"noModTime"`
-	NoMimeType    bool     `json:"noMimeType"`
-	ShowEncrypted bool     `json:"showEncrypted"`
-	ShowOrigIDs   bool     `json:"showOrigIDs"`
-	ShowHash      bool     `json:"showHash"`
-	DirsOnly      bool     `json:"dirsOnly"`
-	FilesOnly     bool     `json:"filesOnly"`
-	HashTypes     []string `json:"hashTypes"` // hash types to show if ShowHash is set, e.g. "MD5", "SHA-1"
+	Recurse            bool     `json:"recurse"`
+	NoModTime          bool     `json:"noModTime"`
+	NoMimeType         bool     `json:"noMimeType"`
+	ShowEncrypted      bool     `json:"showEncrypted"`
+	ShowOrigIDs        bool     `json:"showOrigIDs"`
+	ShowHash           bool     `json:"showHash"`
+	ShowRetentionInfo  bool     `json:"showRetentionInfo"`
+	ShowEventBasedHold bool     `json:"showEventBasedHold"`
+	DirsOnly           bool     `json:"dirsOnly"`
+	FilesOnly          bool     `json:"filesOnly"`
+	HashTypes          []string `json:"hashTypes"` // hash types to show if ShowHash is set, e.g. "MD5", "SHA-1"
 }
 
 // ListJSON lists fsrc using the options in opt calling callback for each item
@@ -159,6 +164,31 @@ func ListJSON(ctx context.Context, fsrc fs.Fs, remote string, opt *ListJSONOpt, 
 				if do, ok := fs.UnWrapObject(o).(fs.IDer); ok {
 					item.OrigID = do.ID()
 				}
+			}
+			if _, ok := entry.(fs.Object); opt.ShowRetentionInfo && ok {
+				ri, ok := entry.(fs.ObjectRetentionInfoer)
+				if !ok {
+					return errors.Errorf("%T does not support object retention info", entry)
+				}
+				info, err := ri.ObjectRetentionInfo(ctx)
+				if err != nil {
+					return errors.Wrapf(err, "failed to read object retention info for %q", entry.Remote())
+				}
+				item.RetentionMode = string(info.Mode)
+				if !info.RetainUntil.IsZero() {
+					item.RetainUntil = &info.RetainUntil
+				}
+			}
+			if _, ok := entry.(fs.Object); opt.ShowEventBasedHold && ok {
+				eh, ok := entry.(fs.EventBasedHolder)
+				if !ok {
+					return errors.Errorf("%T does not support event based hold", entry)
+				}
+				hold, err := eh.EventBasedHold(ctx)
+				if err != nil {
+					return errors.Wrapf(err, "failed to read event based hold for %q", entry.Remote())
+				}
+				item.EventBasedHold = hold
 			}
 			switch x := entry.(type) {
 			case fs.Directory:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -601,7 +601,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/rclone/rclone v1.51.0 => github.com/scylladb/rclone v1.54.0-patched-1
+# github.com/rclone/rclone v1.51.0 => github.com/scylladb/rclone v1.54.0-patched-2
 ## explicit; go 1.25.0
 github.com/rclone/rclone/backend/azureblob
 github.com/rclone/rclone/backend/crypt
@@ -1209,5 +1209,5 @@ gopkg.in/yaml.v2
 ## explicit
 gopkg.in/yaml.v3
 # github.com/gocql/gocql => github.com/scylladb/gocql v1.18.3
-# github.com/rclone/rclone => github.com/scylladb/rclone v1.54.0-patched-1
+# github.com/rclone/rclone => github.com/scylladb/rclone v1.54.0-patched-2
 # google.golang.org/api => github.com/scylladb/google-api-go-client v0.277.0-patched


### PR DESCRIPTION
New rclone fork version introduces new interfaces needed for handling retention locks and event based holds for CLOUD-2890. It also changes retention lock interfaces in a breaking way. Because of that, their usage needs to be adjusted in the same commit which introduces new rclone version.

Here are the new commits included in the rclone fork bump: https://github.com/scylladb/rclone/compare/073b5e53...ccf542aa.

Refs https://scylladb.atlassian.net/browse/CLOUD-2890
