### PR TITLE
fix(dist): use '-' separator in VERSION_NAME for valid semver tag

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -8,7 +8,7 @@ endif
 
 ifeq ($(PUBLISH),0)
 publish = --skip=publish
-VERSION_NAME := $(VERSION).$(RELEASE)
+VERSION_NAME := $(VERSION)-$(RELEASE)
 else
 VERSION_NAME := v$(VERSION)
 endif


### PR DESCRIPTION
PR #4866 changed **VERSION_NAME** to join `VERSION` and `RELEASE` with `'.'` (`'$(VERSION).$(RELEASE)'`) to remove underscores from unstable package versions. On master this yields a valid semver git tag (e.g. `'3.12.0-dev.0.<date>.<sha>'`), but on release branches VERSION is a plain semver core (e.g. `'3.11.2'`), producing `'3.11.2.0.<date>.<sha>'` - a four-segment, invalid semver tag. goreleaser then fails with `"failed to parse tag as semver: Invalid Semantic Version"`, breaking all non-master build jobs.

Revert VERSION_NAME to the '-' separator ('$(VERSION)-$(RELEASE)'), which introduces the RELEASE as a semver pre-release on both master (`'3.12.0-dev-0.<date>.<sha>'`) and release branches (`'3.11.2-0.<date>.<sha>'`). 
Both are valid semver.

The underscore removal that fixed by #4866 is preserved: it comes from the 
**goreleaser snapshot** `'version_template' ('{{ .Version }}.SNAPSHOT'`), which is unchanged. No underscores appear in the resulting RPM/DEB versions on any branch.

Fixes: https://scylladb.atlassian.net/browse/RELENG-710

## Verification

The fix was verified end-to-end on both `master` and `branch-3.11` by building from a fork branch and running the RPM/DEB installation test.

### master (`3.12.0-dev`)

| # | Check | Source | Result |
|---|-------|--------|--------|
| 1 | Snapshot build | [manager-build #368](https://jenkins.scylladb.com/job/manager-master/job/releng-testing/job/manager-build/368/) | ✅ SUCCESS - git tag `3.12.0-dev-0.<date>.<sha>` parsed by goreleaser (valid semver) |
| 2 | Version has no underscores | RPM/DEB package versions from #368 | ✅ `3.12.0~dev~0.<date>.<sha>.SNAPSHOT` - no `_` |
| 3 | Install + version parse | [rocky9-installation-test #53](https://jenkins.scylladb.com/job/manager-master/job/releng-testing/job/rocky9-installation-test/53/) | ✅ SUCCESS - server (RPM) + agent (DEB) install, `sctool` version parsed |

### branch-3.11 (`3.11.x`, the branch that was broken)

| # | Check | Source | Result |
|---|-------|--------|--------|
| 1 | Release build | [manager-build #19](https://jenkins.scylladb.com/job/manager-3.11/job/manager-build/19/) | ✅ SUCCESS - git tag `3.11.99-0.<date>.<sha>` parsed (previously `3.11.2.0.<date>.<sha>` → *Invalid Semantic Version*) |
| 2 | Version has no underscores | RPM filenames from #19 | ✅ `scylla-manager-server-3.11.99-0.<date>.<sha>_linux.x86_64.rpm` - no `_` in version |
| 3 | Install + version parse | [rocky9-installation-test #18](https://jenkins.scylladb.com/job/manager-3.11/job/rocky9-installation-test/18/) | ✅ SUCCESS - server (RPM) + agent (DEB) install, `sctool` version parsed |




**Note:** No backport to `branch-3.11` is needed. This fix targets `master` and will reach the release once `master` is branched to `3.12`. The `branch-3.11` verification below is only to demonstrate that the fix is correct on the release-branch scenario that was originally broken.