### PR TITLE
Event based hold handling during snapshot upload

### DIFF
--- a/pkg/scyllaclient/client_rclone.go
+++ b/pkg/scyllaclient/client_rclone.go
@@ -740,8 +740,6 @@ type PermissionCheckOpts struct {
 	CheckRetention RetentionLockMode
 	// CheckOverrideRetentionLock controls if the permission to override unlocked retention lock is granted.
 	CheckOverrideRetentionLock bool
-	// CheckEventBasedHold takes event based hold and default bucket retention policy into account when checking permissions.
-	CheckEventBasedHold bool
 }
 
 // RcloneCheckPermissions checks if location is available for listing, getting,
@@ -754,7 +752,7 @@ func (c *Client) RcloneCheckPermissions(ctx context.Context, host, remotePath st
 	if opts.CheckRetention == "" {
 		opts.CheckRetention = RetentionLockDisabled
 	}
-	modeParam, err := retentionLockModeToParam(opts.CheckRetention)
+	modeParam, holdParam, err := retentionLockModeToParam(opts.CheckRetention)
 	if err != nil {
 		return err
 	}
@@ -766,7 +764,7 @@ func (c *Client) RcloneCheckPermissions(ctx context.Context, host, remotePath st
 			Remote:           remote,
 			RetentionMode:    modeParam,
 			OverrideUnlocked: opts.CheckOverrideRetentionLock,
-			EventBasedHold:   opts.CheckEventBasedHold,
+			EventBasedHold:   holdParam,
 		},
 	}
 	_, err = c.agentOps.OperationsCheckPermissions(&p)
@@ -818,18 +816,24 @@ const (
 	RetentionLockUnlocked RetentionLockMode = "unlocked"
 	// RetentionLockLocked means that retention lock is applied and cannot be overridden.
 	RetentionLockLocked RetentionLockMode = "locked"
+	// RetentionLockEventBasedHold means that backup files are protected with default
+	// event based hold and bucket retention policy. SM is responsible for clearing
+	// the hold when it's no longer needed which starts bucket retention timer.
+	RetentionLockEventBasedHold RetentionLockMode = "event-based-hold"
 )
 
-func retentionLockModeToParam(mode RetentionLockMode) (string, error) {
+func retentionLockModeToParam(mode RetentionLockMode) (modeParam string, holdParam bool, err error) {
 	switch mode {
 	case RetentionLockDisabled:
-		return "", nil
+		return "", false, nil
 	case RetentionLockUnlocked:
-		return "unlocked", nil
+		return "unlocked", false, nil
 	case RetentionLockLocked:
-		return "locked", nil
+		return "locked", false, nil
+	case RetentionLockEventBasedHold:
+		return "", true, nil
 	default:
-		return "", errors.Errorf("unknown retention lock mode: %s", mode)
+		return "", false, errors.Errorf("unknown retention lock mode: %s", mode)
 	}
 }
 
@@ -844,9 +848,12 @@ func (c *Client) RcloneBatchRetentionLock(ctx context.Context, host, remoteDir s
 	if paths == nil {
 		paths = make([]string, 0)
 	}
-	modeParam, err := retentionLockModeToParam(mode)
+	modeParam, holdParam, err := retentionLockModeToParam(mode)
 	if err != nil {
 		return 0, err
+	}
+	if holdParam {
+		return 0, errors.New("event based hold should be applied with dedicated method")
 	}
 
 	p := operations.OperationsRetentionLockParams{
@@ -877,9 +884,12 @@ func (c *Client) RcloneRetentionLock(ctx context.Context, host, remotePath strin
 	if err != nil {
 		return err
 	}
-	modeParam, err := retentionLockModeToParam(mode)
+	modeParam, holdParam, err := retentionLockModeToParam(mode)
 	if err != nil {
 		return err
+	}
+	if holdParam {
+		return errors.New("event based hold should be applied with dedicated method")
 	}
 
 	p := operations.OperationsRetentionLockParams{

--- a/pkg/scyllaclient/client_rclone.go
+++ b/pkg/scyllaclient/client_rclone.go
@@ -840,6 +840,7 @@ func retentionLockModeToParam(mode RetentionLockMode) (modeParam string, holdPar
 // RcloneBatchRetentionLock sets object retention locks on the specified paths.
 // The remoteDir param format is "provider:bucket/path".
 // Specified paths are relative to remoteDir.
+// The mode arg can't be set to RetentionLockEventBasedHold - in such case, use RcloneBatchEventBasedHold.
 func (c *Client) RcloneBatchRetentionLock(ctx context.Context, host, remoteDir string, paths []string, mode RetentionLockMode, until time.Time, overrideLock bool) (int64, error) {
 	fs, remote, err := rcloneSplitRemotePath(remoteDir)
 	if err != nil {
@@ -848,12 +849,12 @@ func (c *Client) RcloneBatchRetentionLock(ctx context.Context, host, remoteDir s
 	if paths == nil {
 		paths = make([]string, 0)
 	}
-	modeParam, holdParam, err := retentionLockModeToParam(mode)
+	if mode == RetentionLockEventBasedHold {
+		return 0, errors.New("event based hold should be applied with dedicated method")
+	}
+	modeParam, _, err := retentionLockModeToParam(mode)
 	if err != nil {
 		return 0, err
-	}
-	if holdParam {
-		return 0, errors.New("event based hold should be applied with dedicated method")
 	}
 
 	p := operations.OperationsRetentionLockParams{
@@ -879,17 +880,18 @@ func (c *Client) RcloneBatchRetentionLock(ctx context.Context, host, remoteDir s
 
 // RcloneRetentionLock synchronously sets retention lock on the specified object.
 // The remotePath param format is "provider:bucket/path".
+// The mode arg can't be set to RetentionLockEventBasedHold - in such case, use RcloneEventBasedHold.
 func (c *Client) RcloneRetentionLock(ctx context.Context, host, remotePath string, mode RetentionLockMode, until time.Time, overrideLock bool) error {
 	fs, remote, err := rcloneSplitRemotePath(remotePath)
 	if err != nil {
 		return err
 	}
-	modeParam, holdParam, err := retentionLockModeToParam(mode)
+	if mode == RetentionLockEventBasedHold {
+		return errors.New("event based hold should be applied with dedicated method")
+	}
+	modeParam, _, err := retentionLockModeToParam(mode)
 	if err != nil {
 		return err
-	}
-	if holdParam {
-		return errors.New("event based hold should be applied with dedicated method")
 	}
 
 	p := operations.OperationsRetentionLockParams{

--- a/pkg/service/backup/event_based_hold_interceptor_integration_test.go
+++ b/pkg/service/backup/event_based_hold_interceptor_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -19,11 +20,14 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/scylladb/scylla-manager/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
+	"github.com/scylladb/scylla-manager/v3/pkg/sstable"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/httpx"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/agent/models"
 )
 
@@ -320,6 +324,129 @@ func TestBackupRetentionLockCRUDIntegration(t *testing.T) {
 
 	Print("Then: file has locked retention")
 	assertObjectMetadata(t, h.Client, host, remoteFile, false, string(scyllaclient.RetentionLockLocked), until)
+}
+
+func TestBackupEventBasedHoldIntegration(t *testing.T) {
+	// This test verifies basic event based hold backup flow:
+	// - newly uploaded files (manifests, schema files, sstables) have hold
+	// - deduplicated files have hold
+	// - files from non-current snapshot don't have hold
+	// - files with hold manually changed are adjusted
+	const (
+		testBucket   = "backuptest-event-based-hold"
+		testKeyspace = "backuptest_event_based_hold"
+	)
+	host := ManagedClusterHost()
+	policy := 24 * time.Hour
+	// To avoid precision error on round trip comparisons
+	baseTime := timeutc.Now().Truncate(time.Millisecond)
+
+	location := backupspec.Location{Provider: backupspec.GCS, Path: testBucket}
+	GCSInitBucket(t, testBucket)
+	h := newBackupTestHelper(t, CreateSessionWithoutMigration(t), defaultConfig(), location, nil)
+	clusterSession := CreateSessionAndDropAllKeyspaces(t, h.Client)
+
+	interceptor := newEventBasedHoldInterceptor(t, h.Hrt)
+	interceptor.defaultBucketRetentionPolicy = policy
+	interceptor.defaultEventBasedHold = true
+	interceptor.now = func() time.Time { return baseTime }
+
+	nextID := RawWriteData(t, clusterSession, testKeyspace, 0, 1, "{'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 3}", false)
+
+	Print("Given: backup target with event based hold")
+	props := defaultTestProperties(location, testKeyspace)
+	props["dc"] = []string{"dc1"}
+	props["retention"] = 0
+	props["retention_days"] = 2
+	props["method"] = backup.MethodAuto
+	rawProps, err := json.Marshal(props)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := h.service.GetTarget(t.Context(), h.ClusterID, rawProps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target.RetentionLockMode = scyllaclient.RetentionLockEventBasedHold
+	// To skip not interesting schema sstables
+	target.Units = []backup.Unit{{Keyspace: testKeyspace}}
+
+	Print("When: first backup is executed")
+	runID := uuid.NewTime()
+	if err := h.service.Backup(t.Context(), h.ClusterID, h.TaskID, runID, target); err != nil {
+		t.Fatal(err)
+	}
+	tagA, err := h.service.GetProgress(t.Context(), h.ClusterID, h.TaskID, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	Print("Then: all files from the snapshot have event based hold")
+	tagAFiles := listSnapshotFiles(t, h, tagA.SnapshotTag)
+	assertObjectMetadataAll(t, h.Client, host, location, tagAFiles, true, "", time.Time{})
+
+	tagATOCFiles := make([]string, 0)
+	for _, file := range tagAFiles {
+		if strings.HasSuffix(file, string(sstable.ComponentTOC)) {
+			tagATOCFiles = append(tagATOCFiles, file)
+		}
+	}
+	if len(tagATOCFiles) == 0 {
+		t.Fatal("Expected TOC components")
+	}
+
+	// Clearing hold only from TOC components creates inconsistent remote sstables,
+	// as all sstable components should have the same hold state.
+	// Deduplicated sstables need hold re-applied on TOC components,
+	// while non-current sstables need hold removed from the remaining components.
+	Print("When: event based hold is manually removed from every TOC component")
+	for _, file := range tagATOCFiles {
+		if err := h.Client.RcloneEventBasedHold(t.Context(), host, location.RemotePath(file), false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	assertObjectMetadataAll(t, h.Client, host, location, tagATOCFiles, false, string(scyllaclient.RetentionLockLocked), baseTime.Add(policy))
+
+	// The second backup should contain both deduplicated and new sstables
+	Print("And: small amount of new data is inserted")
+	RawWriteData(t, clusterSession, testKeyspace, nextID, 1, "{'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 3}", false)
+
+	Print("And: second backup is executed")
+	runID = uuid.NewTime()
+	if err := h.service.Backup(t.Context(), h.ClusterID, h.TaskID, runID, target); err != nil {
+		t.Fatal(err)
+	}
+	tagB, err := h.service.GetProgress(t.Context(), h.ClusterID, h.TaskID, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	Print("Then: all files from the current snapshot have event based hold")
+	tagBFiles := listSnapshotFiles(t, h, tagB.SnapshotTag)
+	assertObjectMetadataAll(t, h.Client, host, location, tagBFiles, true, "", time.Time{})
+
+	tagBFilesSet := make(map[string]struct{}, len(tagBFiles))
+	for _, file := range tagBFiles {
+		tagBFilesSet[file] = struct{}{}
+	}
+	var tagAOnlyFiles []string
+	for _, file := range tagAFiles {
+		if _, ok := tagBFilesSet[file]; !ok {
+			tagAOnlyFiles = append(tagAOnlyFiles, file)
+		}
+	}
+	if len(tagAOnlyFiles) == 0 {
+		t.Fatal("Expected some files to be present only in the first snapshot")
+	}
+
+	Print("And: files from non-current snapshots don't have event based hold")
+	assertObjectMetadataAll(t, h.Client, host, location, tagAOnlyFiles, false, string(scyllaclient.RetentionLockLocked), baseTime.Add(policy))
+}
+
+func assertObjectMetadataAll(t *testing.T, client *scyllaclient.Client, host string, location backupspec.Location, files []string, hold bool, retentionMode string, retainUntil time.Time) {
+	for _, file := range files {
+		assertObjectMetadata(t, client, host, location.RemotePath(file), hold, retentionMode, retainUntil)
+	}
 }
 
 func assertObjectMetadata(t *testing.T, client *scyllaclient.Client, host, objectPath string, hold bool, retentionMode string, retainUntil time.Time) {

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -873,6 +873,8 @@ func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID
 			Method:      target.Method,
 			Config:      s.config,
 			Client:      client,
+
+			RetentionLockMode: target.RetentionLockMode,
 		},
 		PrevStage:            run.Stage,
 		Metrics:              s.metrics,
@@ -935,6 +937,7 @@ func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID
 			if slices.Contains([]scyllaclient.RetentionLockMode{
 				scyllaclient.RetentionLockUnlocked,
 				scyllaclient.RetentionLockLocked,
+				scyllaclient.RetentionLockEventBasedHold,
 			}, target.RetentionLockMode) {
 				return w.RetentionLock(ctx, hi, target)
 			}

--- a/pkg/service/backup/worker.go
+++ b/pkg/service/backup/worker.go
@@ -72,6 +72,8 @@ type workerTools struct {
 	Config      Config
 	Client      *scyllaclient.Client
 	Logger      log.Logger
+
+	RetentionLockMode scyllaclient.RetentionLockMode
 }
 
 // worker is responsible for coordinating backup procedure.

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -121,6 +121,17 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 		if err != nil {
 			return errors.Wrap(err, "deduplication based on .crc32 content")
 		}
+		if applyHolds && willCreateVersioned {
+			// Creation of versioned sstable happens by copying old sstable version with appended version
+			// suffix, then removing the original old version, then uploading the new version.
+			// This is not compatible with event based hold backup, where default backup retention policy
+			// is expected to prevent files from being deleted.
+			return errors.Errorf("host %s: table %s.%s: snapshot contains sstables with integer based IDs which upload would result in creation of versioned files. "+
+				"Upload of such snapshot is not compatible with event based hold backup. "+
+				"To proceed, make sure that new sstables use UUID based IDs and compact the integer based sstables away. "+
+				"Then, start the backup task from scratch.", h.IP, d.Keyspace, d.Table)
+		}
+
 		d.willCreateVersioned = willCreateVersioned
 		deduplicated := make([]string, 0, len(deduplicatedUUIDSSTables)+len(deduplicatedIntSSTables))
 

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -5,6 +5,7 @@ package backup
 import (
 	"bytes"
 	"context"
+	stdErr "errors"
 	"path"
 	"slices"
 	"strconv"
@@ -61,12 +62,34 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 		d := &dirs[i]
 		dataDst := h.Location.RemotePath(w.remoteSSTableDir(h, *d))
 
+		applyHolds := w.RetentionLockMode == scyllaclient.RetentionLockEventBasedHold
+		var holdHandler *eventBasedHoldHandler
+		if applyHolds {
+			// Initialize holdHandler
+			apply := func(ctx context.Context, paths []string, hold bool) error {
+				return w.holdAndWait(ctx, h.IP, dataDst, paths, hold, d.Keyspace, d.Table)
+			}
+			holdHandler = newEventBasedHoldHandler(apply, eventBasedHoldBatchSize)
+			// Feed local files
+			for _, file := range d.Progress.files {
+				holdHandler.addLocal(file.Name)
+			}
+			for _, name := range d.ScyllaManifests {
+				holdHandler.addLocal(renameScyllaManifest(w.SnapshotTag, h.ID, name))
+			}
+			holdHandler.finalizeLocal()
+		}
+
 		remoteSSTableBundles := newSSTableBundlesByID()
 		listOpts := &scyllaclient.RcloneListDirOpts{
-			FilesOnly: true,
-			Recurse:   true,
+			FilesOnly:          true,
+			Recurse:            true,
+			ShowEventBasedHold: applyHolds,
 		}
-		if err := w.Client.RcloneListDirIter(ctx, h.IP, dataDst, listOpts, func(f *scyllaclient.RcloneListDirItem) {
+		listErr := w.Client.RcloneListDirIter(ctx, h.IP, dataDst, listOpts, func(f *scyllaclient.RcloneListDirItem) {
+			if applyHolds {
+				holdHandler.addRemote(ctx, f.Name, f.EventBasedHold)
+			}
 			// Skip scylla manifests
 			if strings.HasSuffix(f.Name, backupspec.ScyllaManifest) {
 				return
@@ -74,8 +97,16 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 			if err := remoteSSTableBundles.add(f.Name, f.Size); err != nil {
 				w.Logger.Error(ctx, "Couldn't create remote sstable bundle info", "file", f.Name, "error", err)
 			}
-		}); err != nil {
-			return errors.Wrapf(err, "host %s: listing all files from %s", h.IP, dataDst)
+		})
+		var finalizeErr error
+		if applyHolds {
+			finalizeErr = holdHandler.finalize(ctx)
+		}
+		if err := stdErr.Join(
+			errors.Wrapf(listErr, "host %s: listing all files from %s", h.IP, dataDst),
+			errors.Wrap(finalizeErr, "finalize event based holds"),
+		); err != nil {
+			return err
 		}
 
 		localSSTableBundles := newSSTableBundlesByID()

--- a/pkg/service/backup/worker_retention_lock.go
+++ b/pkg/service/backup/worker_retention_lock.go
@@ -234,6 +234,231 @@ func (w *worker) waitRetentionLockJob(ctx context.Context, host string, jobID in
 	}
 }
 
+// eventBasedHoldBatchSize defines how many files are batched together
+// before objects are sent to SM agent.
+const eventBasedHoldBatchSize = 1000
+
+// eventBasedHoldApplyFunc sets (hold=true) or removes (hold=false) event based hold on the given paths.
+type eventBasedHoldApplyFunc func(ctx context.Context, paths []string, hold bool) error
+
+type eventBasedHoldRequest struct {
+	ctx   context.Context // nolint: containedctx
+	paths []string
+	hold  bool
+}
+
+// eventBasedHoldHandler is a helper for applying event based holds.
+//
+// WORM backup created with retention locks can be inefficient in terms
+// of per-object request count, as on every backup run, we need to prolong
+// retention periods on all objects being a part of current snapshot,
+// even if they were deduplicated.
+// Backup made with scyllaclient.RetentionLockEventBasedHold aims to improve
+// this by relying on event based holds which don't need to be reset for
+// deduplicated objects, but need to be separately released when we expect
+// that the object won't be a part of next snapshots.
+// When making backup with scyllaclient.RetentionLockEventBasedHold,
+// we rely on 2 bucket level configurations:
+// - default retention period - ensures WORM backup
+// - default event based hold - optional, saves on per-object requests
+//
+// In many cases (e.g. StageDeduplicate), we operate on two groups of objects:
+// - snapshot objects located on nodes (local)
+// - already uploaded objects in the backup location (remote)
+// Other cases can usually be reduced to this one.
+// Remote objects can already have holds applies from default bucket settings
+// or from previous backup task executions.
+//
+// The table below shows what actions needs to be taken in which scenarios:
+// +----------+------------------+---------------------+-----------+
+// |          | remote with hold | remote without hold | no remote |
+// +----------+------------------+---------------------+-----------+
+// | local    | nothing          | set hold            | nothing*  |
+// | no local | remove hold      | nothing             | nothing   |
+// +----------+------------------+---------------------+-----------+
+// Hold is explicitly set only when local object has remote counterpart without hold.
+// We won't reupload the object, so we need to ensure that it has correct hold.
+// This is a rare case, but a possible one (SSTable migration back and forth,
+// file based restore, manual hold removal).
+// Hold is removed only when remote object with hold is no longer a part of local.
+// This is the common case when SSTable is compacted away.
+// The only remaining interesting case is when we have local object with no remote.
+// We don't need to apply the hold there, as we count on the default hold bucket configuration.
+// Even if it isn't set, the object would be still protected by the default retention period,
+// and if it will be a part of the next snapshot, it would fall to the case of local object
+// with remote without hold, which would apply the hold then.
+//
+// To minimize the per-object request count, we want to send requests only when needed.
+// To do that, we first cache all local files and apply the holds on they fly when reading
+// remote files (we assume that there is strictly less local than remote files).
+// We do it on the fly, as caching all remote objects results in unnecessary memory pressure.
+// Moreover, learning about remote files requires listing, which can be an iterative and time-consuming
+// operation, so it makes sense to start setting/removing needed holds while it's still ongoing.
+// SM agent endpoint responsible for handling holds has built in parallelism, so it's better to send
+// hold jobs to it in batches (aiming for minBatchSize objects per batch).
+// One important consideration is that we don't want to stall the listing because of the longer time
+// needed to apply the holds on multiple objects. Such behavior could lead to timeouts on SM agent
+// side related to a too slow receiver. Implementation takes that into consideration and
+// aggregates objects over minBatchSize when previous batch is still being processed.
+//
+// Usage contract:
+//   - feed all local files via addLocal
+//   - call finalizeLocal
+//   - feed remote files via addRemote (setting/removing holds might happen in the background)
+//   - call finalize (flush remaining batches and wait for all jobs)
+type eventBasedHoldHandler struct {
+	apply        eventBasedHoldApplyFunc
+	minBatchSize int
+
+	local     map[string]struct{}
+	localDone bool
+
+	setBatch    []string
+	removeBatch []string
+
+	reqCh chan eventBasedHoldRequest
+	done  chan error
+}
+
+func newEventBasedHoldHandler(apply eventBasedHoldApplyFunc, minBatchSize int) *eventBasedHoldHandler {
+	h := eventBasedHoldHandler{
+		apply:        apply,
+		minBatchSize: minBatchSize,
+		local:        make(map[string]struct{}),
+		setBatch:     make([]string, 0, minBatchSize),
+		removeBatch:  make([]string, 0, minBatchSize),
+		// Even though we have single worker, buffered channel
+		// allows for cheaper check if worker is busy.
+		reqCh: make(chan eventBasedHoldRequest, 1),
+		done:  make(chan error, 1),
+	}
+	go h.worker()
+	return &h
+}
+
+// addLocal records a local object name. It must be called before finalizeLocal.
+func (r *eventBasedHoldHandler) addLocal(name string) {
+	if r.localDone {
+		close(r.reqCh)
+		panic("cannot add local file after finalizeLocal")
+	}
+	r.local[name] = struct{}{}
+}
+
+// finalizeLocal marks that all local objects have already been added.
+func (r *eventBasedHoldHandler) finalizeLocal() {
+	r.localDone = true
+}
+
+// addRemote reconciles a single remote file against the local set.
+// In case remote needs its hold changed, it's recorded in the batch buffer.
+// When the buffer reaches minBatchSize, objects are sent to SM agent,
+// so that their holds can be adjusted.
+// It must be called after finalizeLocal.
+func (r *eventBasedHoldHandler) addRemote(ctx context.Context, name string, hold bool) {
+	if !r.localDone {
+		close(r.reqCh)
+		panic("cannot add remote file before finishLocal")
+	}
+	_, local := r.local[name]
+	switch {
+	case local && !hold:
+		r.setBatch = append(r.setBatch, name)
+		if len(r.setBatch) >= r.minBatchSize {
+			r.tryFlush(ctx, true)
+		}
+	case !local && hold:
+		r.removeBatch = append(r.removeBatch, name)
+		if len(r.removeBatch) >= r.minBatchSize {
+			r.tryFlush(ctx, false)
+		}
+	}
+}
+
+func (r *eventBasedHoldHandler) tryFlush(ctx context.Context, hold bool) bool { // nolint: unparam
+	if cap(r.reqCh) != 0 && len(r.reqCh) == cap(r.reqCh) {
+		// Quick check cheaper than select
+		return false
+	}
+	batch := r.batch(hold)
+	if len(batch) == 0 {
+		return false
+	}
+	select {
+	case r.reqCh <- eventBasedHoldRequest{ctx: ctx, paths: batch, hold: hold}:
+		r.resetBatch(hold)
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *eventBasedHoldHandler) flush(ctx context.Context, hold bool) error {
+	batch := r.batch(hold)
+	if len(batch) == 0 {
+		return nil
+	}
+	select {
+	case r.reqCh <- eventBasedHoldRequest{ctx: ctx, paths: batch, hold: hold}:
+		r.resetBatch(hold)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (r *eventBasedHoldHandler) batch(hold bool) []string {
+	if hold {
+		return r.setBatch
+	}
+	return r.removeBatch
+}
+
+func (r *eventBasedHoldHandler) resetBatch(hold bool) {
+	if hold {
+		r.setBatch = make([]string, 0, r.minBatchSize)
+		return
+	}
+	r.removeBatch = make([]string, 0, r.minBatchSize)
+}
+
+// worker is method executed in a dedicated goroutine responsible
+// for applying the batches. It returns the first encountered
+// error, but keeps on applying the batches until reqCh is closed.
+func (r *eventBasedHoldHandler) worker() {
+	var err error
+	setErr := func(e error) {
+		if err == nil {
+			err = e
+		}
+	}
+
+	for req := range r.reqCh {
+		paths := req.paths
+		for len(paths) > 0 {
+			if err := req.ctx.Err(); err != nil {
+				setErr(err)
+				break
+			}
+
+			size := min(len(paths), r.minBatchSize)
+			batch := paths[:size]
+			paths = paths[size:]
+
+			setErr(r.apply(req.ctx, batch, req.hold))
+		}
+	}
+	r.done <- err
+}
+
+// finalize flushes the remaining batches and waits for SM agent requests to finish.
+func (r *eventBasedHoldHandler) finalize(ctx context.Context) error {
+	flushSetErr := errors.Wrap(r.flush(ctx, true), "flush set hold batch")
+	flushRemoveErr := errors.Wrap(r.flush(ctx, false), "flush remove hold batch")
+	close(r.reqCh)
+	return stdErr.Join(<-r.done, flushSetErr, flushRemoveErr)
+}
+
 func retentionLockUntil(snapshotTag string, retentionDays int) (time.Time, error) {
 	snapshotTime, err := backupspec.SnapshotTagTime(snapshotTag)
 	if err != nil {

--- a/pkg/service/backup/worker_retention_lock.go
+++ b/pkg/service/backup/worker_retention_lock.go
@@ -25,14 +25,16 @@ type retentionLockConfig struct {
 // Schema files are locked first, then sstables and scylla manifests,
 // finalizing with SM manifests.
 func (w *worker) RetentionLock(egCtx context.Context, hosts []hostInfo, target Target) error {
-	lockUntil, err := retentionLockUntil(w.SnapshotTag, target.RetentionDays)
-	if err != nil {
-		return err
-	}
 	cfg := retentionLockConfig{
-		until:    lockUntil,
 		mode:     target.RetentionLockMode,
 		override: target.OverrideRetentionLock,
+	}
+	if cfg.mode == scyllaclient.RetentionLockUnlocked || cfg.mode == scyllaclient.RetentionLockLocked {
+		lockUntil, err := retentionLockUntil(w.SnapshotTag, target.RetentionDays)
+		if err != nil {
+			return err
+		}
+		cfg.until = lockUntil
 	}
 
 	// Lock schema files separately, as they are per location, not per host
@@ -78,8 +80,41 @@ func (w *worker) lockSchemaFiles(ctx context.Context, hosts []hostInfo, cfg rete
 		}
 		remoteSchemaDir := hosts[i].Location.RemotePath(path.Dir(cqlPath))
 
-		if err := w.lockAndAwait(ctx, hosts[i].IP, remoteSchemaDir, paths, cfg, "", ""); err != nil {
-			return errors.Wrapf(err, "await retention lock with node %s", hosts[i].IP)
+		switch cfg.mode {
+		case scyllaclient.RetentionLockUnlocked, scyllaclient.RetentionLockLocked:
+			if err := w.batchLock(ctx, hosts[i].IP, remoteSchemaDir, paths, cfg, "", ""); err != nil {
+				return errors.Wrapf(err, "await retention lock with node %s", hosts[i].IP)
+			}
+		case scyllaclient.RetentionLockEventBasedHold:
+			// Initialize holdHandler
+			apply := func(ctx context.Context, paths []string, hold bool) error {
+				return w.holdAndWait(ctx, hosts[i].IP, remoteSchemaDir, paths, hold, "", "")
+			}
+			holdHandler := newEventBasedHoldHandler(apply, eventBasedHoldBatchSize)
+			// Feed local files - even though schema files have already been uploaded,
+			// we still treat them as local for the purposes of applying/removing the hold.
+			for _, p := range paths {
+				holdHandler.addLocal(p)
+			}
+			holdHandler.finalizeLocal()
+			// Feed remote files - limit to schema files coming from the same task ID,
+			// so that behavior is consistent with SM manifest holds.
+			opts := &scyllaclient.RcloneListDirOpts{
+				FilesOnly:          true,
+				ShowEventBasedHold: true,
+			}
+			listErr := w.Client.RcloneListDirIter(ctx, hosts[i].IP, remoteSchemaDir, opts, func(item *scyllaclient.RcloneListDirItem) {
+				taskID, _, err := ParseSchemaFileName(item.Name)
+				if err == nil && taskID == w.TaskID {
+					holdHandler.addRemote(ctx, item.Name, item.EventBasedHold)
+				}
+			})
+			if err := stdErr.Join(
+				errors.Wrap(listErr, "list schema files holds"),
+				errors.Wrap(holdHandler.finalize(ctx), "finalize remote schema files holds"),
+			); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -89,36 +124,69 @@ func (w *worker) lockSchemaFiles(ctx context.Context, hosts []hostInfo, cfg rete
 func (w *worker) lockHostFiles(ctx context.Context, h *hostInfo, cfg retentionLockConfig) (err error) {
 	w.Logger.Info(ctx, "Locking host files", "host", h.IP)
 
-	// As we want to make this stage resumable, to discover files that
-	// need to be locked, we need to download manifest from backup location.
 	manifestPath := backupspec.RemoteManifestFile(w.ClusterID, w.TaskID, w.SnapshotTag, h.DC, h.ID)
 	remoteManifestPath := h.Location.RemotePath(manifestPath)
+	remoteManifestDir := path.Dir(remoteManifestPath)
+	switch cfg.mode {
+	case scyllaclient.RetentionLockUnlocked, scyllaclient.RetentionLockLocked:
+		// As we want to make this stage resumable, to discover files that
+		// need to be locked, we need to download manifest from backup location.
+		r, err := w.Client.RcloneOpen(ctx, h.IP, remoteManifestPath)
+		if err != nil {
+			return errors.Wrap(err, "download manifest")
+		}
+		defer func() {
+			err = stdErr.Join(err, r.Close())
+		}()
 
-	r, err := w.Client.RcloneOpen(ctx, h.IP, remoteManifestPath)
-	if err != nil {
-		return errors.Wrap(err, "download manifest")
-	}
-	defer func() {
-		err = stdErr.Join(err, r.Close())
-	}()
+		var manifest backupspec.ManifestContentWithIndex
+		if err := manifest.Read(r); err != nil {
+			return errors.Wrap(err, "read manifest")
+		}
 
-	var manifest backupspec.ManifestContentWithIndex
-	if err := manifest.Read(r); err != nil {
-		return errors.Wrap(err, "read manifest")
-	}
+		// Lock sstables and scylla manifests
+		err = manifest.ForEachIndexIterWithError(nil, func(fm backupspec.FilesMeta) error {
+			return errors.Wrapf(w.lockTableFiles(ctx, h, fm, cfg), "lock table %s.%s files", fm.Keyspace, fm.Table)
+		})
+		if err != nil {
+			return errors.Wrap(err, "lock index files")
+		}
 
-	// Lock sstables and scylla manifests
-	err = manifest.ForEachIndexIterWithError(nil, func(fm backupspec.FilesMeta) error {
-		return errors.Wrapf(w.lockTableFiles(ctx, h, fm, cfg), "lock table %s.%s files", fm.Keyspace, fm.Table)
-	})
-	if err != nil {
-		return errors.Wrap(err, "lock index files")
-	}
-
-	// Lock SM manifest
-	w.Logger.Info(ctx, "Locking manifest file", "host", h.IP)
-	if err := w.lockAndAwait(ctx, h.IP, path.Dir(remoteManifestPath), []string{path.Base(remoteManifestPath)}, cfg, "", ""); err != nil {
-		return errors.Wrap(err, "lock manifest")
+		// Lock SM manifest
+		w.Logger.Info(ctx, "Locking manifest file", "host", h.IP)
+		if err := w.lockAndAwait(ctx, h.IP, remoteManifestDir, []string{path.Base(remoteManifestPath)}, cfg, "", ""); err != nil {
+			return errors.Wrap(err, "lock manifest")
+		}
+	case scyllaclient.RetentionLockEventBasedHold:
+		// Initialize holdHandler
+		apply := func(ctx context.Context, paths []string, hold bool) error {
+			return w.holdAndWait(ctx, h.IP, remoteManifestDir, paths, hold, "", "")
+		}
+		holdHandler := newEventBasedHoldHandler(apply, eventBasedHoldBatchSize)
+		// Feed local files - even though manifests have already been uploaded,
+		// we still treat them as local for the purposes of applying/removing the hold.
+		holdHandler.addLocal(path.Base(remoteManifestPath))
+		holdHandler.finalizeLocal()
+		// Feed remote files - limit to manifests coming from the same task ID,
+		// so that we reduce interference between multiple backup tasks.
+		opts := &scyllaclient.RcloneListDirOpts{
+			FilesOnly:          true,
+			ShowEventBasedHold: true,
+		}
+		listErr := w.Client.RcloneListDirIter(ctx, h.IP, remoteManifestDir, opts, func(item *scyllaclient.RcloneListDirItem) {
+			var mi backupspec.ManifestInfo
+			err := mi.ParsePath(path.Join(path.Dir(manifestPath), item.Name))
+			if err == nil && mi.TaskID == w.TaskID {
+				holdHandler.addRemote(ctx, item.Name, item.EventBasedHold)
+			}
+		})
+		err := stdErr.Join(
+			errors.Wrap(listErr, "list manifests holds"),
+			errors.Wrap(holdHandler.finalize(ctx), "finalize remote manifests holds"),
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -180,12 +248,20 @@ func (w *worker) lockAndAwait(ctx context.Context, host, remoteDir string,
 	if err != nil {
 		return errors.Wrap(err, "schedule retention lock job")
 	}
-	return w.waitRetentionLockJob(ctx, host, jobID, keyspace, table)
+	return w.waitRetentionJob(ctx, host, jobID, keyspace, table)
 }
 
-// waitRetentionLockJob polls the async retention lock job until completion,
+func (w *worker) holdAndWait(ctx context.Context, host, remoteDir string, paths []string, hold bool, keyspace, table string) error {
+	jobID, err := w.Client.RcloneBatchEventBasedHold(ctx, host, remoteDir, paths, hold)
+	if err != nil {
+		return errors.Wrap(err, "schedule event based hold job")
+	}
+	return w.waitRetentionJob(ctx, host, jobID, keyspace, table)
+}
+
+// waitRetentionJob polls the async retention lock job until completion,
 // updating the retention_locked_files metric on each poll.
-func (w *worker) waitRetentionLockJob(ctx context.Context, host string, jobID int64, keyspace, table string) (err error) {
+func (w *worker) waitRetentionJob(ctx context.Context, host string, jobID int64, keyspace, table string) (err error) {
 	defer func() {
 		if err != nil {
 			w.Logger.Info(ctx, "Stop job", "host", host, "id", jobID)

--- a/pkg/service/backup/worker_retention_lock_test.go
+++ b/pkg/service/backup/worker_retention_lock_test.go
@@ -1,14 +1,306 @@
 // Copyright (C) 2026 ScyllaDB
 
-package backup_test
+package backup
 
 import (
+	"context"
+	"errors"
+	"reflect"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/scylladb/scylla-manager/backupspec"
-	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
 )
+
+type holdCall struct {
+	paths []string
+	hold  bool
+}
+
+func TestEventBasedHoldHandler(t *testing.T) {
+	t.Parallel()
+
+	type remoteObject struct {
+		name string
+		hold bool
+	}
+	testCases := []struct {
+		name      string
+		batchSize int
+		local     []string
+		remote    []remoteObject
+		expected  []holdCall
+	}{
+		{
+			name:      "sets missing holds and removes stale holds",
+			batchSize: 10,
+			local:     []string{"a", "b"},
+			remote: []remoteObject{
+				{name: "a", hold: false},
+				{name: "b", hold: true},
+				{name: "c", hold: true},
+				{name: "d", hold: false},
+			},
+			expected: []holdCall{
+				{paths: []string{"a"}, hold: true},
+				{paths: []string{"c"}, hold: false},
+			},
+		},
+		{
+			name:      "flushes full batches while streaming",
+			batchSize: 2,
+			local:     []string{"a", "b", "c"},
+			remote: []remoteObject{
+				{name: "a", hold: false},
+				{name: "b", hold: false},
+				{name: "x", hold: true},
+				{name: "y", hold: true},
+				{name: "c", hold: false},
+				{name: "z", hold: true},
+			},
+			expected: []holdCall{
+				{paths: []string{"a", "b"}, hold: true},
+				{paths: []string{"x", "y"}, hold: false},
+				{paths: []string{"c"}, hold: true},
+				{paths: []string{"z"}, hold: false},
+			},
+		},
+		{
+			name:      "does not call apply for no-op states",
+			batchSize: 2,
+			local:     []string{"a"},
+			remote: []remoteObject{
+				{name: "a", hold: true},
+				{name: "b", hold: false},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got []holdCall
+			apply := func(_ context.Context, paths []string, hold bool) error {
+				got = append(got, holdCall{
+					paths: append([]string{}, paths...),
+					hold:  hold,
+				})
+				return nil
+			}
+			h := newEventBasedHoldHandler(apply, tc.batchSize)
+			for _, name := range tc.local {
+				h.addLocal(name)
+			}
+			h.finalizeLocal()
+			for _, remote := range tc.remote {
+				h.addRemote(t.Context(), remote.name, remote.hold)
+			}
+			if err := h.finalize(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+
+			sortByHold(got)
+			sortByHold(tc.expected)
+			if !reflect.DeepEqual(got, tc.expected) {
+				t.Fatalf("got %+v, expected %+v", got, tc.expected)
+			}
+		})
+	}
+}
+
+// sortByHold ensures that holdCall elements are grouped by hold state.
+// eventBasedHoldHandler applies holds in FIFO order for objects batched
+// with the same hold state, but that's not necessarily the case for objects
+// with different hold state, as they are batched separately.
+func sortByHold(calls []holdCall) {
+	slices.SortStableFunc(calls, func(a, b holdCall) int {
+		switch {
+		case a.hold && !b.hold:
+			return -1
+		case !a.hold && b.hold:
+			return 1
+		default:
+			return 0
+		}
+	})
+}
+
+// TestEventBasedHoldHandlerApplyErrorDrainsRequests validates that a failing apply
+// doesn't stall the handler - all pending requests are still consumed by the worker
+// and the first error is returned.
+func TestEventBasedHoldHandlerApplyError(t *testing.T) {
+	t.Parallel()
+
+	firstErr := errors.New("first apply failed")
+	secondErr := errors.New("second apply failed")
+
+	var got []holdCall
+	applyErrs := []error{firstErr, secondErr}
+	apply := func(_ context.Context, paths []string, hold bool) error {
+		got = append(got, holdCall{paths: slices.Clone(paths), hold: hold})
+		if len(applyErrs) == 0 {
+			return nil
+		}
+		err := applyErrs[0]
+		applyErrs = applyErrs[1:]
+		return err
+	}
+
+	h := newEventBasedHoldHandler(apply, 1)
+	for _, name := range []string{"a", "b", "c"} {
+		h.addLocal(name)
+	}
+	h.finalizeLocal()
+	for _, name := range []string{"a", "b", "c"} {
+		h.addRemote(t.Context(), name, false)
+	}
+
+	err := h.finalize(t.Context())
+	if !errors.Is(err, firstErr) {
+		t.Fatalf("got %v, expected %v", err, firstErr)
+	}
+	if errors.Is(err, secondErr) {
+		t.Fatalf("got %v, expected only the first apply error", err)
+	}
+
+	expected := []holdCall{
+		{paths: []string{"a"}, hold: true},
+		{paths: []string{"b"}, hold: true},
+		{paths: []string{"c"}, hold: true},
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("got %+v, expected %+v", got, expected)
+	}
+}
+
+// TestEventBasedHoldHandlerContextCancel validates that a canceled context
+// unblocks flush waiting for a busy worker, that the worker skips not yet
+// applied requests, and that finalize still cleans the worker goroutine up.
+func TestEventBasedHoldHandlerContextCancel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	var (
+		mu           sync.Mutex
+		got          []holdCall
+		busy         = make(chan struct{})
+		releaseApply = make(chan struct{})
+	)
+	apply := func(_ context.Context, paths []string, hold bool) error {
+		mu.Lock()
+		got = append(got, holdCall{paths: slices.Clone(paths), hold: hold})
+		mu.Unlock()
+		close(busy)
+		<-releaseApply
+		return nil
+	}
+
+	h := newEventBasedHoldHandler(apply, 1)
+	for _, name := range []string{"a", "b", "c"} {
+		h.addLocal(name)
+	}
+	h.finalizeLocal()
+	// "a" is taken by the worker, which blocks inside apply.
+	h.addRemote(ctx, "a", false)
+
+	select {
+	case <-busy:
+	case <-time.After(time.Second):
+		t.Fatal("worker wasn't busy")
+	}
+
+	// "b" fills the request channel buffer.
+	h.addRemote(ctx, "b", false)
+	// "c" can't be handed over to the busy worker, so it stays in the batch buffer.
+	h.addRemote(ctx, "c", false)
+
+	cancel()
+
+	// Flushing "c" can't succeed, as the worker is still busy,
+	// so it must return because of the canceled context.
+	flushErr := make(chan error, 1)
+	go func() { flushErr <- h.flush(ctx, true) }()
+
+	select {
+	case err := <-flushErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, expected %v", err, context.Canceled)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("flush blocked")
+	}
+
+	close(releaseApply)
+	finalizeErr := make(chan error, 1)
+	go func() { finalizeErr <- h.finalize(ctx) }()
+
+	select {
+	case err := <-finalizeErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, expected %v", err, context.Canceled)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("finalize blocked")
+	}
+
+	// Only "a" made it to apply before the cancellation,
+	// "b" and "c" must have been skipped by the worker.
+	if expected := []holdCall{{paths: []string{"a"}, hold: true}}; !reflect.DeepEqual(got, expected) {
+		t.Fatalf("got %+v, expected %+v", got, expected)
+	}
+}
+
+func TestEventBasedHoldHandlerAddRemoteDoesNotBlockOnApply(t *testing.T) {
+	t.Parallel()
+
+	releaseApply := make(chan struct{})
+	applyCalls := make(chan []string, 4)
+	apply := func(_ context.Context, paths []string, _ bool) error {
+		<-releaseApply
+		applyCalls <- append([]string{}, paths...)
+		return nil
+	}
+
+	h := newEventBasedHoldHandler(apply, 1)
+	h.addLocal("a")
+	h.addLocal("b")
+	h.addLocal("c")
+	h.addLocal("d")
+	h.finalizeLocal()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		h.addRemote(t.Context(), "a", false)
+		h.addRemote(t.Context(), "b", false)
+		h.addRemote(t.Context(), "c", false)
+		h.addRemote(t.Context(), "d", false)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("addRemote blocked")
+	}
+
+	close(releaseApply)
+	if err := h.finalize(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	close(applyCalls)
+	var got [][]string
+	for call := range applyCalls {
+		got = append(got, call)
+	}
+	if expected := [][]string{{"a"}, {"b"}, {"c"}, {"d"}}; !reflect.DeepEqual(got, expected) {
+		t.Fatalf("got calls %v, expected %v", got, expected)
+	}
+}
 
 func TestRetentionLockUntil(t *testing.T) {
 	t.Parallel()
@@ -59,7 +351,7 @@ func TestRetentionLockUntil(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := backup.RetentionLockUntil(tc.snapshotTag, tc.retentionDays)
+			got, err := RetentionLockUntil(tc.snapshotTag, tc.retentionDays)
 			if tc.err {
 				if err == nil {
 					t.Fatal("expected error, got nil")


### PR DESCRIPTION
This PR adds the basic flow of setting/removing event based holds during backup task execution.

It adds the `event-based-hold` retention lock mode that is not exposed to users, as the feature is not complete yet.

The original design required listing all current backup dirs to check current hold states and reconcile them. This is needed for WORM compliance, but listing such a large dirs might be time consuming. Because of that, I integrated this listing with the one already performed during deduplication, so that we get it for "free".

Note that this PR only adds the basic flow of setting/removing retention locks.
Changes related to handling non-current snapshot dirs, .tmp manifests, manifest protection, etc. will be added in later PRs.

All copilot comments are addressed, but I left the more interesting ones opened for visibility. 

Fixes https://scylladb.atlassian.net/browse/CLOUD-2891