### PR TITLE
swagger: agent, correctly capitalize eventBasedHold param

### DIFF
--- a/v3/swagger/agent.json
+++ b/v3/swagger/agent.json
@@ -1253,7 +1253,7 @@
           "description": "Allows overriding 'unlocked' retention policy",
           "type": "boolean"
         },
-        "EventBasedHold": {
+        "eventBasedHold": {
           "description": "Whether the object is under event based hold",
           "type": "boolean"
         }
@@ -1437,7 +1437,7 @@
           "type": "string",
           "format": "date-time"
         },
-        "EventBasedHold": {
+        "eventBasedHold": {
           "description": "Whether the object is under event based hold",
           "type": "boolean"
         }

--- a/v3/swagger/gen/agent/models/check_permissions_options.go
+++ b/v3/swagger/gen/agent/models/check_permissions_options.go
@@ -16,7 +16,7 @@ import (
 type CheckPermissionsOptions struct {
 
 	// Whether the object is under event based hold
-	EventBasedHold bool `json:"EventBasedHold,omitempty"`
+	EventBasedHold bool `json:"eventBasedHold,omitempty"`
 
 	// A remote name string eg. drive:
 	Fs string `json:"fs,omitempty"`

--- a/v3/swagger/gen/agent/models/list_item.go
+++ b/v3/swagger/gen/agent/models/list_item.go
@@ -20,9 +20,6 @@ type ListItem struct {
 	// Encrypted name
 	Encrypted string `json:"Encrypted,omitempty"`
 
-	// Whether the object is under event based hold
-	EventBasedHold bool `json:"EventBasedHold,omitempty"`
-
 	// Hash of the item
 	Hashes interface{} `json:"Hashes,omitempty"`
 
@@ -57,6 +54,9 @@ type ListItem struct {
 
 	// Size in bytes
 	Size int64 `json:"Size,omitempty"`
+
+	// Whether the object is under event based hold
+	EventBasedHold bool `json:"eventBasedHold,omitempty"`
 }
 
 // Validate validates this list item


### PR DESCRIPTION
All SM agent handlers expect eventBasedHold, not EventBasedHold. This was overlooked because our hold test interceptor works on swagger models, so it was consistent in the client and test interceptor interaction. Since our gcs mock does not support holds, we didn't spot it until we executed tests against the real gcs.
