### PR TITLE
feat(jenkins): add weekly-trigger Jenkinsfile

### DIFF
--- a/jenkins/weekly-trigger.jenkinsfile
+++ b/jenkins/weekly-trigger.jenkinsfile
@@ -3,7 +3,6 @@ pipeline {
 
 	options {
 		disableConcurrentBuilds()
-		timeout(time: 360, unit: 'MINUTES')
 	}
 
 	triggers {
@@ -11,69 +10,14 @@ pipeline {
 	}
 
 	stages {
-		stage('Build Packages') {
+		stage('Build & Test') {
 			steps {
-				build job: 'manager-build', wait: true
+				build job: 'manager-build', wait: false, parameters: [
+					booleanParam(name: 'RUN_MANAGER_SCT', value: true),
+					booleanParam(name: 'RUN_MANAGER_DTEST', value: true),
+					string(name: 'SCT_TESTS_PRIORITY', value: 'P2')
+				]
 			}
-		}
-
-		stage('Trigger Tests') {
-			parallel {
-				stage('Sanity Tests') {
-					steps {
-						build job: 'ubuntu24-sanity-test', wait: false, parameters: [
-							string(name: 'provision_type', value: 'on_demand')
-						]
-						build job: 'ubuntu24-sanity-ipv6-test', wait: false, parameters: [
-							string(name: 'provision_type', value: 'on_demand')
-						]
-						build job: 'ubuntu24-vnodes-tablets-enterprise-sanity-test', wait: false, parameters: [
-							string(name: 'provision_type', value: 'on_demand')
-						]
-					}
-				}
-
-				stage('Installation Tests') {
-					steps {
-						build job: 'rocky9-installation-test', wait: false, parameters: [
-							string(name: 'provision_type', value: 'on_demand')
-						]
-						build job: 'ubuntu22-installation-test', wait: false, parameters: [
-							string(name: 'provision_type', value: 'on_demand')
-						]
-						build job: 'debian12-installation-test', wait: false, parameters: [
-							string(name: 'provision_type', value: 'on_demand')
-						]
-					}
-				}
-
-				stage('Backup Tests') {
-					steps {
-						build job: 'sct-feature-test-backup', wait: false, parameters: [
-							string(name: 'provision_type', value: 'on_demand')
-						]
-						build job: 'sct-feature-test-backup-gce', wait: false, parameters: [
-							string(name: 'provision_type', value: 'on_demand')
-						]
-						build job: 'sct-feature-test-backup-azure', wait: false, parameters: [
-							string(name: 'provision_type', value: 'on_demand')
-						]
-					}
-				}
-
-				stage('Dtests') {
-					steps {
-						build job: 'dtest-manager-no-tablets', wait: false
-						build job: 'dtest-manager-with-tablets', wait: false
-					}
-				}
-			}
-		}
-	}
-
-	post {
-		failure {
-			echo "Weekly trigger pipeline failed"
 		}
 	}
 }

--- a/jenkins/weekly-trigger.jenkinsfile
+++ b/jenkins/weekly-trigger.jenkinsfile
@@ -1,7 +1,5 @@
 pipeline {
-	agent {
-		label 'builders_x86'
-	}
+	agent none
 
 	options {
 		disableConcurrentBuilds()
@@ -15,7 +13,7 @@ pipeline {
 	stages {
 		stage('Build Packages') {
 			steps {
-				build job: 'manager-master/manager-build', wait: true
+				build job: 'manager-build', wait: true
 			}
 		}
 
@@ -23,13 +21,13 @@ pipeline {
 			parallel {
 				stage('Sanity Tests') {
 					steps {
-						build job: 'manager-master/ubuntu24-sanity-test', wait: false, parameters: [
+						build job: 'ubuntu24-sanity-test', wait: false, parameters: [
 							string(name: 'provision_type', value: 'on_demand')
 						]
-						build job: 'manager-master/ubuntu24-sanity-ipv6-test', wait: false, parameters: [
+						build job: 'ubuntu24-sanity-ipv6-test', wait: false, parameters: [
 							string(name: 'provision_type', value: 'on_demand')
 						]
-						build job: 'manager-master/ubuntu24-vnodes-tablets-enterprise-sanity-test', wait: false, parameters: [
+						build job: 'ubuntu24-vnodes-tablets-enterprise-sanity-test', wait: false, parameters: [
 							string(name: 'provision_type', value: 'on_demand')
 						]
 					}
@@ -37,13 +35,13 @@ pipeline {
 
 				stage('Installation Tests') {
 					steps {
-						build job: 'manager-master/rocky9-installation-test', wait: false, parameters: [
+						build job: 'rocky9-installation-test', wait: false, parameters: [
 							string(name: 'provision_type', value: 'on_demand')
 						]
-						build job: 'manager-master/ubuntu22-installation-test', wait: false, parameters: [
+						build job: 'ubuntu22-installation-test', wait: false, parameters: [
 							string(name: 'provision_type', value: 'on_demand')
 						]
-						build job: 'manager-master/debian12-installation-test', wait: false, parameters: [
+						build job: 'debian12-installation-test', wait: false, parameters: [
 							string(name: 'provision_type', value: 'on_demand')
 						]
 					}
@@ -51,13 +49,13 @@ pipeline {
 
 				stage('Backup Tests') {
 					steps {
-						build job: 'manager-master/sct-feature-test-backup', wait: false, parameters: [
+						build job: 'sct-feature-test-backup', wait: false, parameters: [
 							string(name: 'provision_type', value: 'on_demand')
 						]
-						build job: 'manager-master/sct-feature-test-backup-gce', wait: false, parameters: [
+						build job: 'sct-feature-test-backup-gce', wait: false, parameters: [
 							string(name: 'provision_type', value: 'on_demand')
 						]
-						build job: 'manager-master/sct-feature-test-backup-azure', wait: false, parameters: [
+						build job: 'sct-feature-test-backup-azure', wait: false, parameters: [
 							string(name: 'provision_type', value: 'on_demand')
 						]
 					}
@@ -65,8 +63,8 @@ pipeline {
 
 				stage('Dtests') {
 					steps {
-						build job: 'manager-master/dtest-manager-no-tablets', wait: false
-						build job: 'manager-master/dtest-manager-with-tablets', wait: false
+						build job: 'dtest-manager-no-tablets', wait: false
+						build job: 'dtest-manager-with-tablets', wait: false
 					}
 				}
 			}

--- a/jenkins/weekly-trigger.jenkinsfile
+++ b/jenkins/weekly-trigger.jenkinsfile
@@ -1,0 +1,81 @@
+pipeline {
+	agent {
+		label 'builders_x86'
+	}
+
+	options {
+		disableConcurrentBuilds()
+		timeout(time: 360, unit: 'MINUTES')
+	}
+
+	triggers {
+		cron('TZ=Israel\nH 0 * * 6')
+	}
+
+	stages {
+		stage('Build Packages') {
+			steps {
+				build job: 'manager-master/manager-build', wait: true
+			}
+		}
+
+		stage('Trigger Tests') {
+			parallel {
+				stage('Sanity Tests') {
+					steps {
+						build job: 'manager-master/ubuntu24-sanity-test', wait: false, parameters: [
+							string(name: 'provision_type', value: 'on_demand')
+						]
+						build job: 'manager-master/ubuntu24-sanity-ipv6-test', wait: false, parameters: [
+							string(name: 'provision_type', value: 'on_demand')
+						]
+						build job: 'manager-master/ubuntu24-vnodes-tablets-enterprise-sanity-test', wait: false, parameters: [
+							string(name: 'provision_type', value: 'on_demand')
+						]
+					}
+				}
+
+				stage('Installation Tests') {
+					steps {
+						build job: 'manager-master/rocky9-installation-test', wait: false, parameters: [
+							string(name: 'provision_type', value: 'on_demand')
+						]
+						build job: 'manager-master/ubuntu22-installation-test', wait: false, parameters: [
+							string(name: 'provision_type', value: 'on_demand')
+						]
+						build job: 'manager-master/debian12-installation-test', wait: false, parameters: [
+							string(name: 'provision_type', value: 'on_demand')
+						]
+					}
+				}
+
+				stage('Backup Tests') {
+					steps {
+						build job: 'manager-master/sct-feature-test-backup', wait: false, parameters: [
+							string(name: 'provision_type', value: 'on_demand')
+						]
+						build job: 'manager-master/sct-feature-test-backup-gce', wait: false, parameters: [
+							string(name: 'provision_type', value: 'on_demand')
+						]
+						build job: 'manager-master/sct-feature-test-backup-azure', wait: false, parameters: [
+							string(name: 'provision_type', value: 'on_demand')
+						]
+					}
+				}
+
+				stage('Dtests') {
+					steps {
+						build job: 'manager-master/dtest-manager-no-tablets', wait: false
+						build job: 'manager-master/dtest-manager-with-tablets', wait: false
+					}
+				}
+			}
+		}
+	}
+
+	post {
+		failure {
+			echo "Weekly trigger pipeline failed"
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add a version-controlled Jenkinsfile for the `weekly-trigger` job, replacing the current UI-only FreeStyle configuration.

## Motivation

- The `weekly-trigger` job was the only job in `manager-master/` not tracked in any repo.
- After removing `pollSCM` from `manager-build` (scylladb/scylla-pkg#6495), we need `weekly-trigger` to explicitly build packages before running tests.

## Changes

- Added `jenkins/weekly-trigger.jenkinsfile` that:
  1. Runs on cron: Saturday midnight Israel time (`H 0 * * 6`)
  2. Triggers `manager-build` and waits for completion
  3. Triggers all downstream test jobs in parallel (sanity, installation, backup, dtests)

## Jenkins Reconfiguration Required

After merging, the `manager-master/weekly-trigger` job needs to be reconfigured:
- Convert from FreeStyle to Pipeline
- SCM: `scylladb/scylla-manager`, branch `master`
- Script path: `jenkins/weekly-trigger.jenkinsfile`

Refs: CLOUD-3135