### PR TITLE
Don't return an error on all busy CPUs

### DIFF
--- a/v3/pkg/util/cpuset/cpuset_linux.go
+++ b/v3/pkg/util/cpuset/cpuset_linux.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 //go:build linux
 // +build linux
 
@@ -14,10 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// AvailableCPUs returns a list of CPUs of length wantCPUs that does not contain
-// any of the busyCPUs. If the conditions cannot be met error is returned.
-// AvailableCPUs selects the CPUs with the highest available indexes to offload
-// shard 0...
+// AvailableCPUs returns a list of CPUs that does not contain any of the busyCPUs.
 func AvailableCPUs(busyCPUs []int) ([]int, error) {
 	var cpus unix.CPUSet
 	if err := unix.SchedGetaffinity(os.Getpid(), &cpus); err != nil {
@@ -25,11 +22,6 @@ func AvailableCPUs(busyCPUs []int) ([]int, error) {
 	}
 	for _, c := range busyCPUs {
 		cpus.Clear(c)
-	}
-
-	n := cpus.Count()
-	if n == 0 {
-		return nil, errors.Errorf("no available CPUs")
 	}
 
 	return cpulist(&cpus), nil

--- a/v3/pkg/util/cpuset/cpuset_linux_test.go
+++ b/v3/pkg/util/cpuset/cpuset_linux_test.go
@@ -36,6 +36,23 @@ func TestAvailableCPUs(t *testing.T) {
 	}
 }
 
+func TestAvailableCPUsAllBusy(t *testing.T) {
+	t.Parallel()
+
+	var cpus unix.CPUSet
+	if err := unix.SchedGetaffinity(0, &cpus); err != nil {
+		t.Fatal(err)
+	}
+
+	a, err := AvailableCPUs(cpulist(&cpus))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(a) != 0 {
+		t.Fatalf("expected no available CPUs, got %d", len(a))
+	}
+}
+
 func TestSchedSetAffinity(t *testing.T) {
 	var cpus unix.CPUSet
 	if err := unix.SchedGetaffinity(0, &cpus); err != nil {


### PR DESCRIPTION
In some (small) setups, we might not have any entirely free
CPUs to pin SM agent to. The codebase already handles it in 
findAndPinCPUs by not pinning to any specific CPU, but
setting runtime.GOMAXPROCS(1). So the codebase expects
that there might be no free CPUs to pin to and handles
this correctly. Not to mention, that the pinning error
is ignored in SM agent startup.

This commit removes the error returned by AvailableCPUs
when there is no free CPU. This was not visible on SM
agent startup, as the pinning error is simply ignored
there. It was visible in SM error logs when trying
to re-pin SM agent to CPUs after 1-1 or regular restore
tasks, but it didn't cause any failures.

This commit also adjusts AvailableCPUs comment, so that
it doesn't provide outdated information on AvailableCPUs
behavior.

Note that this is a change in vendored SM submodule,
so the actual fix will land on SM master only after
the module version is bumped.

Fixes https://scylladb.atlassian.net/browse/CLOUD-2380