### PR TITLE
fix(repair): wait for repair goroutine to finish in repair_restart subtest

### DIFF
--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1238,6 +1238,9 @@ func TestServiceRepairIntegration(t *testing.T) {
 
 		Print("And: repair of all nodes continues")
 		h.assertProgress(100, longWait)
+
+		Print("And: wait for repair to fully stop")
+		h.assertDone(shortWait)
 	})
 
 	t.Run("repair restart respect repair control", func(t *testing.T) {


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/CLOUD-3157

Fix flaky `TestServiceRepairIntegration/repair_restart_respect_repair_control`.

**Root cause:** `repair_restart` returns without waiting for its repair goroutine to finish. The next subtest's `ensureNoActiveRepairs()` finds the still-active Scylla repair task left by the previous goroutine's incomplete cleanup.

**Fix:** Explicitly cancel and wait for `Repair()` to return before the subtest exits.

Failing CI run: https://github.com/scylladb/scylla-manager/actions/runs/30001492503/job/89187476313