### PR TITLE
Make permission checks sequential in tests

### DIFF
--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/util/query"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/slice"
 	"github.com/scylladb/scylla-manager/v3/pkg/util2/maps"
+	slices2 "github.com/scylladb/scylla-manager/v3/pkg/util2/slices"
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/agent/models"
 	"go.uber.org/atomic"
 	"go.uber.org/zap/zapcore"
@@ -520,10 +521,6 @@ func TestGetTargetInParallelIntegration(t *testing.T) {
 		h        = newBackupTestHelper(t, session, cfg, location, nil)
 		ctx      = t.Context()
 	)
-	ni, err := h.Client.AnyNodeInfo(t.Context())
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// Prepare additional service using altered config
 	cleanupCfg := defaultConfig()
@@ -533,9 +530,7 @@ func TestGetTargetInParallelIntegration(t *testing.T) {
 
 	// Prepare different backup properties
 	props := defaultTestProperties(location, "")
-	if CheckConstraint(t, ni.ScyllaVersion, "< 2026.1") {
-		props["method"] = "rclone"
-	}
+	props["method"] = backup.MethodAuto
 	rawProps, err := json.Marshal(props)
 	if err != nil {
 		t.Fatal(err)
@@ -564,6 +559,7 @@ func TestGetTargetInParallelIntegration(t *testing.T) {
 	if err := h.Client.RclonePut(ctx, ManagedClusterHost(), location.RemotePath(path.Join(basePath, initialFileUnknownFormat)), bytes.NewBuffer([]byte{0})); err != nil {
 		t.Fatal(err)
 	}
+	t.Logf("Initial file known format: %s, initial file unknown format: %s", initialFile, initialFileUnknownFormat)
 
 	Print("When: call GetTarget in parallel")
 	eg := errgroup.Group{}
@@ -593,7 +589,10 @@ func TestGetTargetInParallelIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(leftoverFiles) != 1 || leftoverFiles[0].Path != initialFileUnknownFormat {
-		t.Fatalf("Expected only the initial unknown permission check file to be present after cleanup, got: %v", leftoverFiles)
+		leftover := slices2.Map(leftoverFiles, func(li *scyllaclient.RcloneListDirItem) string {
+			return li.Path
+		})
+		t.Fatalf("Expected only the initial unknown permission check file to be present after cleanup, got: %v", leftover)
 	}
 }
 

--- a/pkg/service/one2onerestore/helpers_integration_test.go
+++ b/pkg/service/one2onerestore/helpers_integration_test.go
@@ -38,6 +38,7 @@ type testHelper struct {
 
 func newTestHelper(t *testing.T, hosts []string) *testHelper {
 	clientCfg := scyllaclient.TestConfig(hosts, AgentAuthToken())
+	clientCfg.Transport = NewHackableRoundTripper(scyllaclient.DefaultTransport())
 	sc, err := scyllaclient.NewClient(clientCfg, log.NopLogger)
 	if err != nil {
 		t.Fatalf("Unexpected err: %v", err)

--- a/pkg/testutils/hrt.go
+++ b/pkg/testutils/hrt.go
@@ -1,10 +1,12 @@
-// Copyright (C) 2017 ScyllaDB
+// Copyright (C) 2026 ScyllaDB
 
 package testutils
 
 import (
 	"net/http"
 	"sync"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/util/httpx"
 )
 
 // HackableRoundTripper is a round tripper that allows for interceptor injection.
@@ -15,9 +17,12 @@ type HackableRoundTripper struct {
 	mu              sync.Mutex
 }
 
+// NewHackableRoundTripper creates HackableRoundTripper with the inner round
+// tripper wrapped with sequentialPermissionCheck. Requests handled fully by
+// the interceptor are not affected.
 func NewHackableRoundTripper(inner http.RoundTripper) *HackableRoundTripper {
 	return &HackableRoundTripper{
-		inner: inner,
+		inner: sequentialPermissionCheck(inner),
 	}
 }
 
@@ -67,4 +72,28 @@ func (h *HackableRoundTripper) RoundTrip(req *http.Request) (resp *http.Response
 		}
 	}
 	return
+}
+
+// sequentialPermissionCheck is a default interceptor ensuring that permission
+// check requests are executed sequentially. This is needed for our test env
+// as parallel permission checks operating on objects with common prefix are
+// not handled well by our MinIo container and result in test flakiness.
+// This problem is not observed in production or mock GCS server.
+func sequentialPermissionCheck(next http.RoundTripper) http.RoundTripper {
+	const permissionCheckPath = "/agent/rclone/operations/check-permissions"
+	permissionCheckSemaphore := make(chan struct{}, 1)
+	permissionCheckSemaphore <- struct{}{}
+	return httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Path == permissionCheckPath {
+			select {
+			case <-permissionCheckSemaphore:
+				defer func() {
+					permissionCheckSemaphore <- struct{}{}
+				}()
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			}
+		}
+		return next.RoundTrip(req)
+	})
 }


### PR DESCRIPTION
This change aims to remove MinIo permission check flakiness, which is hypothesized to come from poor handling of parallel object sharing common prefix deletion.

Fixes https://scylladb.atlassian.net/browse/CLOUD-3354
