### PR TITLE
Handle tmp manifests from event based hold backup

### DIFF
--- a/pkg/service/backup/event_based_hold_interceptor_integration_test.go
+++ b/pkg/service/backup/event_based_hold_interceptor_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/scylla-manager/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
@@ -384,6 +385,7 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 	Print("Then: all files from the snapshot have event based hold")
 	tagAFiles := listSnapshotFiles(t, h, tagA.SnapshotTag)
 	assertObjectMetadataAll(t, h.Client, host, location, tagAFiles, true, "", time.Time{})
+	assertShadowedTemporaryManifests(t, h, tagA.SnapshotTag)
 
 	tagATOCFiles := make([]string, 0)
 	for _, file := range tagAFiles {
@@ -424,6 +426,7 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 	Print("Then: all files from the current snapshot have event based hold")
 	tagBFiles := listSnapshotFiles(t, h, tagB.SnapshotTag)
 	assertObjectMetadataAll(t, h.Client, host, location, tagBFiles, true, "", time.Time{})
+	assertShadowedTemporaryManifests(t, h, tagB.SnapshotTag)
 
 	tagBFilesSet := make(map[string]struct{}, len(tagBFiles))
 	for _, file := range tagBFiles {
@@ -441,6 +444,27 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 
 	Print("And: files from non-current snapshots don't have event based hold")
 	assertObjectMetadataAll(t, h.Client, host, location, tagAOnlyFiles, false, string(scyllaclient.RetentionModeLocked), baseTime.Add(policy))
+}
+
+func assertShadowedTemporaryManifests(t *testing.T, h *backupTestHelper, snapshotTag string) {
+	t.Helper()
+
+	manifests, _, _, _ := h.listS3Files()
+	manifestSet := strset.New(manifests...)
+	for _, m := range manifests {
+		if !strings.Contains(m, snapshotTag) {
+			continue
+		}
+		if strings.HasSuffix(m, backupspec.TempFileExt) {
+			if !manifestSet.Has(strings.TrimSuffix(m, backupspec.TempFileExt)) {
+				t.Fatalf("Expected temporary manifest %s to have regular shadowing copy", m)
+			}
+			continue
+		}
+		if !manifestSet.Has(backupspec.TempFile(m)) {
+			t.Fatalf("Expected manifest %s to have temporary shadowed copy", m)
+		}
+	}
 }
 
 func assertObjectMetadataAll(t *testing.T, client *scyllaclient.Client, host string, location backupspec.Location, files []string, hold bool, retentionMode string, retainUntil time.Time) {

--- a/pkg/service/backup/list.go
+++ b/pkg/service/backup/list.go
@@ -230,6 +230,32 @@ func filterManifests(manifests []*backupspec.ManifestInfo, filter ListFilter) []
 	return out
 }
 
+// filterShadowedTemporaryManifests filters out shadowed temporary manifests,
+// which are the temporary manifests that already have their regular counterpart.
+// This can happen when scyllaclient.RetentionLockEventBasedHold is used and
+// default retention policy is set on bucket's objects.
+func filterShadowedTemporaryManifests(manifests []*backupspec.ManifestInfo) []*backupspec.ManifestInfo {
+	regular := strset.New()
+	for _, m := range manifests {
+		if !m.Temporary {
+			regular.Add(m.Location.RemotePath(m.Path()))
+		}
+	}
+
+	var out []*backupspec.ManifestInfo
+	for _, m := range manifests {
+		if m.Temporary {
+			r := *m
+			r.Temporary = false
+			if regular.Has(r.Location.RemotePath(r.Path())) {
+				continue
+			}
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
 func groupManifestsByNode(manifests []*backupspec.ManifestInfo) map[string][]*backupspec.ManifestInfo {
 	v := map[string][]*backupspec.ManifestInfo{}
 	for _, m := range manifests {

--- a/pkg/service/backup/list_test.go
+++ b/pkg/service/backup/list_test.go
@@ -49,3 +49,81 @@ func TestListManifests(t *testing.T) {
 		}
 	})
 }
+
+func TestFilterShadowedTemporaryManifests(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nodeA        = "a"
+		nodeB        = "b"
+		snapshotTagA = "sm_19700101000000UTC"
+		snapshotTagB = "sm_19700101000001UTC"
+	)
+	var (
+		taskID        = uuid.MustRandom()
+		clusterID     = uuid.MustRandom()
+		location      = backupspec.Location{Provider: backupspec.S3, Path: "test"}
+		otherLocation = backupspec.Location{Provider: backupspec.S3, Path: "other"}
+	)
+	manifest := func(l backupspec.Location, nodeID, snapshotTag string, temporary bool) *backupspec.ManifestInfo {
+		return &backupspec.ManifestInfo{
+			Location:    l,
+			DC:          "dc1",
+			ClusterID:   clusterID,
+			NodeID:      nodeID,
+			TaskID:      taskID,
+			SnapshotTag: snapshotTag,
+			Temporary:   temporary,
+		}
+	}
+
+	var (
+		nodeATagARegular                = manifest(location, nodeA, snapshotTagA, false)
+		nodeATagATemporary              = manifest(location, nodeA, snapshotTagA, true)
+		nodeBTagATemporary              = manifest(location, nodeB, snapshotTagA, true)
+		nodeATagBTemporary              = manifest(location, nodeA, snapshotTagB, true)
+		nodeATagATemporaryOtherLocation = manifest(otherLocation, nodeA, snapshotTagA, true)
+		nodeBTagBRegular                = manifest(location, nodeB, snapshotTagB, false)
+	)
+
+	tests := []struct {
+		name      string
+		manifests []*backupspec.ManifestInfo
+		expected  []*backupspec.ManifestInfo
+	}{
+		{
+			name:      "shadowed temporary manifest is filtered out",
+			manifests: []*backupspec.ManifestInfo{nodeATagARegular, nodeATagATemporary},
+			expected:  []*backupspec.ManifestInfo{nodeATagARegular},
+		},
+		{
+			name:      "temporary manifest without regular counterpart is kept",
+			manifests: []*backupspec.ManifestInfo{nodeBTagBRegular, nodeATagATemporary},
+			expected:  []*backupspec.ManifestInfo{nodeBTagBRegular, nodeATagATemporary},
+		},
+		{
+			name:      "regular manifest of another node does not shadow temporary manifest",
+			manifests: []*backupspec.ManifestInfo{nodeATagARegular, nodeBTagATemporary},
+			expected:  []*backupspec.ManifestInfo{nodeATagARegular, nodeBTagATemporary},
+		},
+		{
+			name:      "regular manifest of another snapshot tag does not shadow temporary manifest",
+			manifests: []*backupspec.ManifestInfo{nodeATagARegular, nodeATagBTemporary},
+			expected:  []*backupspec.ManifestInfo{nodeATagARegular, nodeATagBTemporary},
+		},
+		{
+			name:      "regular manifest from another location does not shadow temporary manifest",
+			manifests: []*backupspec.ManifestInfo{nodeATagARegular, nodeATagATemporaryOtherLocation},
+			expected:  []*backupspec.ManifestInfo{nodeATagARegular, nodeATagATemporaryOtherLocation},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if diff := cmp.Diff(filterShadowedTemporaryManifests(test.manifests), test.expected, testutils.UUIDComparer()); diff != "" {
+				t.Fatalf("filterShadowedTemporaryManifests() diff\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/service/backup/purger.go
+++ b/pkg/service/backup/purger.go
@@ -204,6 +204,15 @@ func (p purger) PurgeSnapshotTags(ctx context.Context, manifests []*backupspec.M
 		if err := p.deleteFile(ctx, m.Location.RemotePath(alternatorPath)); err != nil {
 			p.logger.Info(ctx, "Remove alternator schema file", "path", alternatorPath, "error", err)
 		}
+		// Shadowed temporary manifests are not passed here,
+		// so we always want to double-check to remove temporary
+		// manifest when the regular one is deleted.
+		if !m.Temporary {
+			tempPath := backupspec.TempFile(m.Path())
+			if err := p.deleteFile(ctx, m.Location.RemotePath(tempPath)); err != nil {
+				p.logger.Info(ctx, "Failed to remove shadowed temporary manifest", "path", tempPath, "error", err)
+			}
+		}
 		if err := p.deleteFile(ctx, m.Location.RemotePath(m.Path())); err != nil {
 			p.logger.Info(ctx, "Failed to remove manifest", "path", m.Path(), "error", err)
 		} else {

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -1269,12 +1269,13 @@ func (s *Service) DeleteSnapshot(ctx context.Context, clusterID uuid.UUID, locat
 	if err != nil {
 		return errors.Wrap(err, "list manifests")
 	}
-	manifests := manifestInfos(remoteManifests)
-
+	// Look for protected tags first - temporary manifests can still protect the tag
 	protected := protectedTags(remoteManifests)
 	if protectedRemoved := strset.Intersection(protected, tags); !protectedRemoved.IsEmpty() {
 		return errors.Errorf("snapshots protected by retention lock or event based hold cannot be deleted: %v", protectedRemoved.List())
 	}
+	// Filter out temporary manifests shadowed by regular ones
+	manifests := filterShadowedTemporaryManifests(manifestInfos(remoteManifests))
 
 	oldest, err := oldestKeptTag(manifests, tags)
 	if err != nil {

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -2011,6 +2011,20 @@ func TestDeleteSnapshotIntegration(t *testing.T) {
 		t.Fatal("Expected to have different scylla manifest files in both tasks")
 	}
 
+	Print("Given: shadowed temporary manifest")
+	manifests, _, _, _ := h.listS3Files()
+	var shadowedManifest string
+	for _, m := range manifests {
+		if strings.Contains(m, h.TaskID.String()) {
+			shadowedManifest = m
+			break
+		}
+	}
+	h.tamperWithManifest(ctx, shadowedManifest, func(m backupspec.ManifestInfoWithContent) bool {
+		m.Temporary = true
+		return true
+	})
+
 	Print("When: first task snapshot is deleted")
 	firstTaskTags := taskTags(t, ctx, h, h.TaskID)
 	if firstTaskTags.Size() != 1 {
@@ -2022,7 +2036,7 @@ func TestDeleteSnapshotIntegration(t *testing.T) {
 	}
 
 	Print("Then: no sstables are removed")
-	_, _, files, scyllaManifests := h.listS3Files()
+	manifests, _, files, scyllaManifests := h.listS3Files()
 	if len(files) == 0 {
 		t.Fatal("Expected to have second task files in storage")
 	}
@@ -2035,6 +2049,11 @@ func TestDeleteSnapshotIntegration(t *testing.T) {
 	Print("And: scylla manifests from first task are removed")
 	if !strset.New(secondTaskScyllaManifestPaths...).IsEqual(strset.New(scyllaManifests...)) {
 		t.Fatal("First task scylla manifests were not removed during first task snapshot delete")
+	}
+
+	Print("And: shadowed temporary manifest is removed with its counterpart")
+	if _, temporaryManifests := splitManifests(manifests); len(temporaryManifests) != 0 {
+		t.Fatalf("Expected no temporary manifests, got %s", strings.Join(temporaryManifests, "\n"))
 	}
 
 	Print("When: last snapshot is removed")

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -269,6 +269,18 @@ func (h *backupTestHelper) listS3Files() (manifests, schemas, files, scyllaManif
 	return
 }
 
+// splitManifests divides manifest paths into the regular and the temporary ones.
+func splitManifests(manifests []string) (regular, temporary []string) {
+	for _, m := range manifests {
+		if strings.HasSuffix(m, backupspec.TempFileExt) {
+			temporary = append(temporary, m)
+		} else {
+			regular = append(regular, m)
+		}
+	}
+	return
+}
+
 func restartAgents(h *CommonTestHelper) {
 	execOnAllHosts(h, "supervisorctl restart scylla-manager-agent")
 }
@@ -1782,10 +1794,24 @@ func TestPurgeIntegration(t *testing.T) {
 		m.SnapshotTag = backupspec.SnapshotTagAt(now.AddDate(0, 0, -1))
 		return true
 	})
+	Print("And: temporary manifest shadowed by it - should NOT be removed")
+	h.tamperWithManifest(ctx, manifests[0], func(m backupspec.ManifestInfoWithContent) bool {
+		m.TaskID = task2
+		m.SnapshotTag = backupspec.SnapshotTagAt(now.AddDate(0, 0, -1))
+		m.Temporary = true
+		return true
+	})
 	Print("And: add another manifest for task2 - should be removed")
 	h.tamperWithManifest(ctx, manifests[0], func(m backupspec.ManifestInfoWithContent) bool {
 		m.TaskID = task2
 		m.SnapshotTag = backupspec.SnapshotTagAt(now.AddDate(0, 0, -2))
+		return true
+	})
+	Print("And: temporary manifest shadowed by it - should be removed with it")
+	h.tamperWithManifest(ctx, manifests[0], func(m backupspec.ManifestInfoWithContent) bool {
+		m.TaskID = task2
+		m.SnapshotTag = backupspec.SnapshotTagAt(now.AddDate(0, 0, -2))
+		m.Temporary = true
 		return true
 	})
 	Print("And: add 2 hour old manifest for task 3 - should NOT be removed")
@@ -1827,9 +1853,14 @@ func TestPurgeIntegration(t *testing.T) {
 	}
 
 	Print("Then: there should be 3 + 4 manifests")
-	manifests, _, files, scyllaManifests := h.listS3Files()
+	allManifests, _, files, scyllaManifests := h.listS3Files()
+	manifests, temporaryManifests := splitManifests(allManifests)
 	if len(manifests) != 7 {
 		t.Fatalf("Expected 7 manifests (1 per each node) plus 4 generated, got %d %s", len(manifests), strings.Join(manifests, "\n"))
+	}
+	Print("And: only the temporary manifest shadowed by the kept manifest is left")
+	if len(temporaryManifests) != 1 {
+		t.Fatalf("Expected 1 temporary manifest, got %d %s", len(temporaryManifests), strings.Join(temporaryManifests, "\n"))
 	}
 
 	Print("And: old files (sstables and scylla manifests) are removed")

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -2271,6 +2271,12 @@ func TestValidateIntegration(t *testing.T) {
 		return true
 	})
 
+	Print("And: add shadowed temporary manifest - should be ignored")
+	h.tamperWithManifest(ctx, manifests[0], func(m backupspec.ManifestInfoWithContent) bool {
+		m.Temporary = true
+		return true
+	})
+
 	Print("And: add tampered manifest - should be reported as broken snapshot")
 	h.tamperWithManifest(ctx, manifests[1], func(m backupspec.ManifestInfoWithContent) bool {
 		m.SnapshotTag = tamperedSnapshotTag

--- a/pkg/service/backup/validation.go
+++ b/pkg/service/backup/validation.go
@@ -171,6 +171,12 @@ func (s *Service) Validate(ctx context.Context, clusterID, taskID, runID uuid.UU
 	if err != nil {
 		return errors.Wrap(err, "list manifests")
 	}
+	// Pass only the not shadowed temporary manifests to validation logic.
+	// It's not strictly needed for correctness, as validation treats
+	// temporary manifests as ones coming from ongoing backup and ignores
+	// them, but it would still result in downloading and reading them,
+	// so it's better to filter them out.
+	manifests = filterShadowedTemporaryManifests(manifests)
 	// Get a nodeID manifests popping function
 	pop := popNodeIDManifestsForLocation(manifests)
 

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -121,13 +121,16 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 		if err != nil {
 			return errors.Wrap(err, "deduplication based on .crc32 content")
 		}
-		if applyHolds && willCreateVersioned {
+		if willCreateVersioned && w.RetentionLockMode != RetentionLockDisabled {
 			// Creation of versioned sstable happens by copying old sstable version with appended version
 			// suffix, then removing the original old version, then uploading the new version.
 			// This is not compatible with event based hold backup, where default backup retention policy
-			// is expected to prevent files from being deleted.
+			// is expected to prevent files from being deleted. We could make it work for object retention
+			// lock backup, but since this is an edge-case that might not even exist with modern UUID based
+			// SSTables, we simply don't need to support it. This would add both implementation and performance
+			// implications, as it would require listing snapshot dirs in stage retention lock.
 			return errors.Errorf("host %s: table %s.%s: snapshot contains sstables with integer based IDs which upload would result in creation of versioned files. "+
-				"Upload of such snapshot is not compatible with event based hold backup. "+
+				"Upload of such snapshot is not compatible with --retention-lock-mode backup. "+
 				"To proceed, make sure that new sstables use UUID based IDs and compact the integer based sstables away. "+
 				"Then, start the backup task from scratch.", h.IP, d.Keyspace, d.Table)
 		}

--- a/pkg/service/backup/worker_manifest.go
+++ b/pkg/service/backup/worker_manifest.go
@@ -191,6 +191,12 @@ func (w *worker) uploadScyllaManifests(ctx context.Context, h hostInfo, m backup
 }
 
 func (w *worker) MoveManifest(ctx context.Context, hosts []hostInfo) (err error) {
+	// When scyllaclient.RetentionLockEventBasedHold is used, objects can't be deleted
+	// from quickly deleted from backup bucket because default retention policy is used.
+	// This makes moving and rolling back temporary manifests impossible.
+	// In such case, they need to be copied and other places in the codebase
+	// needs to expect their existence.
+	copyInstead := w.RetentionLockMode == RetentionLockEventBasedHold
 	rollbacks := make([]func(context.Context) error, len(hosts))
 
 	f := func(i int) (hostErr error) {
@@ -199,9 +205,25 @@ func (w *worker) MoveManifest(ctx context.Context, hosts []hostInfo) (err error)
 			hostErr = errors.Wrap(hostErr, h.String())
 		}()
 
-		w.Logger.Info(ctx, "Moving manifest file on host", "host", h.IP)
 		dst := h.Location.RemotePath(backupspec.RemoteManifestFile(w.ClusterID, w.TaskID, w.SnapshotTag, h.DC, h.ID))
 		src := backupspec.TempFile(dst)
+
+		if copyInstead {
+			w.Logger.Info(ctx, "Copying manifest file on host", "host", h.IP)
+
+			if err := w.Client.RcloneCopyFile(ctx, h.IP, dst, src); err != nil {
+				// Check if manifest has already been copied during the previous run
+				if fi, e := w.Client.RcloneFileInfo(ctx, h.IP, dst); e == nil && fi != nil {
+					w.Logger.Info(ctx, "Copied manifest was already in place", "host", h.IP)
+					return nil
+				}
+				return err
+			}
+			w.Logger.Info(ctx, "Done copying manifest file on host", "host", h.IP)
+			return nil
+		}
+
+		w.Logger.Info(ctx, "Moving manifest file on host", "host", h.IP)
 
 		// Register rollback
 		rollbacks[i] = func(ctx context.Context) error { return w.Client.RcloneMoveFile(ctx, h.IP, src, dst) }

--- a/pkg/service/backup/worker_purge.go
+++ b/pkg/service/backup/worker_purge.go
@@ -17,16 +17,19 @@ func (w *worker) Purge(ctx context.Context, hosts []hostInfo, retentionMap Reten
 	if err != nil {
 		return errors.Wrap(err, "list manifests")
 	}
-	manifests := manifestInfos(remoteManifests)
+	// Look for protected tags first - temporary manifests can still protect the tag
+	protected := protectedTags(remoteManifests).List()
+	if len(protected) > 0 {
+		w.Logger.Info(ctx, "Skipping tags with manifests protected by retention lock or event based hold", "tags", protected)
+	}
+	// Filter out temporary manifests shadowed by regular ones
+	manifests := filterShadowedTemporaryManifests(manifestInfos(remoteManifests))
 	// Get a list of stale tags
 	tags, err := staleTags(manifests, retentionMap)
 	if err != nil {
 		return errors.Wrap(err, "get stale snapshot tags")
 	}
-	protected := protectedTags(remoteManifests).List()
-	if len(protected) > 0 {
-		w.Logger.Info(ctx, "Skipping tags with manifests protected by retention lock or event based hold", "tags", protected)
-	}
+	// Make sure that stale tags don't include protected ones
 	tags.Remove(protected...)
 	oldest, err := oldestKeptTag(manifests, tags)
 	if err != nil {

--- a/pkg/service/backup/worker_retention_lock.go
+++ b/pkg/service/backup/worker_retention_lock.go
@@ -165,7 +165,10 @@ func (w *worker) lockHostFiles(ctx context.Context, h *hostInfo, cfg retentionLo
 		holdHandler := newEventBasedHoldHandler(apply, eventBasedHoldBatchSize)
 		// Feed local files - even though manifests have already been uploaded,
 		// we still treat them as local for the purposes of applying/removing the hold.
+		// For consistency, we also treat shadowed temporary manifest as local,
+		// so that its hold cycle follows the regular manifest cycle.
 		holdHandler.addLocal(path.Base(remoteManifestPath))
+		holdHandler.addLocal(backupspec.TempFile(path.Base(remoteManifestPath)))
 		holdHandler.finalizeLocal()
 		// Feed remote files - limit to manifests coming from the same task ID,
 		// so that we reduce interference between multiple backup tasks.

--- a/pkg/service/one2onerestore/helpers_integration_test.go
+++ b/pkg/service/one2onerestore/helpers_integration_test.go
@@ -68,6 +68,11 @@ func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {
 	taskID := uuid.NewTime()
 	runID := uuid.NewTime()
 
+	retMode, ok := props["retention_lock_mode"].(backup.RetentionLockMode)
+	if ok && retMode == backup.RetentionLockEventBasedHold {
+		delete(props, "retention_lock_mode")
+	}
+
 	rawProps, err := json.Marshal(props)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "marshal properties"))
@@ -76,6 +81,9 @@ func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {
 	target, err := h.backupSvc.GetTarget(ctx, h.clusterID, rawProps)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "generate target"))
+	}
+	if ok && retMode == backup.RetentionLockEventBasedHold {
+		target.RetentionLockMode = backup.RetentionLockEventBasedHold
 	}
 
 	err = h.backupSvc.Backup(ctx, h.clusterID, taskID, runID, target)

--- a/pkg/service/one2onerestore/service_integration_test.go
+++ b/pkg/service/one2onerestore/service_integration_test.go
@@ -7,6 +7,7 @@ package one2onerestore
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/gocqlx/v2/qb"
 	"github.com/scylladb/scylla-manager/backupspec"
+	"github.com/scylladb/scylla-manager/v3/pkg/service/backup"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
@@ -117,6 +119,71 @@ func TestOne2OneRestoreServiceIntegration(t *testing.T) {
 		}
 		validateGetProgress(t, pr)
 	})
+}
+
+func TestOne2OneRestoreRetentionLockIntegration(t *testing.T) {
+	// This test validates that restore works with backups
+	// made with different WORM --retention-lock-mode values.
+	if tablets := os.Getenv("TABLETS"); tablets == "enabled" || tablets == "none" {
+		t.Skip("1-1-restore is available only for v-nodes")
+	}
+	h := newTestHelper(t, ManagedClusterHosts())
+	clusterSession := CreateSessionAndDropAllKeyspaces(t, h.client)
+	loc := []backupspec.Location{testLocation("retention-lock", "")}
+	loc[0].Provider = backupspec.GCS
+	GCSInitBucket(t, loc[0].Path)
+
+	ks := "test_retention_lock"
+	WriteData(t, clusterSession, ks, 1)
+	srcRowCnt := rowCount(t, clusterSession, ks, BigTableName)
+	if srcRowCnt == 0 {
+		t.Fatalf("Unexpected row count in table: 0")
+	}
+	nodeMappings := getNodeMappings(t, h.client)
+
+	testCases := []struct {
+		name        string
+		backupProps map[string]any
+	}{
+		{
+			name: "retention lock",
+			backupProps: map[string]any{
+				"retention_days":      1,
+				"retention_lock_mode": backup.RetentionLockUnlocked,
+			},
+		},
+		{
+			name: "event based hold",
+			backupProps: map[string]any{
+				"retention_lock_mode": backup.RetentionLockEventBasedHold,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			Print("When: WORM backup is executed")
+			backupProps := map[string]any{
+				"location": loc,
+				"keyspace": []string{ks},
+			}
+			maps.Copy(backupProps, tc.backupProps)
+			tag := h.runBackup(t, backupProps)
+
+			Print("And: restore target table is truncated")
+			truncateAllTablesInKeyspace(t, clusterSession, ks)
+
+			Print("Then: 1-1-restore succeeds")
+			h.runRestore(t, map[string]any{
+				"location":          loc,
+				"snapshot_tag":      tag,
+				"source_cluster_id": h.clusterID,
+				"nodes_mapping":     nodeMappings,
+			})
+			if dstRowCnt := rowCount(t, clusterSession, ks, BigTableName); srcRowCnt != dstRowCnt {
+				t.Fatalf("Expected row count in table %d, but got %d", srcRowCnt, dstRowCnt)
+			}
+		})
+	}
 }
 
 type testTable struct {

--- a/pkg/service/one2onerestore/worker_manifest.go
+++ b/pkg/service/one2onerestore/worker_manifest.go
@@ -22,19 +22,42 @@ func (w *worker) getManifestInfo(ctx context.Context, host, snapshotTag string, 
 		Recurse:   true,
 	}
 
-	var manifests []*backupspec.ManifestInfo
+	regular := map[backupspec.ManifestInfo]struct{}{}
+	tmp := map[backupspec.ManifestInfo]struct{}{}
 	err := w.client.RcloneListDirIter(ctx, host, location.RemotePath(metaBaseDir), &opts, func(f *scyllaclient.RcloneListDirItem) {
 		m := new(backupspec.ManifestInfo)
 		if err := m.ParsePath(path.Join(metaBaseDir, f.Path)); err != nil {
 			return
 		}
 		m.Location = location
-		if m.ClusterID == clusterID && m.SnapshotTag == snapshotTag {
-			manifests = append(manifests, m)
+		if m.ClusterID != clusterID || m.SnapshotTag != snapshotTag {
+			return
 		}
+		if m.Temporary {
+			tmp[*m] = struct{}{}
+			return
+		}
+		regular[*m] = struct{}{}
 	})
 	if err != nil {
 		return nil, err
+	}
+	// Validate that the only encountered temporary manifests
+	// are shadowed by regular ones - otherwise we are trying
+	// to restore partial backup.
+	for m := range tmp {
+		r := m
+		r.Temporary = false
+		if _, ok := regular[r]; !ok {
+			return nil, errors.Errorf("temporary manifest %s is not shadowed by regular manifest. "+
+				"This might mean that snapshot %s wasn't fully uploaded or that it was partially deleted. "+
+				"Validate snapshot correctness and remove/promote the temporary manifest before proceeding.", m.Path(), snapshotTag)
+		}
+	}
+	// Don't return shadowed temporary manifests.
+	manifests := make([]*backupspec.ManifestInfo, 0, len(regular))
+	for m := range regular {
+		manifests = append(manifests, new(m))
 	}
 	return manifests, nil
 }

--- a/pkg/service/one2onerestore/worker_validate_integration_test.go
+++ b/pkg/service/one2onerestore/worker_validate_integration_test.go
@@ -5,6 +5,7 @@
 package one2onerestore
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"math/rand/v2"
@@ -52,6 +53,15 @@ func TestWorkerValidateClustersIntegration(t *testing.T) {
 	}
 
 	nodeMappings := getNodeMappings(t, w.client)
+
+	t.Run("temporary and shadowed manifests", func(t *testing.T) {
+		target := Target{
+			SourceClusterID: h.clusterID,
+			SnapshotTag:     snapshotTag,
+			Location:        []backupspec.Location{loc},
+		}
+		testTmpShadowedManifest(t, w, target)
+	})
 
 	testCases := []struct {
 		name                 string
@@ -236,6 +246,100 @@ func TestWorkerValidateClustersIntegration(t *testing.T) {
 			hrt.SetInterceptor(nil)
 		})
 	}
+}
+
+// testTmpShadowedManifest tests that 1-1-restore ignores shadowed temporary
+// manifests when listing. It also validates, that it fails validation
+// when not shadowed temporary manifest is encountered.
+// This test helper assumes that a backup was already executed.
+func testTmpShadowedManifest(t *testing.T, w *worker, target Target) {
+	t.Helper()
+
+	ctx := context.Background()
+	location := target.Location[0]
+	host := w.client.Config().Hosts[0]
+	manifests, _, _, _ := listBucketFiles(t, ctx, w.client, location)
+	// Find already uploaded manifest
+	var manifestInfo backupspec.ManifestInfo
+	for _, m := range manifests {
+		if !strings.Contains(m, target.SnapshotTag) {
+			continue
+		}
+		mi := backupspec.ManifestInfo{}
+		if err := mi.ParsePath(m); err != nil {
+			t.Fatal(err)
+		}
+		if mi.Temporary {
+			continue
+		}
+		mi.Location = location
+		manifestInfo = mi
+		break
+	}
+	if manifestInfo.SnapshotTag != target.SnapshotTag {
+		t.Fatalf("Manifest for snapshot tag %s not found", target.SnapshotTag)
+	}
+	// Inject unshadowed temporary manifest
+	temporaryManifest := manifestInfo
+	temporaryManifest.NodeID = uuid.MustRandom().String()
+	temporaryManifest.Temporary = true
+	if err := w.client.RclonePut(ctx, host, location.RemotePath(temporaryManifest.Path()), bytes.NewBufferString("broken manifest")); err != nil {
+		t.Fatal(err)
+	}
+	// Expect it to cause validation error
+	if _, _, err := w.getAllSnapshotManifestsAndTargetHosts(ctx, target); err == nil {
+		t.Fatal("Expected unshadowed temporary manifest to fail 1-1-restore target validation")
+	}
+	// Replace unshadowed temporary manifest with a shadowed one.
+	if err := w.client.RcloneDeleteFile(ctx, host, location.RemotePath(temporaryManifest.Path())); err != nil {
+		t.Fatal(err)
+	}
+	shadowed := manifestInfo
+	shadowed.Temporary = true
+	if err := w.client.RclonePut(ctx, host, location.RemotePath(shadowed.Path()), bytes.NewBufferString("broken manifest")); err != nil {
+		t.Fatal(err)
+	}
+	// Expect shadowed temporary manifest to not cause problems and not be returned
+	got, _, err := w.getAllSnapshotManifestsAndTargetHosts(ctx, target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, m := range got {
+		if m.Temporary {
+			t.Fatalf("Expected shadowed temporary manifest not to be returned: %s", m.Path())
+		}
+	}
+}
+
+func listBucketFiles(t *testing.T, ctx context.Context, client *scyllaclient.Client, location backupspec.Location) (manifests, schemas, files, scyllaManifests []string) {
+	t.Helper()
+
+	host := client.Config().Hosts[0]
+	opts := &scyllaclient.RcloneListDirOpts{
+		Recurse:   true,
+		FilesOnly: true,
+	}
+	allFiles, err := client.RcloneListDir(ctx, host, location.RemotePath(""), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range allFiles {
+		switch {
+		case strings.HasPrefix(f.Path, ".permission-check"):
+			// Ignore permission check leftover.
+		case strings.HasPrefix(f.Path, "backup/meta"):
+			manifests = append(manifests, f.Path)
+		case strings.HasPrefix(f.Path, "backup/schema"):
+			schemas = append(schemas, f.Path)
+		case strings.HasPrefix(f.Path, "backup/sst") && strings.HasSuffix(f.Path, backupspec.ScyllaManifest):
+			scyllaManifests = append(scyllaManifests, f.Path)
+		case strings.HasPrefix(f.Path, "backup/sst"):
+			files = append(files, f.Path)
+		default:
+			t.Fatalf("Unexpected file type in backup dir: %s", f.Path)
+		}
+	}
+	return
 }
 
 func newTestWorker(t *testing.T, hosts []string) (*worker, *testutils.HackableRoundTripper) {

--- a/pkg/service/restore/helper_integration_test.go
+++ b/pkg/service/restore/helper_integration_test.go
@@ -259,6 +259,11 @@ func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {
 	ctx := context.Background()
 	h.srcCluster.RunID = uuid.NewTime()
 
+	retMode, ok := props["retention_lock_mode"].(backup.RetentionLockMode)
+	if ok && retMode == backup.RetentionLockEventBasedHold {
+		delete(props, "retention_lock_mode")
+	}
+
 	rawProps, err := json.Marshal(props)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "marshal properties"))
@@ -267,6 +272,9 @@ func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {
 	target, err := h.srcBackupSvc.GetTarget(ctx, h.srcCluster.ClusterID, rawProps)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "generate target"))
+	}
+	if ok && retMode == backup.RetentionLockEventBasedHold {
+		target.RetentionLockMode = backup.RetentionLockEventBasedHold
 	}
 
 	err = h.srcBackupSvc.Backup(ctx, h.srcCluster.ClusterID, h.srcCluster.TaskID, h.srcCluster.RunID, target)

--- a/pkg/service/restore/restore_integration_test.go
+++ b/pkg/service/restore/restore_integration_test.go
@@ -159,6 +159,69 @@ func TestRestoreTablesNoReplicationIntegration(t *testing.T) {
 	h.validateIdenticalTables(t, []table{{ks: ks, tab: tab}})
 }
 
+func TestRestoreTablesRetentionLockIntegration(t *testing.T) {
+	// This test validates that restore works with backups
+	// made with different WORM --retention-lock-mode values.
+	h := newTestHelper(t, ManagedSecondClusterHosts(), ManagedClusterHosts())
+	loc := testLocation("retention-lock", "")
+	loc.Provider = backupspec.GCS
+	GCSInitBucket(t, loc.Path)
+
+	ks := randomizedName("worm_ks_")
+	tab := randomizedName("tab_")
+	Printf("Create %s.%s in both clusters", ks, tab)
+	ksStmt := fmt.Sprintf("CREATE KEYSPACE %q WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}", ks)
+	ExecStmt(t, h.srcCluster.rootSession, ksStmt)
+	ExecStmt(t, h.dstCluster.rootSession, ksStmt)
+	createTable(t, h.srcCluster.rootSession, ks, tab)
+	createTable(t, h.dstCluster.rootSession, ks, tab)
+
+	Print("Fill created table")
+	fillTable(t, h.srcCluster.rootSession, 100, ks, tab)
+
+	ksFilter := []string{ks}
+	grantRestoreTablesPermissions(t, h.dstCluster.rootSession, ksFilter, h.dstUser)
+
+	testCases := []struct {
+		name        string
+		backupProps map[string]any
+	}{
+		{
+			name: "retention lock",
+			backupProps: map[string]any{
+				"retention_days":      1,
+				"retention_lock_mode": backup.RetentionLockUnlocked,
+				"method":              backup.MethodAuto,
+			},
+		},
+		{
+			name: "event based hold",
+			backupProps: map[string]any{
+				"retention_lock_mode": backup.RetentionLockEventBasedHold,
+				"method":              backup.MethodAuto,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			Print("When: WORM backup is executed")
+			backupProps := defaultTestBackupProperties(loc, ks)
+			maps.Copy(backupProps, tc.backupProps)
+			tag := h.runBackup(t, backupProps)
+
+			Print("And: restore target table is truncated")
+			ExecStmt(t, h.dstCluster.rootSession, fmt.Sprintf("TRUNCATE TABLE %q.%q", ks, tab))
+
+			Print("Then: restore succeeds")
+			h.dstCluster.TaskID = uuid.NewTime()
+			props := defaultTestProperties(loc, tag, true)
+			props["keyspace"] = ksFilter
+			h.runRestore(t, props)
+			h.validateIdenticalTables(t, []table{{ks: ks, tab: tab}})
+		})
+	}
+}
+
 func TestRestoreSchemaRoundtripIntegration(t *testing.T) {
 	// Test scenario for both CQL and alternator schema:
 	// - create schema on src cluster

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -728,6 +728,10 @@ func smokeRestore(t *testing.T, target Target, keyspace string, loadCnt, loadSiz
 		target.SnapshotTag = srcH.simpleBackup(target.Location[0])
 	}
 
+	t.Run("temporary and shadowed manifests", func(t *testing.T) {
+		srcH.testTmpShadowedManifest(t, ctx, dstH, target)
+	})
+
 	ni, err := dstH.Client.AnyNodeInfo(t.Context())
 	if err != nil {
 		t.Fatal(err)
@@ -969,7 +973,6 @@ func restoreWithResume(t *testing.T, target Target, keyspace string, loadCnt, lo
 	if !strings.Contains(err.Error(), "context") {
 		t.Fatalf("Expected context error but got: %+v", err)
 	}
-
 
 	Print("When: resume restore and complete it")
 	dstH.RunID = uuid.MustRandom()
@@ -1390,6 +1393,91 @@ func (h *restoreTestHelper) targetToProperties(target Target) json.RawMessage {
 		h.T.Fatal(err)
 	}
 	return props
+}
+
+// testTmpShadowedManifest tests that restore ignores shadowed temporary manifests
+// when creating restored units. It also validates, that it fails validation
+// when not shadowed temporary manifest is encountered.
+// This test helper assumes that a backup was already executed.
+func (h *restoreTestHelper) testTmpShadowedManifest(t *testing.T, ctx context.Context, dstH *restoreTestHelper, target Target) {
+	location := target.Location[0]
+	host := h.Client.Config().Hosts[0]
+	manifests, _, _, _ := h.listBucketFiles(ctx, location)
+	// Find already uploaded manifest
+	var manifestInfo backupspec.ManifestInfo
+	for _, m := range manifests {
+		if !strings.Contains(m, target.SnapshotTag) {
+			continue
+		}
+		mi := backupspec.ManifestInfo{}
+		if err := mi.ParsePath(m); err != nil {
+			t.Fatal(err)
+		}
+		if mi.Temporary {
+			continue
+		}
+		mi.Location = location
+		manifestInfo = mi
+		break
+	}
+	if manifestInfo.SnapshotTag != target.SnapshotTag {
+		t.Fatalf("Manifest for snapshot tag %s not found", target.SnapshotTag)
+	}
+	// Inject not shadowed temporary manifest
+	temporaryManifest := manifestInfo
+	temporaryManifest.NodeID = uuid.MustRandom().String()
+	temporaryManifest.Temporary = true
+	if err := h.Client.RclonePut(ctx, host, location.RemotePath(temporaryManifest.Path()), bytes.NewBufferString("broken manifest")); err != nil {
+		t.Fatal(err)
+	}
+	// Expect it to cause validation error
+	if _, _, _, err := dstH.service.GetTargetUnitsViews(ctx, dstH.ClusterID, dstH.targetToProperties(target)); err == nil {
+		t.Fatal("Expected unshadowed temporary manifest to fail restore target validation")
+	}
+	// Replace not shadowed temporary manifest with a shadowed one.
+	if err := h.Client.RcloneDeleteFile(ctx, host, location.RemotePath(temporaryManifest.Path())); err != nil {
+		t.Fatal(err)
+	}
+	shadowed := manifestInfo
+	shadowed.Temporary = true
+	if err := h.Client.RclonePut(ctx, host, location.RemotePath(shadowed.Path()), bytes.NewBufferString("broken manifest")); err != nil {
+		t.Fatal(err)
+	}
+	// Expect shadowed temporary manifest to not cause problems
+	if _, _, _, err := dstH.service.GetTargetUnitsViews(ctx, dstH.ClusterID, dstH.targetToProperties(target)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (h *restoreTestHelper) listBucketFiles(ctx context.Context, location backupspec.Location) (manifests, schemas, files, scyllaManifests []string) {
+	h.T.Helper()
+
+	host := h.Client.Config().Hosts[0]
+	opts := &scyllaclient.RcloneListDirOpts{
+		Recurse:   true,
+		FilesOnly: true,
+	}
+	allFiles, err := h.Client.RcloneListDir(ctx, host, location.RemotePath(""), opts)
+	if err != nil {
+		h.T.Fatal(err)
+	}
+	for _, f := range allFiles {
+		switch {
+		case strings.HasPrefix(f.Path, ".permission-check"):
+			// Ignore permission check leftover.
+		case strings.HasPrefix(f.Path, "backup/meta"):
+			manifests = append(manifests, f.Path)
+		case strings.HasPrefix(f.Path, "backup/schema"):
+			schemas = append(schemas, f.Path)
+		case strings.HasPrefix(f.Path, "backup/sst") && strings.HasSuffix(f.Path, backupspec.ScyllaManifest):
+			scyllaManifests = append(scyllaManifests, f.Path)
+		case strings.HasPrefix(f.Path, "backup/sst"):
+			files = append(files, f.Path)
+		default:
+			h.T.Fatalf("Unexpected file type in backup dir: %s", f.Path)
+		}
+	}
+	return
 }
 
 func (h *restoreTestHelper) validateRestoreSuccess(dstSession, srcSession gocqlx.Session, target Target, tables []table) {

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -717,16 +717,7 @@ func smokeRestore(t *testing.T, target Target, keyspace string, loadCnt, loadSiz
 	}
 
 	srcH.prepareRestoreBackup(srcSession, keyspace, loadCnt, loadSize)
-	// Additionally validate that backup retention
-	// locks don't interfere with restore procedure.
-	if target.Location[0].Provider == backupspec.GCS {
-		backupProps := defaultTestBackupProperties(target.Location[0], "")
-		backupProps["retention_days"] = 1
-		backupProps["retention_lock_mode"] = "unlocked"
-		target.SnapshotTag = srcH.simpleBackupWithProperties(target.Location[0], backupProps)
-	} else {
-		target.SnapshotTag = srcH.simpleBackup(target.Location[0])
-	}
+	target.SnapshotTag = srcH.simpleBackup(target.Location[0])
 
 	t.Run("temporary and shadowed manifests", func(t *testing.T) {
 		srcH.testTmpShadowedManifest(t, ctx, dstH, target)

--- a/pkg/service/restore/worker_manifest.go
+++ b/pkg/service/restore/worker_manifest.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"sort"
 
+	"github.com/pkg/errors"
 	"github.com/scylladb/scylla-manager/backupspec"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"go.uber.org/multierr"
@@ -47,24 +48,46 @@ func (w *worker) getManifestInfo(ctx context.Context, host string, location back
 		Recurse:   true,
 	}
 
-	var manifests []*backupspec.ManifestInfo
+	regular := map[backupspec.ManifestInfo]struct{}{}
+	tmp := map[backupspec.ManifestInfo]struct{}{}
 	err := w.client.RcloneListDirIter(ctx, host, location.RemotePath(baseDir), &opts, func(f *scyllaclient.RcloneListDirItem) {
 		m := new(backupspec.ManifestInfo)
 		if err := m.ParsePath(path.Join(baseDir, f.Path)); err != nil {
 			return
 		}
 		m.Location = location
-		if m.SnapshotTag == snapshotTag {
-			manifests = append(manifests, m)
+		if m.SnapshotTag != snapshotTag {
+			return
 		}
+		if m.Temporary {
+			tmp[*m] = struct{}{}
+			return
+		}
+		regular[*m] = struct{}{}
 	})
 	if err != nil {
 		return nil, err
 	}
-
+	// Validate that the only encountered temporary manifests
+	// are shadowed by regular ones - otherwise we are trying
+	// to restore partial backup.
+	for m := range tmp {
+		r := m
+		r.Temporary = false
+		if _, ok := regular[r]; !ok {
+			return nil, errors.Errorf("temporary manifest %s is not shadowed by regular manifest. "+
+				"This might mean that snapshot %s wasn't fully uploaded or that it was partially deleted. "+
+				"Validate snapshot correctness and remove/promote the temporary manifest before proceeding.", m.Path(), snapshotTag)
+		}
+	}
+	// Don't return shadowed temporary manifests
+	out := make([]*backupspec.ManifestInfo, 0, len(regular))
+	for m := range regular {
+		out = append(out, new(m))
+	}
 	// Ensure deterministic order
-	sort.Slice(manifests, func(i, j int) bool {
-		return manifests[i].NodeID < manifests[j].NodeID
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].NodeID < out[j].NodeID
 	})
-	return manifests, nil
+	return out, nil
 }


### PR DESCRIPTION
This PR targets the event based hold backup and temporary manifest interaction.
Since event based hold backup is executed with default bucket retention policy, it makes it impossible to delete tmp manifests shortly after they were uploaded. This means that we can't replace them with regular manifests, but instead we need to keep them both.
This creates friction with multiple places in SM codebase, as the existence of tmp manifests used to indicate partial or ongoing backup.

This PR starts by preparing all impacted places in SM codebase for the existence of shadowed tmp manifest.
Temporary manifest is "shadowed", when it has also corresponding regular manifest.
Most places in SM codebase should simply ignore shadowed tmp manifests.
In terms of places like purge and delete snapshot, which are also responsible for tmp manifest cleanup - shadowed manifests are also ignored (so that we don't need to read and parse the same manifest contents multiple times), but the cleanup mechanism will try to also remove tmp manifest anyway.

This PR introduces multiple integration tests, but I also executed its dirty version against CI where all backups were event based hold by default, and apart from failures related to wrong expected manifest count in some bakcup tests, all of them passed.

Fixes https://scylladb.atlassian.net/browse/CLOUD-3214
