### PR TITLE
test: refresh permissions between table creation

### DIFF
--- a/pkg/service/restore/restore_method_integration_test.go
+++ b/pkg/service/restore/restore_method_integration_test.go
@@ -278,7 +278,6 @@ func TestRestoreFullChangingMethodIntegration(t *testing.T) {
 		},
 	}
 	grantRestoreSchemaPermissions(t, h.dstCluster.rootSession, h.dstUser)
-	grantRestoreTablesPermissions(t, h.dstCluster.rootSession, ksFilter, h.dstUser)
 
 	type testIter struct {
 		backupMethod backup.Method
@@ -305,6 +304,7 @@ func TestRestoreFullChangingMethodIntegration(t *testing.T) {
 		h.runRestore(t, restoreProps)
 
 		t.Log("Restore tables: ", i)
+		grantRestoreTablesPermissions(t, h.dstCluster.rootSession, ksFilter, h.dstUser)
 		restoreProps = defaultTestProperties(loc, tag, true)
 		h.runRestore(t, restoreProps)
 


### PR DESCRIPTION
`TestRestoreFullChangingMethodIntegration` behaved flaky recently. Even though a few initial restore table could succeed, it could fail on the last one on permissions' error.

In this test, we drop and re-create the tables constantly. This also drops their permissions configuration.
The test worked because the same user also re-created those tables and was granted all their permissions by default. It might be that such permissions are not instantly propagated to all other nodes and depending on which node the alter schema query is routed to, the test might fail.

To fix that, we could either make an explicit raft read barrier on all nodes, or just re-apply the needed permissions, as explicit permissions changes also result in raft read barrier being performed underneath. I chose the second approach, because it requires only a single API call and is more explicit in terms of what permissions are expected from the restore user instead of relying on the default permissions granted on schema restore.

Fixes https://scylladb.atlassian.net/browse/CLOUD-3264
