### PR TITLE
Handle protected manifests

### DIFF
--- a/pkg/scyllaclient/client_rclone.go
+++ b/pkg/scyllaclient/client_rclone.go
@@ -736,10 +736,11 @@ func (c *Client) RcloneListDirIter(ctx context.Context, host, remotePath string,
 // PermissionCheckOpts describes permission check options.
 type PermissionCheckOpts struct {
 	// CheckRetention controls if the permission related to given retention mode is granted.
-	// Empty value is translated to RetentionLockDisabled.
-	CheckRetention RetentionLockMode
+	CheckRetention RetentionMode
 	// CheckOverrideRetentionLock controls if the permission to override unlocked retention lock is granted.
 	CheckOverrideRetentionLock bool
+	// CheckEventBasedHold controls if the permissions to set and clear event based hold are granted.
+	CheckEventBasedHold bool
 }
 
 // RcloneCheckPermissions checks if location is available for listing, getting,
@@ -749,11 +750,7 @@ func (c *Client) RcloneCheckPermissions(ctx context.Context, host, remotePath st
 	if err != nil {
 		return err
 	}
-	if opts.CheckRetention == "" {
-		opts.CheckRetention = RetentionLockDisabled
-	}
-	modeParam, holdParam, err := retentionLockModeToParam(opts.CheckRetention)
-	if err != nil {
+	if err := opts.CheckRetention.validate(); err != nil {
 		return err
 	}
 
@@ -762,9 +759,9 @@ func (c *Client) RcloneCheckPermissions(ctx context.Context, host, remotePath st
 		Options: &models.CheckPermissionsOptions{
 			Fs:               fs,
 			Remote:           remote,
-			RetentionMode:    modeParam,
+			RetentionMode:    string(opts.CheckRetention),
 			OverrideUnlocked: opts.CheckOverrideRetentionLock,
-			EventBasedHold:   holdParam,
+			EventBasedHold:   opts.CheckEventBasedHold,
 		},
 	}
 	_, err = c.agentOps.OperationsCheckPermissions(&p)
@@ -806,42 +803,31 @@ func (c *Client) RclonePut(ctx context.Context, host, remotePath string, body *b
 	return nil
 }
 
-// RetentionLockMode describes the object retention lock mode for backup files.
-type RetentionLockMode string
+// RetentionMode describes the object retention lock mode.
+type RetentionMode string
 
 const (
-	// RetentionLockDisabled means that no retention lock is applied to backup files.
-	RetentionLockDisabled RetentionLockMode = "disabled"
-	// RetentionLockUnlocked means that retention lock is applied but can be overridden with special permissions.
-	RetentionLockUnlocked RetentionLockMode = "unlocked"
-	// RetentionLockLocked means that retention lock is applied and cannot be overridden.
-	RetentionLockLocked RetentionLockMode = "locked"
-	// RetentionLockEventBasedHold means that backup files are protected with default
-	// event based hold and bucket retention policy. SM is responsible for clearing
-	// the hold when it's no longer needed which starts bucket retention timer.
-	RetentionLockEventBasedHold RetentionLockMode = "event-based-hold"
+	// RetentionModeNone means that no retention lock is applied.
+	RetentionModeNone RetentionMode = ""
+	// RetentionModeUnlocked means that retention lock is applied but can be overridden with special permissions.
+	RetentionModeUnlocked RetentionMode = "unlocked"
+	// RetentionModeLocked means that retention lock is applied and cannot be overridden.
+	RetentionModeLocked RetentionMode = "locked"
 )
 
-func retentionLockModeToParam(mode RetentionLockMode) (modeParam string, holdParam bool, err error) {
-	switch mode {
-	case RetentionLockDisabled:
-		return "", false, nil
-	case RetentionLockUnlocked:
-		return "unlocked", false, nil
-	case RetentionLockLocked:
-		return "locked", false, nil
-	case RetentionLockEventBasedHold:
-		return "", true, nil
+func (m RetentionMode) validate() error {
+	switch m {
+	case RetentionModeNone, RetentionModeUnlocked, RetentionModeLocked:
+		return nil
 	default:
-		return "", false, errors.Errorf("unknown retention lock mode: %s", mode)
+		return errors.Errorf("unknown retention mode: %s", m)
 	}
 }
 
 // RcloneBatchRetentionLock sets object retention locks on the specified paths.
 // The remoteDir param format is "provider:bucket/path".
 // Specified paths are relative to remoteDir.
-// The mode arg can't be set to RetentionLockEventBasedHold - in such case, use RcloneBatchEventBasedHold.
-func (c *Client) RcloneBatchRetentionLock(ctx context.Context, host, remoteDir string, paths []string, mode RetentionLockMode, until time.Time, overrideLock bool) (int64, error) {
+func (c *Client) RcloneBatchRetentionLock(ctx context.Context, host, remoteDir string, paths []string, mode RetentionMode, until time.Time, overrideLock bool) (int64, error) {
 	fs, remote, err := rcloneSplitRemotePath(remoteDir)
 	if err != nil {
 		return 0, err
@@ -849,11 +835,7 @@ func (c *Client) RcloneBatchRetentionLock(ctx context.Context, host, remoteDir s
 	if paths == nil {
 		paths = make([]string, 0)
 	}
-	if mode == RetentionLockEventBasedHold {
-		return 0, errors.New("event based hold should be applied with dedicated method")
-	}
-	modeParam, _, err := retentionLockModeToParam(mode)
-	if err != nil {
+	if err := mode.validate(); err != nil {
 		return 0, err
 	}
 
@@ -863,7 +845,7 @@ func (c *Client) RcloneBatchRetentionLock(ctx context.Context, host, remoteDir s
 			Fs:               fs,
 			Remote:           remote,
 			Paths:            paths,
-			RetentionMode:    modeParam,
+			RetentionMode:    string(mode),
 			RetainUntil:      strfmt.DateTime(until),
 			OverrideUnlocked: overrideLock,
 		},
@@ -880,17 +862,12 @@ func (c *Client) RcloneBatchRetentionLock(ctx context.Context, host, remoteDir s
 
 // RcloneRetentionLock synchronously sets retention lock on the specified object.
 // The remotePath param format is "provider:bucket/path".
-// The mode arg can't be set to RetentionLockEventBasedHold - in such case, use RcloneEventBasedHold.
-func (c *Client) RcloneRetentionLock(ctx context.Context, host, remotePath string, mode RetentionLockMode, until time.Time, overrideLock bool) error {
+func (c *Client) RcloneRetentionLock(ctx context.Context, host, remotePath string, mode RetentionMode, until time.Time, overrideLock bool) error {
 	fs, remote, err := rcloneSplitRemotePath(remotePath)
 	if err != nil {
 		return err
 	}
-	if mode == RetentionLockEventBasedHold {
-		return errors.New("event based hold should be applied with dedicated method")
-	}
-	modeParam, _, err := retentionLockModeToParam(mode)
-	if err != nil {
+	if err := mode.validate(); err != nil {
 		return err
 	}
 
@@ -900,7 +877,7 @@ func (c *Client) RcloneRetentionLock(ctx context.Context, host, remotePath strin
 			Fs:               fs,
 			Remote:           path.Dir(remote),
 			Paths:            []string{path.Base(remote)},
-			RetentionMode:    modeParam,
+			RetentionMode:    string(mode),
 			RetainUntil:      strfmt.DateTime(until),
 			OverrideUnlocked: overrideLock,
 		},

--- a/pkg/service/backup/event_based_hold_interceptor_integration_test.go
+++ b/pkg/service/backup/event_based_hold_interceptor_integration_test.go
@@ -271,7 +271,7 @@ func TestBackupEventBasedHoldInterceptorIntegration(t *testing.T) {
 	interceptor.now = func() time.Time { return baseTime.Add(10 * policy) }
 
 	Print("Then: file has retention lock and no event based hold")
-	assertObjectMetadata(t, h.Client, host, remoteFile, false, string(scyllaclient.RetentionLockLocked), baseTime.Add(policy))
+	assertObjectMetadata(t, h.Client, host, remoteFile, false, string(scyllaclient.RetentionModeLocked), baseTime.Add(policy))
 
 	Print("When: event based hold is re-applied")
 	if err := h.Client.RcloneEventBasedHold(t.Context(), host, remoteFile, true); err != nil {
@@ -310,20 +310,20 @@ func TestBackupRetentionLockCRUDIntegration(t *testing.T) {
 
 	Print("When: unlocked retention is applied")
 	until := timeutc.Now().Add(24 * time.Hour).Truncate(time.Second)
-	if err := h.Client.RcloneRetentionLock(t.Context(), host, remoteFile, scyllaclient.RetentionLockUnlocked, until, false); err != nil {
+	if err := h.Client.RcloneRetentionLock(t.Context(), host, remoteFile, scyllaclient.RetentionModeUnlocked, until, false); err != nil {
 		t.Fatal(err)
 	}
 
 	Print("Then: file has unlocked retention")
-	assertObjectMetadata(t, h.Client, host, remoteFile, false, string(scyllaclient.RetentionLockUnlocked), until)
+	assertObjectMetadata(t, h.Client, host, remoteFile, false, string(scyllaclient.RetentionModeUnlocked), until)
 
 	Print("When: retention is upgraded to locked")
-	if err := h.Client.RcloneRetentionLock(t.Context(), host, remoteFile, scyllaclient.RetentionLockLocked, until, true); err != nil {
+	if err := h.Client.RcloneRetentionLock(t.Context(), host, remoteFile, scyllaclient.RetentionModeLocked, until, true); err != nil {
 		t.Fatal(err)
 	}
 
 	Print("Then: file has locked retention")
-	assertObjectMetadata(t, h.Client, host, remoteFile, false, string(scyllaclient.RetentionLockLocked), until)
+	assertObjectMetadata(t, h.Client, host, remoteFile, false, string(scyllaclient.RetentionModeLocked), until)
 }
 
 func TestBackupEventBasedHoldIntegration(t *testing.T) {
@@ -367,7 +367,7 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	target.RetentionLockMode = scyllaclient.RetentionLockEventBasedHold
+	target.RetentionLockMode = backup.RetentionLockEventBasedHold
 	// To skip not interesting schema sstables
 	target.Units = []backup.Unit{{Keyspace: testKeyspace}}
 
@@ -405,7 +405,7 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	assertObjectMetadataAll(t, h.Client, host, location, tagATOCFiles, false, string(scyllaclient.RetentionLockLocked), baseTime.Add(policy))
+	assertObjectMetadataAll(t, h.Client, host, location, tagATOCFiles, false, string(scyllaclient.RetentionModeLocked), baseTime.Add(policy))
 
 	// The second backup should contain both deduplicated and new sstables
 	Print("And: small amount of new data is inserted")
@@ -440,7 +440,7 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 	}
 
 	Print("And: files from non-current snapshots don't have event based hold")
-	assertObjectMetadataAll(t, h.Client, host, location, tagAOnlyFiles, false, string(scyllaclient.RetentionLockLocked), baseTime.Add(policy))
+	assertObjectMetadataAll(t, h.Client, host, location, tagAOnlyFiles, false, string(scyllaclient.RetentionModeLocked), baseTime.Add(policy))
 }
 
 func assertObjectMetadataAll(t *testing.T, client *scyllaclient.Client, host string, location backupspec.Location, files []string, hold bool, retentionMode string, retainUntil time.Time) {

--- a/pkg/service/backup/list.go
+++ b/pkg/service/backup/list.go
@@ -73,15 +73,6 @@ func listRemoteManifestsInAllLocations(ctx context.Context, client *scyllaclient
 	return manifests, nil
 }
 
-// listManifests is a type wrapper for listRemoteManifests.
-func listManifests(ctx context.Context, client *scyllaclient.Client, host string, location backupspec.Location, clusterID uuid.UUID) ([]*backupspec.ManifestInfo, error) {
-	manifests, err := listRemoteManifests(ctx, client, host, location, clusterID)
-	if err != nil {
-		return nil, err
-	}
-	return manifestInfos(manifests), nil
-}
-
 // listRemoteManifests returns remote manifests for all nodes of a given cluster in the location.
 // Manifests are sorted deterministically by their ClusterID, TaskID, SnapshotTag and NodeID.
 // If cluster is uuid.Nil then it returns manifests for all clusters it can find.
@@ -251,6 +242,14 @@ func groupManifestsByTask(manifests []*backupspec.ManifestInfo) map[uuid.UUID][]
 	v := map[uuid.UUID][]*backupspec.ManifestInfo{}
 	for _, m := range manifests {
 		v[m.TaskID] = append(v[m.TaskID], m)
+	}
+	return v
+}
+
+func groupManifestsByLocation(manifests []*backupspec.ManifestInfo) map[backupspec.Location][]*backupspec.ManifestInfo {
+	v := map[backupspec.Location][]*backupspec.ManifestInfo{}
+	for _, m := range manifests {
+		v[m.Location] = append(v[m.Location], m)
 	}
 	return v
 }

--- a/pkg/service/backup/list.go
+++ b/pkg/service/backup/list.go
@@ -27,7 +27,7 @@ type remoteManifestInfo struct {
 }
 
 func (m remoteManifestInfo) Protected(now time.Time) bool {
-	return m.EventBasedHold || m.RetainUntil.After(now)
+	return m.EventBasedHold || (m.RetentionMode != scyllaclient.RetentionModeNone && m.RetainUntil.After(now))
 }
 
 func protectedTags(manifests []remoteManifestInfo) *strset.Set {

--- a/pkg/service/backup/list.go
+++ b/pkg/service/backup/list.go
@@ -9,18 +9,52 @@ import (
 	"sync"
 	"time"
 
+	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-manager/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
+	"github.com/scylladb/scylla-manager/v3/pkg/util2/slices"
 
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 )
 
-// listManifestsInAllLocations returns manifests for all nodes of a in all
-// locations specified in hosts.
+type remoteManifestInfo struct {
+	*backupspec.ManifestInfo
+
+	RetentionMode  scyllaclient.RetentionLockMode
+	RetainUntil    time.Time
+	EventBasedHold bool
+}
+
+func (m remoteManifestInfo) Protected(now time.Time) bool {
+	return m.EventBasedHold || m.RetainUntil.After(now)
+}
+
+func protectedTags(manifests []remoteManifestInfo) *strset.Set {
+	tags := strset.New()
+	now := timeutc.Now()
+	for _, m := range manifests {
+		if m.Protected(now) {
+			tags.Add(m.SnapshotTag)
+		}
+	}
+	return tags
+}
+
+// listManifestsInAllLocations is a type wrapper for listRemoteManifestsInAllLocations.
 func listManifestsInAllLocations(ctx context.Context, client *scyllaclient.Client, hosts []hostInfo, clusterID uuid.UUID) ([]*backupspec.ManifestInfo, error) {
+	manifests, err := listRemoteManifestsInAllLocations(ctx, client, hosts, clusterID)
+	if err != nil {
+		return nil, err
+	}
+	return manifestInfos(manifests), nil
+}
+
+// listRemoteManifestsInAllLocations returns remote manifests for locations specified in hosts.
+func listRemoteManifestsInAllLocations(ctx context.Context, client *scyllaclient.Client, hosts []hostInfo, clusterID uuid.UUID) ([]remoteManifestInfo, error) {
 	var (
 		locations = make(map[backupspec.Location]struct{})
-		manifests []*backupspec.ManifestInfo
+		manifests []remoteManifestInfo
 	)
 
 	for i := range hosts {
@@ -29,7 +63,7 @@ func listManifestsInAllLocations(ctx context.Context, client *scyllaclient.Clien
 		}
 		locations[hosts[i].Location] = struct{}{}
 
-		lm, err := listManifests(ctx, client, hosts[i].IP, hosts[i].Location, clusterID)
+		lm, err := listRemoteManifests(ctx, client, hosts[i].IP, hosts[i].Location, clusterID)
 		if err != nil {
 			return nil, err
 		}
@@ -39,10 +73,19 @@ func listManifestsInAllLocations(ctx context.Context, client *scyllaclient.Clien
 	return manifests, nil
 }
 
-// listManifests returns manifests for all nodes of a given cluster in the location.
+// listManifests is a type wrapper for listRemoteManifests.
+func listManifests(ctx context.Context, client *scyllaclient.Client, host string, location backupspec.Location, clusterID uuid.UUID) ([]*backupspec.ManifestInfo, error) {
+	manifests, err := listRemoteManifests(ctx, client, host, location, clusterID)
+	if err != nil {
+		return nil, err
+	}
+	return manifestInfos(manifests), nil
+}
+
+// listRemoteManifests returns remote manifests for all nodes of a given cluster in the location.
 // Manifests are sorted deterministically by their ClusterID, TaskID, SnapshotTag and NodeID.
 // If cluster is uuid.Nil then it returns manifests for all clusters it can find.
-func listManifests(ctx context.Context, client *scyllaclient.Client, host string, location backupspec.Location, clusterID uuid.UUID) ([]*backupspec.ManifestInfo, error) {
+func listRemoteManifests(ctx context.Context, client *scyllaclient.Client, host string, location backupspec.Location, clusterID uuid.UUID) ([]remoteManifestInfo, error) {
 	baseDir := backupspec.RemoteMetaClusterDCDir(clusterID)
 	if clusterID == uuid.Nil {
 		baseDir = path.Join("backup", string(backupspec.MetaDirKind))
@@ -52,11 +95,20 @@ func listManifests(ctx context.Context, client *scyllaclient.Client, host string
 		FilesOnly: true,
 		Recurse:   true,
 	}
+	if location.Provider == backupspec.GCS {
+		opts.ShowRetentionInfo = true
+		opts.ShowEventBasedHold = true
+	}
 
-	var manifests []*backupspec.ManifestInfo
+	var manifests []remoteManifestInfo
 	err := client.RcloneListDirIter(ctx, host, location.RemotePath(baseDir), &opts, func(f *scyllaclient.RcloneListDirItem) {
 		p := path.Join(baseDir, f.Path)
-		m := &backupspec.ManifestInfo{}
+		m := remoteManifestInfo{
+			ManifestInfo:   &backupspec.ManifestInfo{},
+			RetentionMode:  scyllaclient.RetentionLockMode(f.RetentionMode),
+			RetainUntil:    time.Time(f.RetainUntil),
+			EventBasedHold: f.EventBasedHold,
+		}
 		if err := m.ParsePath(p); err != nil {
 			return
 		}
@@ -81,6 +133,12 @@ func listManifests(ctx context.Context, client *scyllaclient.Client, host string
 	})
 
 	return manifests, nil
+}
+
+func manifestInfos(manifests []remoteManifestInfo) []*backupspec.ManifestInfo {
+	return slices.Map(manifests, func(m remoteManifestInfo) *backupspec.ManifestInfo {
+		return m.ManifestInfo
+	})
 }
 
 // ListFilter specifies manifest listing criteria.

--- a/pkg/service/backup/list.go
+++ b/pkg/service/backup/list.go
@@ -21,7 +21,7 @@ import (
 type remoteManifestInfo struct {
 	*backupspec.ManifestInfo
 
-	RetentionMode  scyllaclient.RetentionLockMode
+	RetentionMode  scyllaclient.RetentionMode
 	RetainUntil    time.Time
 	EventBasedHold bool
 }
@@ -96,7 +96,7 @@ func listRemoteManifests(ctx context.Context, client *scyllaclient.Client, host 
 		p := path.Join(baseDir, f.Path)
 		m := remoteManifestInfo{
 			ManifestInfo:   &backupspec.ManifestInfo{},
-			RetentionMode:  scyllaclient.RetentionLockMode(f.RetentionMode),
+			RetentionMode:  scyllaclient.RetentionMode(f.RetentionMode),
 			RetainUntil:    time.Time(f.RetainUntil),
 			EventBasedHold: f.EventBasedHold,
 		}

--- a/pkg/service/backup/list_test.go
+++ b/pkg/service/backup/list_test.go
@@ -25,13 +25,14 @@ func TestListManifests(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("one cluster", func(t *testing.T) {
-		manifests, error := listManifests(ctx, client, scyllaclienttest.TestHost,
+		remoteManifests, error := listRemoteManifests(ctx, client, scyllaclienttest.TestHost,
 			backupspec.Location{Provider: "testdata", Path: "list"},
 			uuid.MustParse("2e4ac82f-a7b5-4b6d-ab5e-0a1553a50a21"),
 		)
 		if error != nil {
 			t.Fatal("listManifests() error", error)
 		}
+		manifests := manifestInfos(remoteManifests)
 		testutils.SaveGoldenJSONFileIfNeeded(t, manifests)
 		var golden []*backupspec.ManifestInfo
 		testutils.LoadGoldenJSONFile(t, &golden)

--- a/pkg/service/backup/model.go
+++ b/pkg/service/backup/model.go
@@ -47,22 +47,22 @@ type ListItem struct {
 
 // Target specifies what should be backed up and where.
 type Target struct {
-	Units                 []Unit                         `json:"units,omitempty"`
-	DC                    []string                       `json:"dc,omitempty"`
-	Location              []backupspec.Location          `json:"location"`
-	Retention             int                            `json:"retention"`
-	RetentionDays         int                            `json:"retention_days"`
-	RetentionMap          RetentionMap                   `json:"-"` // policy for all tasks, injected in runtime
-	RateLimit             []DCLimit                      `json:"rate_limit,omitempty"`
-	Transfers             int                            `json:"transfers"`
-	SnapshotParallel      []DCLimit                      `json:"snapshot_parallel,omitempty"`
-	UploadParallel        []DCLimit                      `json:"upload_parallel,omitempty"`
-	Continue              bool                           `json:"continue,omitempty"`
-	PurgeOnly             bool                           `json:"purge_only,omitempty"`
-	SkipSchema            bool                           `json:"skip_schema,omitempty"`
-	Method                Method                         `json:"method,omitempty"`
-	RetentionLockMode     scyllaclient.RetentionLockMode `json:"retention_lock_mode"`
-	OverrideRetentionLock bool                           `json:"override_retention_lock"`
+	Units                 []Unit                `json:"units,omitempty"`
+	DC                    []string              `json:"dc,omitempty"`
+	Location              []backupspec.Location `json:"location"`
+	Retention             int                   `json:"retention"`
+	RetentionDays         int                   `json:"retention_days"`
+	RetentionMap          RetentionMap          `json:"-"` // policy for all tasks, injected in runtime
+	RateLimit             []DCLimit             `json:"rate_limit,omitempty"`
+	Transfers             int                   `json:"transfers"`
+	SnapshotParallel      []DCLimit             `json:"snapshot_parallel,omitempty"`
+	UploadParallel        []DCLimit             `json:"upload_parallel,omitempty"`
+	Continue              bool                  `json:"continue,omitempty"`
+	PurgeOnly             bool                  `json:"purge_only,omitempty"`
+	SkipSchema            bool                  `json:"skip_schema,omitempty"`
+	Method                Method                `json:"method,omitempty"`
+	RetentionLockMode     RetentionLockMode     `json:"retention_lock_mode"`
+	OverrideRetentionLock bool                  `json:"override_retention_lock"`
 
 	// LiveNodes caches node status for GetTarget GetTargetSize calls.
 	liveNodes scyllaclient.NodeStatusInfoSlice `json:"-"`
@@ -99,6 +99,53 @@ func (u *Unit) UnmarshalUDT(name string, info gocql.TypeInfo, data []byte) error
 // This happens when working with runs coming from versions prior to adding stage.
 const stageNone Stage = ""
 
+// RetentionLockMode describes the WORM protection of backup files,
+// as specified with the --retention-lock-mode flag.
+type RetentionLockMode string
+
+const (
+	// RetentionLockDisabled means that no WORM protection is applied to backup files.
+	RetentionLockDisabled RetentionLockMode = "disabled"
+	// RetentionLockUnlocked means that retention lock is applied but can be overridden with special permissions.
+	RetentionLockUnlocked RetentionLockMode = "unlocked"
+	// RetentionLockLocked means that retention lock is applied and cannot be overridden.
+	RetentionLockLocked RetentionLockMode = "locked"
+	// RetentionLockEventBasedHold means that backup files are protected with default
+	// event based hold and bucket retention policy. SM is responsible for clearing
+	// the hold when it's no longer needed which starts bucket retention timer.
+	// Note that it's not an exact object retention lock mode - it's a different
+	// approach for ensuring WORM backup.
+	RetentionLockEventBasedHold RetentionLockMode = "event-based-hold"
+)
+
+// toRetentionMode converts mode to the object retention lock mode used in scyllaclient pkg.
+// It returns an error for RetentionLockEventBasedHold, as it can't be expressed as an object
+// retention lock mode - event based hold should be applied with dedicated methods.
+func (m RetentionLockMode) toRetentionMode() (scyllaclient.RetentionMode, error) {
+	switch m {
+	case RetentionLockDisabled:
+		return scyllaclient.RetentionModeNone, nil
+	case RetentionLockUnlocked:
+		return scyllaclient.RetentionModeUnlocked, nil
+	case RetentionLockLocked:
+		return scyllaclient.RetentionModeLocked, nil
+	case RetentionLockEventBasedHold:
+		return "", errors.New("event based hold should be applied with dedicated method")
+	default:
+		return "", errors.Errorf("unknown retention lock mode: %s", m)
+	}
+}
+
+// toRetentionParams converts mode to the object retention lock mode
+// and event based hold flag used in scyllaclient pkg.
+func (m RetentionLockMode) toRetentionParams() (mode scyllaclient.RetentionMode, eventBasedHold bool, err error) {
+	if m == RetentionLockEventBasedHold {
+		return scyllaclient.RetentionModeNone, true, nil
+	}
+	mode, err = m.toRetentionMode()
+	return mode, false, err
+}
+
 // Method describes which API should be used by SM during backup.
 type Method string
 
@@ -125,7 +172,7 @@ type Run struct {
 	Location              []backupspec.Location
 	StartTime             time.Time
 	Stage                 Stage
-	RetentionLockMode     scyllaclient.RetentionLockMode
+	RetentionLockMode     RetentionLockMode
 	OverrideRetentionLock bool
 	RetentionDays         int
 }
@@ -193,13 +240,13 @@ type progress struct {
 type Progress struct {
 	progress
 
-	SnapshotTag           string                         `json:"snapshot_tag"`
-	DC                    []string                       `json:"dcs,omitempty"`
-	Hosts                 []HostProgress                 `json:"hosts,omitempty"`
-	Stage                 Stage                          `json:"stage"`
-	RetentionLockMode     scyllaclient.RetentionLockMode `json:"retention_lock_mode"`
-	OverrideRetentionLock bool                           `json:"override_retention_lock"`
-	RetentionDays         int                            `json:"retention_days"`
+	SnapshotTag           string            `json:"snapshot_tag"`
+	DC                    []string          `json:"dcs,omitempty"`
+	Hosts                 []HostProgress    `json:"hosts,omitempty"`
+	Stage                 Stage             `json:"stage"`
+	RetentionLockMode     RetentionLockMode `json:"retention_lock_mode"`
+	OverrideRetentionLock bool              `json:"override_retention_lock"`
+	RetentionDays         int               `json:"retention_days"`
 }
 
 // HostProgress groups uploading progress for keyspaces belonging to this host.
@@ -229,22 +276,22 @@ type TableProgress struct {
 
 // taskProperties is the main data structure of the runner.Properties blob.
 type taskProperties struct {
-	Keyspace              []string                       `json:"keyspace"`
-	DC                    []string                       `json:"dc"`
-	Location              []backupspec.Location          `json:"location"`
-	Retention             *int                           `json:"retention"`
-	RetentionDays         *int                           `json:"retention_days"`
-	RetentionMap          RetentionMap                   `json:"retention_map"`
-	RateLimit             []DCLimit                      `json:"rate_limit"`
-	Transfers             int                            `json:"transfers"`
-	SnapshotParallel      []DCLimit                      `json:"snapshot_parallel"`
-	UploadParallel        []DCLimit                      `json:"upload_parallel"`
-	Continue              bool                           `json:"continue"`
-	PurgeOnly             bool                           `json:"purge_only"`
-	SkipSchema            bool                           `json:"skip_schema"`
-	Method                Method                         `json:"method,omitempty"`
-	RetentionLockMode     scyllaclient.RetentionLockMode `json:"retention_lock_mode"`
-	OverrideRetentionLock bool                           `json:"override_retention_lock"`
+	Keyspace              []string              `json:"keyspace"`
+	DC                    []string              `json:"dc"`
+	Location              []backupspec.Location `json:"location"`
+	Retention             *int                  `json:"retention"`
+	RetentionDays         *int                  `json:"retention_days"`
+	RetentionMap          RetentionMap          `json:"retention_map"`
+	RateLimit             []DCLimit             `json:"rate_limit"`
+	Transfers             int                   `json:"transfers"`
+	SnapshotParallel      []DCLimit             `json:"snapshot_parallel"`
+	UploadParallel        []DCLimit             `json:"upload_parallel"`
+	Continue              bool                  `json:"continue"`
+	PurgeOnly             bool                  `json:"purge_only"`
+	SkipSchema            bool                  `json:"skip_schema"`
+	Method                Method                `json:"method,omitempty"`
+	RetentionLockMode     RetentionLockMode     `json:"retention_lock_mode"`
+	OverrideRetentionLock bool                  `json:"override_retention_lock"`
 }
 
 func (p taskProperties) validate(dcs []string, dcMap map[string][]string) error {
@@ -261,12 +308,12 @@ func (p taskProperties) validate(dcs []string, dcMap map[string][]string) error 
 	if !slices.Contains([]Method{MethodAuto, MethodRclone, MethodNative}, p.Method) {
 		return errors.New("unknown Method: " + string(p.Method))
 	}
-	if !slices.Contains([]scyllaclient.RetentionLockMode{
-		scyllaclient.RetentionLockDisabled, scyllaclient.RetentionLockUnlocked, scyllaclient.RetentionLockLocked,
+	if !slices.Contains([]RetentionLockMode{
+		RetentionLockDisabled, RetentionLockUnlocked, RetentionLockLocked,
 	}, p.RetentionLockMode) {
 		return errors.New("unknown retention lock mode: " + string(p.RetentionLockMode))
 	}
-	if p.RetentionLockMode != scyllaclient.RetentionLockDisabled {
+	if p.RetentionLockMode != RetentionLockDisabled {
 		if p.RetentionDays == nil || *p.RetentionDays <= 0 {
 			return util.ErrValidate(errors.New("retention days must be set when retention lock is enabled"))
 		}
@@ -281,7 +328,7 @@ func (p taskProperties) validate(dcs []string, dcMap map[string][]string) error 
 			}
 		}
 	}
-	if p.RetentionLockMode == scyllaclient.RetentionLockDisabled && p.OverrideRetentionLock {
+	if p.RetentionLockMode == RetentionLockDisabled && p.OverrideRetentionLock {
 		return util.ErrValidate(errors.New("retention lock cannot be overridden when it is disabled"))
 	}
 
@@ -456,7 +503,7 @@ func defaultTaskProperties() taskProperties {
 		Transfers:             scyllaclient.TransfersFromConfig,
 		Method:                MethodRclone,
 		Continue:              true,
-		RetentionLockMode:     scyllaclient.RetentionLockDisabled,
+		RetentionLockMode:     RetentionLockDisabled,
 		OverrideRetentionLock: false,
 	}
 }

--- a/pkg/service/backup/purger.go
+++ b/pkg/service/backup/purger.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 package backup
 
@@ -26,10 +26,8 @@ import (
 // - manifests over task days retention days policy,
 // - manifests over task retention policy,
 // - manifests older than threshold if retention policy is unknown.
-// Moreover, it returns the oldest snapshot tag time that remains undeleted by retention policy.
-func staleTags(manifests []*backupspec.ManifestInfo, retentionMap RetentionMap) (*strset.Set, time.Time, error) {
+func staleTags(manifests []*backupspec.ManifestInfo, retentionMap RetentionMap) (*strset.Set, error) {
 	tags := strset.New()
-	var oldest time.Time
 
 	for taskID, taskManifests := range groupManifestsByTask(manifests) {
 		taskPolicy := GetRetention(taskID, retentionMap)
@@ -37,7 +35,7 @@ func staleTags(manifests []*backupspec.ManifestInfo, retentionMap RetentionMap) 
 		for _, m := range taskManifests {
 			t, err := backupspec.SnapshotTagTime(m.SnapshotTag)
 			if err != nil {
-				return nil, time.Time{}, errors.Wrapf(err, "parse manifest snapshot tag time")
+				return nil, errors.Wrapf(err, "parse manifest snapshot tag time")
 			}
 
 			switch {
@@ -48,8 +46,6 @@ func staleTags(manifests []*backupspec.ManifestInfo, retentionMap RetentionMap) 
 				tags.Add(m.SnapshotTag)
 			case taskPolicy.Retention > 0:
 				taskTags.Add(m.SnapshotTag)
-			case t.Before(oldest) || oldest.IsZero():
-				oldest = t
 			}
 		}
 
@@ -58,18 +54,30 @@ func staleTags(manifests []*backupspec.ManifestInfo, retentionMap RetentionMap) 
 			sort.Strings(l)
 			cut := len(l) - taskPolicy.Retention
 			tags.Add(l[:cut]...)
-
-			t, err := backupspec.SnapshotTagTime(l[cut])
-			if err != nil {
-				return nil, time.Time{}, err
-			}
-			if t.Before(oldest) || oldest.IsZero() {
-				oldest = t
-			}
 		}
 	}
 
-	return tags, oldest, nil
+	return tags, nil
+}
+
+// oldestKeptTag returns the time of the oldest snapshot tag that remains
+// after removing all manifests matching the given tags.
+func oldestKeptTag(manifests []*backupspec.ManifestInfo, staleTags *strset.Set) (time.Time, error) {
+	var oldest time.Time
+	for _, m := range manifests {
+		if staleTags.Has(m.SnapshotTag) {
+			continue
+		}
+
+		t, err := backupspec.SnapshotTagTime(m.SnapshotTag)
+		if err != nil {
+			return time.Time{}, errors.Wrapf(err, "parse manifest snapshot tag time")
+		}
+		if t.Before(oldest) || oldest.IsZero() {
+			oldest = t
+		}
+	}
+	return oldest, nil
 }
 
 type purger struct {

--- a/pkg/service/backup/purger_test.go
+++ b/pkg/service/backup/purger_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 package backup
 
@@ -72,12 +72,17 @@ func TestStaleTags(t *testing.T) {
 	x.Temporary = true
 	manifests = append(manifests, x)
 
-	tags, oldest, err := staleTags(manifests, RetentionMap{
+	tags, err := staleTags(manifests, RetentionMap{
 		task0: {Retention: 3, RetentionDays: 0},
 		task1: {Retention: 2, RetentionDays: 0},
 		task3: {Retention: 2, RetentionDays: 10},
 		task4: {Retention: 1, RetentionDays: 10},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldest, err := oldestKeptTag(manifests, tags)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/service/backup/purger_test.go
+++ b/pkg/service/backup/purger_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-manager/backupspec"
 
 	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
@@ -106,5 +107,80 @@ func TestStaleTags(t *testing.T) {
 
 	if diff := cmp.Diff(tags.List(), golden, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 		t.Fatalf("staleTags() = %s, diff:\n%s", tags.List(), diff)
+	}
+}
+
+func TestRemoteManifestInfoProtected(t *testing.T) {
+	t.Parallel()
+	now := timeutc.Now()
+
+	tests := []struct {
+		name     string
+		manifest remoteManifestInfo
+		expected bool
+	}{
+		{
+			name: "not protected",
+		},
+		{
+			name: "event based hold",
+			manifest: remoteManifestInfo{
+				EventBasedHold: true,
+			},
+			expected: true,
+		},
+		{
+			name: "future retention",
+			manifest: remoteManifestInfo{
+				RetainUntil: now.Add(time.Hour),
+			},
+			expected: true,
+		},
+		{
+			name: "expired retention",
+			manifest: remoteManifestInfo{
+				RetainUntil: now.Add(-time.Hour),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := test.manifest.Protected(now); got != test.expected {
+				t.Fatalf("Protected() = %v, expected %v", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestProtectedTags(t *testing.T) {
+	t.Parallel()
+
+	manifests := []remoteManifestInfo{
+		{
+			ManifestInfo: &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000000UTC"},
+		},
+		{
+			ManifestInfo: &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000001UTC"},
+			RetainUntil:  timeutc.Now().Add(time.Hour),
+		},
+		{
+			ManifestInfo:   &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000002UTC"},
+			EventBasedHold: true,
+		},
+		{
+			ManifestInfo: &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000003UTC"},
+			RetainUntil:  timeutc.Now().Add(-time.Hour),
+		},
+		{
+			ManifestInfo:   &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000001UTC"},
+			EventBasedHold: true,
+		},
+	}
+
+	expected := strset.New("sm_19700101000001UTC", "sm_19700101000002UTC")
+	if got := protectedTags(manifests); !got.IsEqual(expected) {
+		t.Fatalf("protectedTags() = %s, expected %s", got.List(), expected.List())
 	}
 }

--- a/pkg/service/backup/purger_test.go
+++ b/pkg/service/backup/purger_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-manager/backupspec"
 
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 )
@@ -132,14 +133,22 @@ func TestRemoteManifestInfoProtected(t *testing.T) {
 		{
 			name: "future retention",
 			manifest: remoteManifestInfo{
-				RetainUntil: now.Add(time.Hour),
+				RetentionMode: scyllaclient.RetentionModeLocked,
+				RetainUntil:   now.Add(time.Hour),
 			},
 			expected: true,
 		},
 		{
+			name: "future retention without retention mode",
+			manifest: remoteManifestInfo{
+				RetainUntil: now.Add(time.Hour),
+			},
+		},
+		{
 			name: "expired retention",
 			manifest: remoteManifestInfo{
-				RetainUntil: now.Add(-time.Hour),
+				RetentionMode: scyllaclient.RetentionModeLocked,
+				RetainUntil:   now.Add(-time.Hour),
 			},
 		},
 	}
@@ -162,16 +171,22 @@ func TestProtectedTags(t *testing.T) {
 			ManifestInfo: &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000000UTC"},
 		},
 		{
-			ManifestInfo: &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000001UTC"},
-			RetainUntil:  timeutc.Now().Add(time.Hour),
+			ManifestInfo:  &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000001UTC"},
+			RetentionMode: scyllaclient.RetentionModeLocked,
+			RetainUntil:   timeutc.Now().Add(time.Hour),
 		},
 		{
 			ManifestInfo:   &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000002UTC"},
 			EventBasedHold: true,
 		},
 		{
-			ManifestInfo: &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000003UTC"},
-			RetainUntil:  timeutc.Now().Add(-time.Hour),
+			ManifestInfo:  &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000003UTC"},
+			RetentionMode: scyllaclient.RetentionModeLocked,
+			RetainUntil:   timeutc.Now().Add(-time.Hour),
+		},
+		{
+			ManifestInfo: &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000004UTC"},
+			RetainUntil:  timeutc.Now().Add(time.Hour),
 		},
 		{
 			ManifestInfo:   &backupspec.ManifestInfo{SnapshotTag: "sm_19700101000001UTC"},

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -1259,24 +1259,31 @@ func (s *Service) DeleteSnapshot(ctx context.Context, clusterID uuid.UUID, locat
 		return errors.Wrap(err, "resolve hosts")
 	}
 
+	tags := strset.New(snapshotTags...)
+	remoteManifests, err := listRemoteManifestsInAllLocations(ctx, client, hosts, clusterID)
+	if err != nil {
+		return errors.Wrap(err, "list manifests")
+	}
+	manifests := manifestInfos(remoteManifests)
+
+	protected := protectedTags(remoteManifests)
+	if protectedRemoved := strset.Intersection(protected, tags); !protectedRemoved.IsEmpty() {
+		return errors.Errorf("snapshots protected by retention lock or event based hold cannot be deleted: %v", protectedRemoved.List())
+	}
+
+	oldest, err := oldestKeptTag(manifests, tags)
+	if err != nil {
+		return errors.Wrap(err, "get oldest kept snapshot")
+	}
+
+	manifestsByLocation := groupManifestsByLocation(manifests)
 	deletedManifests := atomic.NewInt32(0)
 
 	f := func(h hostInfo) error {
 		s.logger.Info(ctx, "Purging snapshot data on host", "host", h.IP)
 
-		manifests, err := listManifests(ctx, client, h.IP, h.Location, clusterID)
-		if err != nil {
-			return err
-		}
 		p := newPurger(client, h.IP, s.logger)
-
-		tagS := strset.New(snapshotTags...)
-		oldest, err := oldestKeptTag(manifests, tagS)
-		if err != nil {
-			return errors.Wrap(err, "get oldest kept snapshot")
-		}
-
-		n, err := p.PurgeSnapshotTags(ctx, manifests, tagS, oldest)
+		n, err := p.PurgeSnapshotTags(ctx, manifestsByLocation[h.Location], tags, oldest)
 		deletedManifests.Add(int32(n))
 
 		if err == nil {

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -1271,19 +1271,9 @@ func (s *Service) DeleteSnapshot(ctx context.Context, clusterID uuid.UUID, locat
 		p := newPurger(client, h.IP, s.logger)
 
 		tagS := strset.New(snapshotTags...)
-		var oldest time.Time
-		for _, m := range manifests {
-			if tagS.Has(m.SnapshotTag) {
-				continue
-			}
-
-			t, err := backupspec.SnapshotTagTime(m.SnapshotTag)
-			if err != nil {
-				return err
-			}
-			if t.Before(oldest) || oldest.IsZero() {
-				oldest = t
-			}
+		oldest, err := oldestKeptTag(manifests, tagS)
+		if err != nil {
+			return errors.Wrap(err, "get oldest kept snapshot")
 		}
 
 		n, err := p.PurgeSnapshotTags(ctx, manifests, tagS, oldest)

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -272,7 +272,7 @@ func (s *Service) getLiveNodes(ctx context.Context, client *scyllaclient.Client,
 // checkLocationsAvailableFromNodes checks if each node has access location for its datacenter.
 func (s *Service) checkLocationsAvailableFromNodes(ctx context.Context, client *scyllaclient.Client,
 	nodes scyllaclient.NodeStatusInfoSlice, locations []backupspec.Location,
-	clusterID uuid.UUID, retentionMode scyllaclient.RetentionLockMode, overrideLock bool,
+	clusterID uuid.UUID, retentionMode RetentionLockMode, overrideLock bool,
 ) error {
 	s.logger.Info(ctx, "Checking accessibility of remote locations")
 	defer s.logger.Info(ctx, "Done checking accessibility of remote locations")
@@ -405,11 +405,16 @@ func (s *Service) cleanupPermissionCheckFiles(ctx context.Context, client *scyll
 }
 
 func (s *Service) checkHostLocation(ctx context.Context, client *scyllaclient.Client,
-	h string, l backupspec.Location, path string, retentionMode scyllaclient.RetentionLockMode, overrideLock bool,
+	h string, l backupspec.Location, path string, retentionMode RetentionLockMode, overrideLock bool,
 ) error {
-	err := client.RcloneCheckPermissions(ctx, h, l.RemotePath(path), scyllaclient.PermissionCheckOpts{
-		CheckRetention:             retentionMode,
+	mode, hold, err := retentionMode.toRetentionParams()
+	if err != nil {
+		return err
+	}
+	err = client.RcloneCheckPermissions(ctx, h, l.RemotePath(path), scyllaclient.PermissionCheckOpts{
+		CheckRetention:             mode,
 		CheckOverrideRetentionLock: overrideLock,
+		CheckEventBasedHold:        hold,
 	})
 	if err != nil {
 		s.logger.Info(ctx, "Location check FAILED", "host", h, "location", l, "error", err)
@@ -934,10 +939,10 @@ func (s *Service) Backup(ctx context.Context, clusterID, taskID, runID uuid.UUID
 			return w.MoveManifest(ctx, hi)
 		},
 		StageRetentionLock: func() error {
-			if slices.Contains([]scyllaclient.RetentionLockMode{
-				scyllaclient.RetentionLockUnlocked,
-				scyllaclient.RetentionLockLocked,
-				scyllaclient.RetentionLockEventBasedHold,
+			if slices.Contains([]RetentionLockMode{
+				RetentionLockUnlocked,
+				RetentionLockLocked,
+				RetentionLockEventBasedHold,
 			}, target.RetentionLockMode) {
 				return w.RetentionLock(ctx, hi, target)
 			}

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -541,7 +541,7 @@ func TestGetTargetInParallelIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 	props["retention_days"] = 1
-	props["retention_lock_mode"] = scyllaclient.RetentionLockUnlocked
+	props["retention_lock_mode"] = backup.RetentionLockUnlocked
 	rawRetentionLockProps, err := json.Marshal(props)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/service/backup/service_retention_lock_integration_test.go
+++ b/pkg/service/backup/service_retention_lock_integration_test.go
@@ -15,11 +15,15 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
+	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-manager/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
+	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/httpx"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/timeutc"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 	"github.com/scylladb/scylla-manager/v3/pkg/util2/maps"
 	"go.uber.org/atomic"
@@ -370,6 +374,184 @@ func TestBackupResumeOnRetentionLockStageIntegration(t *testing.T) {
 	Print("Then: all objects have correct retention locks after resume")
 	expectedRetain := snapshotTagRetainUntil(t, tag, 1)
 	lockHandler.assertRetention("Unlocked", expectedRetain, listSnapshotFiles(t, h, tag)...)
+}
+
+func TestBackupProtectedManifestsIntegration(t *testing.T) {
+	// This test verifies that snapshots whose manifests are protected by a retention
+	// lock or an event based hold are not removed. It checks that:
+	// - purge skips them even when the retention policy marks them as stale
+	// - explicit snapshot deletion fails instead of removing them
+	// and that once protection is cleared, those methods can remove them.
+	testCases := []struct {
+		name              string
+		bucket            string
+		keyspace          string
+		retentionLockMode scyllaclient.RetentionLockMode
+		setupInterceptor  func(ctx context.Context, h *backupTestHelper) *eventBasedHoldInterceptor
+		clearProtection   func(ctx context.Context, h *backupTestHelper, i *eventBasedHoldInterceptor, remotePath string) error
+	}{
+		{
+			name:              "retention lock",
+			bucket:            "backuptest-purge-protected-lock",
+			keyspace:          "backuptest_purge_protected_lock",
+			retentionLockMode: scyllaclient.RetentionLockUnlocked,
+			clearProtection: func(ctx context.Context, h *backupTestHelper, _ *eventBasedHoldInterceptor, remotePath string) error {
+				// GCS mock used in test env does not support clearing retention policy,
+				// but it allows to override it and set it in the past.
+				return h.Client.RcloneRetentionLock(ctx, ManagedClusterHost(), remotePath,
+					scyllaclient.RetentionLockUnlocked, timeutc.Now().Add(-24*time.Hour), true)
+			},
+		},
+		{
+			name:              "event based hold",
+			bucket:            "backuptest-purge-protected-hold",
+			keyspace:          "backuptest_purge_protected_hold",
+			retentionLockMode: scyllaclient.RetentionLockEventBasedHold,
+			setupInterceptor: func(ctx context.Context, h *backupTestHelper) *eventBasedHoldInterceptor {
+				i := newEventBasedHoldInterceptor(t, h.Hrt)
+				i.defaultEventBasedHold = true
+				i.defaultBucketRetentionPolicy = 24 * time.Hour
+				return i
+			},
+			clearProtection: func(ctx context.Context, h *backupTestHelper, i *eventBasedHoldInterceptor, remotePath string) error {
+				// Simple hold removal triggers bucket retention policy, so we need to first
+				// remove it, apply the hold and only then remove it, so that it correctly
+				// handles objects with already started retention periods.
+				i.defaultBucketRetentionPolicy = 0
+				if err := h.Client.RcloneEventBasedHold(ctx, ManagedClusterHost(), remotePath, true); err != nil {
+					return err
+				}
+				return h.Client.RcloneEventBasedHold(ctx, ManagedClusterHost(), remotePath, false)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			location := backupspec.Location{Provider: backupspec.GCS, Path: tc.bucket}
+			GCSInitBucket(t, tc.bucket)
+
+			var (
+				session        = CreateScyllaManagerDBSession(t)
+				h              = newBackupTestHelper(t, session, defaultConfig(), location, nil)
+				ctx            = t.Context()
+				clusterSession = CreateSessionAndDropAllKeyspaces(t, h.Client)
+			)
+
+			var i *eventBasedHoldInterceptor
+			if tc.setupInterceptor != nil {
+				i = tc.setupInterceptor(ctx, h)
+			}
+
+			const replication = "{'class': 'NetworkTopologyStrategy', 'dc1': 3, 'dc2': 3}"
+			nextID := RawWriteData(t, clusterSession, tc.keyspace, 0, 1, replication, true)
+
+			props := defaultTestProperties(location, tc.keyspace)
+			// Just to satisfy retention lock validation.
+			// Different retention policy will be used for purge purposes.
+			props["retention_days"] = 1
+			// Tests forcing GCS provider need to use method auto to avoid
+			// CI workflows using scylla version without native backup
+			// support for gcs aimed to test native backup for s3.
+			props["method"] = backup.MethodAuto
+			rawProps, err := json.Marshal(props)
+			if err != nil {
+				t.Fatal(err)
+			}
+			target, err := h.service.GetTarget(ctx, h.ClusterID, rawProps)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Added here to bypass validation, as this method is not yet exposed
+			target.RetentionLockMode = tc.retentionLockMode
+			// Inject purge so that it keeps only the last snapshot
+			target.RetentionMap = backup.RetentionMap{h.TaskID: {Retention: 1}}
+			// To skip not interesting schema sstables
+			target.Units = []backup.Unit{{Keyspace: tc.keyspace}}
+
+			// runBackup executes a backup and returns its snapshot tag
+			runBackup := func(target backup.Target) string {
+				runID := uuid.NewTime()
+				if err := h.service.Backup(ctx, h.ClusterID, h.TaskID, runID, target); err != nil {
+					t.Fatal(err)
+				}
+				pr, err := h.service.GetProgress(ctx, h.ClusterID, h.TaskID, runID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return pr.SnapshotTag
+			}
+
+			// assertSnapshotFiles verifies that the snapshot consists of exactly the expected set of files
+			assertSnapshotFiles := func(tag string, want *strset.Set) {
+				if got := strset.New(listSnapshotFiles(t, h, tag)...); !want.IsEqual(got) {
+					t.Fatalf("snapshot %s files changed, want: \n%v\n, got: \n%v\n", tag, want.List(), got.List())
+				}
+			}
+
+			Print("When: protected backup is executed")
+			tagA := runBackup(target)
+			tagAFiles := strset.New(listSnapshotFiles(t, h, tagA)...)
+
+			Print("Then: deleting protected snapshot fails")
+			if err := h.service.DeleteSnapshot(ctx, h.ClusterID, []backupspec.Location{location}, []string{tagA}); err == nil {
+				t.Fatalf("Expected protected snapshot %s deletion to fail", tagA)
+			}
+
+			Print("And: protected snapshot is still there")
+			assertSnapshotFiles(tagA, tagAFiles)
+
+			Print("When: new backup with new data is executed")
+			nextID = RawWriteData(t, clusterSession, tc.keyspace, nextID, 1, replication, true)
+			tagB := runBackup(target)
+			tagBFiles := strset.New(listSnapshotFiles(t, h, tagB)...)
+
+			Print("Then: first snapshot exists despite retention=1")
+			assertSnapshotFiles(tagA, tagAFiles)
+
+			Print("And: deleting any protected snapshot fails")
+			for _, tag := range []string{tagA, tagB} {
+				if err := h.service.DeleteSnapshot(ctx, h.ClusterID, []backupspec.Location{location}, []string{tag}); err == nil {
+					t.Fatalf("Expected protected snapshot %s deletion to fail", tag)
+				}
+			}
+
+			Print("And: both protected snapshots are still there")
+			assertSnapshotFiles(tagA, tagAFiles)
+			assertSnapshotFiles(tagB, tagBFiles)
+
+			Print("When: all protection is manually cleared")
+			strset.Union(tagAFiles, tagBFiles).Each(func(f string) bool {
+				if err := tc.clearProtection(ctx, h, i, h.location.RemotePath(f)); err != nil {
+					t.Fatal(err)
+				}
+				return true
+			})
+
+			Print("And: purge is executed")
+			purgeTarget := target
+			purgeTarget.PurgeOnly = true
+			runBackup(purgeTarget)
+
+			Print("Then: stale snapshot is purged")
+			if got := listSnapshotFiles(t, h, tagA); len(got) != 0 {
+				t.Fatalf("Expected stale snapshot %s to be purged", tagA)
+			}
+
+			Print("And: last snapshot is kept")
+			assertSnapshotFiles(tagB, tagBFiles)
+
+			Print("When: last snapshot is deleted")
+			if err := h.service.DeleteSnapshot(ctx, h.ClusterID, []backupspec.Location{location}, []string{tagB}); err != nil {
+				t.Fatal(err)
+			}
+
+			Print("Then: last snapshot is deleted")
+			if got := listSnapshotFiles(t, h, tagB); len(got) != 0 {
+				t.Fatalf("Expected last snapshot %s to be deleted", tagB)
+			}
+		})
+	}
 }
 
 func listSnapshotFiles(t *testing.T, h *backupTestHelper, snapshotTag string) []string {

--- a/pkg/service/backup/service_retention_lock_integration_test.go
+++ b/pkg/service/backup/service_retention_lock_integration_test.go
@@ -386,7 +386,7 @@ func TestBackupProtectedManifestsIntegration(t *testing.T) {
 		name              string
 		bucket            string
 		keyspace          string
-		retentionLockMode scyllaclient.RetentionLockMode
+		retentionLockMode backup.RetentionLockMode
 		setupInterceptor  func(ctx context.Context, h *backupTestHelper) *eventBasedHoldInterceptor
 		clearProtection   func(ctx context.Context, h *backupTestHelper, i *eventBasedHoldInterceptor, remotePath string) error
 	}{
@@ -394,19 +394,19 @@ func TestBackupProtectedManifestsIntegration(t *testing.T) {
 			name:              "retention lock",
 			bucket:            "backuptest-purge-protected-lock",
 			keyspace:          "backuptest_purge_protected_lock",
-			retentionLockMode: scyllaclient.RetentionLockUnlocked,
+			retentionLockMode: backup.RetentionLockUnlocked,
 			clearProtection: func(ctx context.Context, h *backupTestHelper, _ *eventBasedHoldInterceptor, remotePath string) error {
 				// GCS mock used in test env does not support clearing retention policy,
 				// but it allows to override it and set it in the past.
 				return h.Client.RcloneRetentionLock(ctx, ManagedClusterHost(), remotePath,
-					scyllaclient.RetentionLockUnlocked, timeutc.Now().Add(-24*time.Hour), true)
+					scyllaclient.RetentionModeUnlocked, timeutc.Now().Add(-24*time.Hour), true)
 			},
 		},
 		{
 			name:              "event based hold",
 			bucket:            "backuptest-purge-protected-hold",
 			keyspace:          "backuptest_purge_protected_hold",
-			retentionLockMode: scyllaclient.RetentionLockEventBasedHold,
+			retentionLockMode: backup.RetentionLockEventBasedHold,
 			setupInterceptor: func(ctx context.Context, h *backupTestHelper) *eventBasedHoldInterceptor {
 				i := newEventBasedHoldInterceptor(t, h.Hrt)
 				i.defaultEventBasedHold = true

--- a/pkg/service/backup/validation.go
+++ b/pkg/service/backup/validation.go
@@ -335,7 +335,7 @@ func (s *Service) checkValidationTarget(ctx context.Context, client *scyllaclien
 	if len(liveNodes) == 0 {
 		return nil, util.ErrValidate(errors.Errorf("wrong location"))
 	}
-	if err := s.checkLocationsAvailableFromNodes(ctx, client, liveNodes, target.Location, clusterID, scyllaclient.RetentionLockDisabled, false); err != nil {
+	if err := s.checkLocationsAvailableFromNodes(ctx, client, liveNodes, target.Location, clusterID, RetentionLockDisabled, false); err != nil {
 		return nil, util.ErrValidate(errors.Wrap(err, "location is not accessible"))
 	}
 

--- a/pkg/service/backup/worker.go
+++ b/pkg/service/backup/worker.go
@@ -73,7 +73,7 @@ type workerTools struct {
 	Client      *scyllaclient.Client
 	Logger      log.Logger
 
-	RetentionLockMode scyllaclient.RetentionLockMode
+	RetentionLockMode RetentionLockMode
 }
 
 // worker is responsible for coordinating backup procedure.

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -62,7 +62,7 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 		d := &dirs[i]
 		dataDst := h.Location.RemotePath(w.remoteSSTableDir(h, *d))
 
-		applyHolds := w.RetentionLockMode == scyllaclient.RetentionLockEventBasedHold
+		applyHolds := w.RetentionLockMode == RetentionLockEventBasedHold
 		var holdHandler *eventBasedHoldHandler
 		if applyHolds {
 			// Initialize holdHandler

--- a/pkg/service/backup/worker_purge.go
+++ b/pkg/service/backup/worker_purge.go
@@ -13,15 +13,21 @@ import (
 
 func (w *worker) Purge(ctx context.Context, hosts []hostInfo, retentionMap RetentionMap) (err error) {
 	// List manifests in all locations
-	manifests, err := listManifestsInAllLocations(ctx, w.Client, hosts, w.ClusterID)
+	remoteManifests, err := listRemoteManifestsInAllLocations(ctx, w.Client, hosts, w.ClusterID)
 	if err != nil {
 		return errors.Wrap(err, "list manifests")
 	}
+	manifests := manifestInfos(remoteManifests)
 	// Get a list of stale tags
 	tags, err := staleTags(manifests, retentionMap)
 	if err != nil {
 		return errors.Wrap(err, "get stale snapshot tags")
 	}
+	protected := protectedTags(remoteManifests).List()
+	if len(protected) > 0 {
+		w.Logger.Info(ctx, "Skipping tags with manifests protected by retention lock or event based hold", "tags", protected)
+	}
+	tags.Remove(protected...)
 	oldest, err := oldestKeptTag(manifests, tags)
 	if err != nil {
 		return errors.Wrap(err, "get oldest kept snapshot")

--- a/pkg/service/backup/worker_purge.go
+++ b/pkg/service/backup/worker_purge.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 package backup
 
@@ -18,9 +18,13 @@ func (w *worker) Purge(ctx context.Context, hosts []hostInfo, retentionMap Reten
 		return errors.Wrap(err, "list manifests")
 	}
 	// Get a list of stale tags
-	tags, oldest, err := staleTags(manifests, retentionMap)
+	tags, err := staleTags(manifests, retentionMap)
 	if err != nil {
 		return errors.Wrap(err, "get stale snapshot tags")
+	}
+	oldest, err := oldestKeptTag(manifests, tags)
+	if err != nil {
+		return errors.Wrap(err, "get oldest kept snapshot")
 	}
 	// Get a nodeID manifests popping function
 	pop := popNodeIDManifestsForLocation(manifests)

--- a/pkg/service/backup/worker_retention_lock.go
+++ b/pkg/service/backup/worker_retention_lock.go
@@ -17,7 +17,7 @@ import (
 // retentionLockConfig holds retention lock parameters.
 type retentionLockConfig struct {
 	until    time.Time
-	mode     scyllaclient.RetentionLockMode
+	mode     RetentionLockMode
 	override bool
 }
 
@@ -29,7 +29,7 @@ func (w *worker) RetentionLock(egCtx context.Context, hosts []hostInfo, target T
 		mode:     target.RetentionLockMode,
 		override: target.OverrideRetentionLock,
 	}
-	if cfg.mode == scyllaclient.RetentionLockUnlocked || cfg.mode == scyllaclient.RetentionLockLocked {
+	if cfg.mode == RetentionLockUnlocked || cfg.mode == RetentionLockLocked {
 		lockUntil, err := retentionLockUntil(w.SnapshotTag, target.RetentionDays)
 		if err != nil {
 			return err
@@ -81,11 +81,11 @@ func (w *worker) lockSchemaFiles(ctx context.Context, hosts []hostInfo, cfg rete
 		remoteSchemaDir := hosts[i].Location.RemotePath(path.Dir(cqlPath))
 
 		switch cfg.mode {
-		case scyllaclient.RetentionLockUnlocked, scyllaclient.RetentionLockLocked:
+		case RetentionLockUnlocked, RetentionLockLocked:
 			if err := w.batchLock(ctx, hosts[i].IP, remoteSchemaDir, paths, cfg, "", ""); err != nil {
 				return errors.Wrapf(err, "await retention lock with node %s", hosts[i].IP)
 			}
-		case scyllaclient.RetentionLockEventBasedHold:
+		case RetentionLockEventBasedHold:
 			// Initialize holdHandler
 			apply := func(ctx context.Context, paths []string, hold bool) error {
 				return w.holdAndWait(ctx, hosts[i].IP, remoteSchemaDir, paths, hold, "", "")
@@ -128,7 +128,7 @@ func (w *worker) lockHostFiles(ctx context.Context, h *hostInfo, cfg retentionLo
 	remoteManifestPath := h.Location.RemotePath(manifestPath)
 	remoteManifestDir := path.Dir(remoteManifestPath)
 	switch cfg.mode {
-	case scyllaclient.RetentionLockUnlocked, scyllaclient.RetentionLockLocked:
+	case RetentionLockUnlocked, RetentionLockLocked:
 		// As we want to make this stage resumable, to discover files that
 		// need to be locked, we need to download manifest from backup location.
 		r, err := w.Client.RcloneOpen(ctx, h.IP, remoteManifestPath)
@@ -157,7 +157,7 @@ func (w *worker) lockHostFiles(ctx context.Context, h *hostInfo, cfg retentionLo
 		if err := w.lockAndAwait(ctx, h.IP, remoteManifestDir, []string{path.Base(remoteManifestPath)}, cfg, "", ""); err != nil {
 			return errors.Wrap(err, "lock manifest")
 		}
-	case scyllaclient.RetentionLockEventBasedHold:
+	case RetentionLockEventBasedHold:
 		// Initialize holdHandler
 		apply := func(ctx context.Context, paths []string, hold bool) error {
 			return w.holdAndWait(ctx, h.IP, remoteManifestDir, paths, hold, "", "")
@@ -244,7 +244,11 @@ func (w *worker) batchLock(ctx context.Context, host, remoteDir string,
 func (w *worker) lockAndAwait(ctx context.Context, host, remoteDir string,
 	paths []string, cfg retentionLockConfig, keyspace, table string,
 ) error {
-	jobID, err := w.Client.RcloneBatchRetentionLock(ctx, host, remoteDir, paths, cfg.mode, cfg.until, cfg.override)
+	mode, err := cfg.mode.toRetentionMode()
+	if err != nil {
+		return err
+	}
+	jobID, err := w.Client.RcloneBatchRetentionLock(ctx, host, remoteDir, paths, mode, cfg.until, cfg.override)
 	if err != nil {
 		return errors.Wrap(err, "schedule retention lock job")
 	}
@@ -329,11 +333,11 @@ type eventBasedHoldRequest struct {
 // of per-object request count, as on every backup run, we need to prolong
 // retention periods on all objects being a part of current snapshot,
 // even if they were deduplicated.
-// Backup made with scyllaclient.RetentionLockEventBasedHold aims to improve
+// Backup made with RetentionLockEventBasedHold aims to improve
 // this by relying on event based holds which don't need to be reset for
 // deduplicated objects, but need to be separately released when we expect
 // that the object won't be a part of next snapshots.
-// When making backup with scyllaclient.RetentionLockEventBasedHold,
+// When making backup with RetentionLockEventBasedHold,
 // we rely on 2 bucket level configurations:
 // - default retention period - ensures WORM backup
 // - default event based hold - optional, saves on per-object requests


### PR DESCRIPTION
This PR adds the notion of protected manifest - a manifest which has either event based hold set or is under not expired retention period.
Such manifests shouldn't be skipped during purge and explicit removal (sctool backup delete) of such manifests should return an error.
This is especially needed for event based hold backup, where we expect backup retention policy (--retention, --retention-days) to drift from the actual manifest protection, as:
- holds are released only during the next backup task execution
- we can't set exact retention date after hold is released - it simply starts the timer with the default bucket retention policy as soon as the hold is removed

Having said that, that's also useful for other WORM backup approaches where backup task retention policy has changed in between backup task executions.  

Fixes https://scylladb.atlassian.net/browse/CLOUD-3212