### PR TITLE
Event based hold metrics

### DIFF
--- a/pkg/metrics/backup.go
+++ b/pkg/metrics/backup.go
@@ -63,7 +63,12 @@ func NewBackupMetrics() BackupMetrics {
 
 // MustRegister shall be called to make the metrics visible by prometheus client.
 func (m BackupMetrics) MustRegister() BackupMetrics {
-	prometheus.MustRegister(m.all()...)
+	return m.MustRegisterWith(prometheus.DefaultRegisterer)
+}
+
+// MustRegisterWith registers all backup metrics with the given registerer.
+func (m BackupMetrics) MustRegisterWith(reg prometheus.Registerer) BackupMetrics {
+	reg.MustRegister(m.all()...)
 	return m
 }
 

--- a/pkg/metrics/backup.go
+++ b/pkg/metrics/backup.go
@@ -9,14 +9,19 @@ import (
 )
 
 type BackupMetrics struct {
-	snapshot             *prometheus.GaugeVec
-	filesSizeBytes       *prometheus.GaugeVec
-	filesUploadedBytes   *prometheus.GaugeVec
-	filesSkippedBytes    *prometheus.GaugeVec
-	filesFailedBytes     *prometheus.GaugeVec
-	purgeFiles           *prometheus.GaugeVec
-	purgeDeletedFiles    *prometheus.GaugeVec
-	retentionLockedFiles *prometheus.GaugeVec
+	snapshot               *prometheus.GaugeVec
+	filesSizeBytes         *prometheus.GaugeVec
+	filesUploadedBytes     *prometheus.GaugeVec
+	filesSkippedBytes      *prometheus.GaugeVec
+	filesFailedBytes       *prometheus.GaugeVec
+	purgeFiles             *prometheus.GaugeVec
+	purgeDeletedFiles      *prometheus.GaugeVec
+	retentionLockedFiles   *prometheus.GaugeVec
+	filesCount             *prometheus.GaugeVec
+	filesSkippedCount      *prometheus.GaugeVec
+	versionedFilesCount    *prometheus.GaugeVec
+	setEventBasedHolds     *prometheus.GaugeVec
+	removedEventBasedHolds *prometheus.GaugeVec
 }
 
 func NewBackupMetrics() BackupMetrics {
@@ -39,6 +44,20 @@ func NewBackupMetrics() BackupMetrics {
 			"purge_deleted_files", "cluster", "host"),
 		retentionLockedFiles: g("Number of backup files that had retention lock set.",
 			"retention_locked_files", "cluster", "keyspace", "table", "host"),
+		filesCount: g("Number of snapshot files before deduplication.",
+			"files_count", "cluster", "keyspace", "table", "host"),
+		filesSkippedCount: g("Number of deduplicated snapshot files already uploaded to backup location.",
+			"files_skipped_count", "cluster", "keyspace", "table", "host"),
+		versionedFilesCount: g("Number of versioned snapshot files that will be created on snapshot upload.",
+			"versioned_files_count", "cluster", "node", "keyspace", "table"),
+		setEventBasedHolds: g("Number of snapshot files that had event based hold set. "+
+			"The \"node\" label describes the ID of the node owning the file, "+
+			"while the \"host\" label describes the IP of the node setting the hold.",
+			"set_event_based_holds", "cluster", "node", "keyspace", "table", "host"),
+		removedEventBasedHolds: g("Number of snapshot files that had event based hold removed. "+
+			"The \"node\" label describes the ID of the node owning the file, "+
+			"while the \"host\" label describes the IP of the node setting the hold.",
+			"removed_event_based_holds", "cluster", "node", "keyspace", "table", "host"),
 	}
 }
 
@@ -58,13 +77,39 @@ func (m BackupMetrics) all() []prometheus.Collector {
 		m.purgeFiles,
 		m.purgeDeletedFiles,
 		m.retentionLockedFiles,
+		m.filesCount,
+		m.filesSkippedCount,
+		m.versionedFilesCount,
+		m.setEventBasedHolds,
+		m.removedEventBasedHolds,
 	}
 }
 
 // ResetClusterMetrics resets all backup metrics labeled with the cluster.
 func (m BackupMetrics) ResetClusterMetrics(clusterID uuid.UUID) {
-	for _, c := range m.all() {
-		setGaugeVecMatching(c.(*prometheus.GaugeVec), unspecifiedValue, clusterMatcher(clusterID))
+	for _, c := range []*prometheus.GaugeVec{
+		m.snapshot,
+		m.filesSizeBytes,
+		m.filesUploadedBytes,
+		m.filesSkippedBytes,
+		m.filesFailedBytes,
+		m.purgeFiles,
+		m.purgeDeletedFiles,
+		m.retentionLockedFiles,
+		m.filesCount,
+		m.filesSkippedCount,
+	} {
+		setGaugeVecMatching(c, unspecifiedValue, clusterMatcher(clusterID))
+	}
+	// Newer metrics are deleted instead of being set to unspecifiedValue,
+	// so that series of nodes and tables that are no longer part of
+	// the cluster aren't reported indefinitely.
+	for _, c := range []*prometheus.GaugeVec{
+		m.versionedFilesCount,
+		m.setEventBasedHolds,
+		m.removedEventBasedHolds,
+	} {
+		DeleteMatching(c, clusterMatcher(clusterID))
 	}
 }
 
@@ -82,8 +127,10 @@ func (m BackupMetrics) SetSnapshot(clusterID uuid.UUID, keyspace, host string, t
 	m.snapshot.With(l).Set(v)
 }
 
-// SetFilesProgress updates backup "files_{uploaded,skipped,failed}_bytes" metrics.
-func (m BackupMetrics) SetFilesProgress(clusterID uuid.UUID, keyspace, table, host string, size, uploaded, skipped, failed int64) {
+// SetFilesProgress updates backup "files_{size,count,uploaded,skipped,skipped_count,failed}_bytes" metrics.
+func (m BackupMetrics) SetFilesProgress(clusterID uuid.UUID, keyspace, table, host string,
+	size, uploaded, skipped, failed, filesCount, filesSkippedCount int64,
+) {
 	l := prometheus.Labels{
 		"cluster":  clusterID.String(),
 		"keyspace": keyspace,
@@ -94,6 +141,8 @@ func (m BackupMetrics) SetFilesProgress(clusterID uuid.UUID, keyspace, table, ho
 	m.filesUploadedBytes.With(l).Set(float64(uploaded))
 	m.filesSkippedBytes.With(l).Set(float64(skipped))
 	m.filesFailedBytes.With(l).Set(float64(failed))
+	m.filesCount.With(l).Set(float64(filesCount))
+	m.filesSkippedCount.With(l).Set(float64(filesSkippedCount))
 }
 
 // SetPurgeFiles updates backup "purge_files" and "purge_deleted_files" metrics.
@@ -111,4 +160,34 @@ func (m BackupMetrics) IncreaseRetentionLockedFiles(clusterID uuid.UUID, keyspac
 		"host":     host,
 	}
 	m.retentionLockedFiles.With(l).Add(float64(locked))
+}
+
+// SetVersionedFilesCount updates backup "versioned_files_count" metric.
+func (m BackupMetrics) SetVersionedFilesCount(clusterID uuid.UUID, nodeID, keyspace, table string, count int) {
+	l := prometheus.Labels{
+		"cluster":  clusterID.String(),
+		"node":     nodeID,
+		"keyspace": keyspace,
+		"table":    table,
+	}
+	m.versionedFilesCount.With(l).Set(float64(count))
+}
+
+// IncreaseEventBasedHolds increases backup "set_event_based_holds" (hold=true)
+// or "removed_event_based_holds" (hold=false) metric.
+// The "node" label describes the ID of the node owning the file,
+// while the "host" label describes the IP of the node setting the hold.
+func (m BackupMetrics) IncreaseEventBasedHolds(clusterID uuid.UUID, nodeID, keyspace, table, host string, hold bool, count int64) {
+	l := prometheus.Labels{
+		"cluster":  clusterID.String(),
+		"node":     nodeID,
+		"keyspace": keyspace,
+		"table":    table,
+		"host":     host,
+	}
+	if hold {
+		m.setEventBasedHolds.With(l).Add(float64(count))
+	} else {
+		m.removedEventBasedHolds.With(l).Add(float64(count))
+	}
 }

--- a/pkg/metrics/backup_test.go
+++ b/pkg/metrics/backup_test.go
@@ -30,9 +30,9 @@ func TestBackupMetrics(t *testing.T) {
 	})
 
 	t.Run("SetFilesProgress", func(t *testing.T) {
-		m.SetFilesProgress(c, "k", "t", "h", 10, 5, 3, 2)
+		m.SetFilesProgress(c, "k", "t", "h", 10, 5, 3, 2, 7, 3)
 
-		text := Dump(t, m.filesSizeBytes, m.filesUploadedBytes, m.filesSkippedBytes, m.filesFailedBytes)
+		text := Dump(t, m.filesSizeBytes, m.filesUploadedBytes, m.filesSkippedBytes, m.filesFailedBytes, m.filesCount, m.filesSkippedCount)
 		fmt.Println(text)
 		testutils.SaveGoldenTextFileIfNeeded(t, text)
 		golden := testutils.LoadGoldenTextFile(t)
@@ -45,6 +45,62 @@ func TestBackupMetrics(t *testing.T) {
 		m.SetPurgeFiles(c, "h", 2, 1)
 
 		text := Dump(t, m.purgeFiles, m.purgeDeletedFiles)
+
+		testutils.SaveGoldenTextFileIfNeeded(t, text)
+		golden := testutils.LoadGoldenTextFile(t)
+		if diff := cmp.Diff(text, golden); diff != "" {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("SetVersionedFilesCount", func(t *testing.T) {
+		m.SetVersionedFilesCount(c, "n", "k", "t", 2)
+
+		text := Dump(t, m.versionedFilesCount)
+
+		testutils.SaveGoldenTextFileIfNeeded(t, text)
+		golden := testutils.LoadGoldenTextFile(t)
+		if diff := cmp.Diff(text, golden); diff != "" {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("IncreaseEventBasedHolds", func(t *testing.T) {
+		m.IncreaseEventBasedHolds(c, "n", "k", "t", "h", true, 2)
+		m.IncreaseEventBasedHolds(c, "n", "k", "t", "h", true, 3)
+		m.IncreaseEventBasedHolds(c, "n", "k", "t", "h", false, 1)
+
+		text := Dump(t, m.setEventBasedHolds, m.removedEventBasedHolds)
+
+		testutils.SaveGoldenTextFileIfNeeded(t, text)
+		golden := testutils.LoadGoldenTextFile(t)
+		if diff := cmp.Diff(text, golden); diff != "" {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("ResetClusterMetrics", func(t *testing.T) {
+		// Use a dedicated metrics instance, so that this subtest
+		// doesn't depend on series created by the other subtests.
+		m := NewBackupMetrics()
+		c2 := uuid.MustParse("400d09d8-b3ce-4023-102c-6912671b051a")
+		// Set all metrics for two clusters
+		for _, cluster := range []uuid.UUID{c, c2} {
+			m.SetSnapshot(cluster, "k", "h", true)
+			m.SetFilesProgress(cluster, "k", "t", "h", 10, 5, 3, 2, 7, 3)
+			m.SetPurgeFiles(cluster, "h", 2, 1)
+			m.IncreaseRetentionLockedFiles(cluster, "k", "t", "h", 5)
+			m.SetVersionedFilesCount(cluster, "n", "k", "t", 2)
+			m.IncreaseEventBasedHolds(cluster, "n", "k", "t", "h", true, 2)
+			m.IncreaseEventBasedHolds(cluster, "n", "k", "t", "h", false, 1)
+		}
+		// Reset all metrics for the first cluster
+		m.ResetClusterMetrics(c)
+		// Expect:
+		// - second cluster metrics to be intact
+		// - older first cluster metrics to be set to -1
+		// - newer first cluster metrics to be deleted
+		text := Dump(t, m.all()...)
 
 		testutils.SaveGoldenTextFileIfNeeded(t, text)
 		golden := testutils.LoadGoldenTextFile(t)

--- a/pkg/metrics/testdata/BackupMetrics/IncreaseEventBasedHolds.golden.txt
+++ b/pkg/metrics/testdata/BackupMetrics/IncreaseEventBasedHolds.golden.txt
@@ -1,0 +1,6 @@
+# HELP scylla_manager_backup_removed_event_based_holds Number of snapshot files that had event based hold removed. The "node" label describes the ID of the node owning the file, while the "host" label describes the IP of the node setting the hold.
+# TYPE scylla_manager_backup_removed_event_based_holds gauge
+scylla_manager_backup_removed_event_based_holds{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",node="n",table="t"} 1
+# HELP scylla_manager_backup_set_event_based_holds Number of snapshot files that had event based hold set. The "node" label describes the ID of the node owning the file, while the "host" label describes the IP of the node setting the hold.
+# TYPE scylla_manager_backup_set_event_based_holds gauge
+scylla_manager_backup_set_event_based_holds{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",node="n",table="t"} 5

--- a/pkg/metrics/testdata/BackupMetrics/ResetClusterMetrics.golden.txt
+++ b/pkg/metrics/testdata/BackupMetrics/ResetClusterMetrics.golden.txt
@@ -1,0 +1,49 @@
+# HELP scylla_manager_backup_files_count Number of snapshot files before deduplication.
+# TYPE scylla_manager_backup_files_count gauge
+scylla_manager_backup_files_count{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h",keyspace="k",table="t"} 7
+scylla_manager_backup_files_count{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} -1
+# HELP scylla_manager_backup_files_failed_bytes Number of bytes failed to upload to backup location.
+# TYPE scylla_manager_backup_files_failed_bytes gauge
+scylla_manager_backup_files_failed_bytes{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h",keyspace="k",table="t"} 2
+scylla_manager_backup_files_failed_bytes{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} -1
+# HELP scylla_manager_backup_files_size_bytes Total size of backup files in bytes.
+# TYPE scylla_manager_backup_files_size_bytes gauge
+scylla_manager_backup_files_size_bytes{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h",keyspace="k",table="t"} 10
+scylla_manager_backup_files_size_bytes{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} -1
+# HELP scylla_manager_backup_files_skipped_bytes Number of deduplicated bytes already uploaded to backup location.
+# TYPE scylla_manager_backup_files_skipped_bytes gauge
+scylla_manager_backup_files_skipped_bytes{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h",keyspace="k",table="t"} 3
+scylla_manager_backup_files_skipped_bytes{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} -1
+# HELP scylla_manager_backup_files_skipped_count Number of deduplicated snapshot files already uploaded to backup location.
+# TYPE scylla_manager_backup_files_skipped_count gauge
+scylla_manager_backup_files_skipped_count{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h",keyspace="k",table="t"} 3
+scylla_manager_backup_files_skipped_count{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} -1
+# HELP scylla_manager_backup_files_uploaded_bytes Number of bytes uploaded to backup location.
+# TYPE scylla_manager_backup_files_uploaded_bytes gauge
+scylla_manager_backup_files_uploaded_bytes{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h",keyspace="k",table="t"} 5
+scylla_manager_backup_files_uploaded_bytes{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} -1
+# HELP scylla_manager_backup_purge_deleted_files Number of files that were deleted.
+# TYPE scylla_manager_backup_purge_deleted_files gauge
+scylla_manager_backup_purge_deleted_files{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h"} 1
+scylla_manager_backup_purge_deleted_files{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h"} -1
+# HELP scylla_manager_backup_purge_files Number of files that need to be deleted due to retention policy.
+# TYPE scylla_manager_backup_purge_files gauge
+scylla_manager_backup_purge_files{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h"} 2
+scylla_manager_backup_purge_files{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h"} -1
+# HELP scylla_manager_backup_removed_event_based_holds Number of snapshot files that had event based hold removed. The "node" label describes the ID of the node owning the file, while the "host" label describes the IP of the node setting the hold.
+# TYPE scylla_manager_backup_removed_event_based_holds gauge
+scylla_manager_backup_removed_event_based_holds{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h",keyspace="k",node="n",table="t"} 1
+# HELP scylla_manager_backup_retention_locked_files Number of backup files that had retention lock set.
+# TYPE scylla_manager_backup_retention_locked_files gauge
+scylla_manager_backup_retention_locked_files{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h",keyspace="k",table="t"} 5
+scylla_manager_backup_retention_locked_files{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} -1
+# HELP scylla_manager_backup_set_event_based_holds Number of snapshot files that had event based hold set. The "node" label describes the ID of the node owning the file, while the "host" label describes the IP of the node setting the hold.
+# TYPE scylla_manager_backup_set_event_based_holds gauge
+scylla_manager_backup_set_event_based_holds{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h",keyspace="k",node="n",table="t"} 2
+# HELP scylla_manager_backup_snapshot Indicates if snapshot was taken.
+# TYPE scylla_manager_backup_snapshot gauge
+scylla_manager_backup_snapshot{cluster="400d09d8-b3ce-4023-102c-6912671b051a",host="h",keyspace="k"} 1
+scylla_manager_backup_snapshot{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k"} -1
+# HELP scylla_manager_backup_versioned_files_count Number of versioned snapshot files that will be created on snapshot upload.
+# TYPE scylla_manager_backup_versioned_files_count gauge
+scylla_manager_backup_versioned_files_count{cluster="400d09d8-b3ce-4023-102c-6912671b051a",keyspace="k",node="n",table="t"} 2

--- a/pkg/metrics/testdata/BackupMetrics/SetFilesProgress.golden.txt
+++ b/pkg/metrics/testdata/BackupMetrics/SetFilesProgress.golden.txt
@@ -1,3 +1,6 @@
+# HELP scylla_manager_backup_files_count Number of snapshot files before deduplication.
+# TYPE scylla_manager_backup_files_count gauge
+scylla_manager_backup_files_count{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} 7
 # HELP scylla_manager_backup_files_failed_bytes Number of bytes failed to upload to backup location.
 # TYPE scylla_manager_backup_files_failed_bytes gauge
 scylla_manager_backup_files_failed_bytes{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} 2
@@ -7,6 +10,9 @@ scylla_manager_backup_files_size_bytes{cluster="b703df56-c428-46a7-bfba-cfa6ee91
 # HELP scylla_manager_backup_files_skipped_bytes Number of deduplicated bytes already uploaded to backup location.
 # TYPE scylla_manager_backup_files_skipped_bytes gauge
 scylla_manager_backup_files_skipped_bytes{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} 3
+# HELP scylla_manager_backup_files_skipped_count Number of deduplicated snapshot files already uploaded to backup location.
+# TYPE scylla_manager_backup_files_skipped_count gauge
+scylla_manager_backup_files_skipped_count{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} 3
 # HELP scylla_manager_backup_files_uploaded_bytes Number of bytes uploaded to backup location.
 # TYPE scylla_manager_backup_files_uploaded_bytes gauge
 scylla_manager_backup_files_uploaded_bytes{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",host="h",keyspace="k",table="t"} 5

--- a/pkg/metrics/testdata/BackupMetrics/SetVersionedFilesCount.golden.txt
+++ b/pkg/metrics/testdata/BackupMetrics/SetVersionedFilesCount.golden.txt
@@ -1,0 +1,3 @@
+# HELP scylla_manager_backup_versioned_files_count Number of versioned snapshot files that will be created on snapshot upload.
+# TYPE scylla_manager_backup_versioned_files_count gauge
+scylla_manager_backup_versioned_files_count{cluster="b703df56-c428-46a7-bfba-cfa6ee91b976",keyspace="k",node="n",table="t"} 2

--- a/pkg/schema/table/table.go
+++ b/pkg/schema/table/table.go
@@ -41,6 +41,8 @@ var (
 			"completed_at",
 			"error",
 			"failed",
+			"files_count",
+			"files_skipped_count",
 			"host",
 			"run_id",
 			"scylla_task_id",

--- a/pkg/service/backup/event_based_hold_interceptor_integration_test.go
+++ b/pkg/service/backup/event_based_hold_interceptor_integration_test.go
@@ -335,6 +335,7 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 	// - deduplicated files have hold
 	// - files from non-current snapshot don't have hold
 	// - files with hold manually changed are adjusted
+	// - hold metrics reflect the hold changes on the sstable dir files
 	const (
 		testBucket   = "backuptest-event-based-hold"
 		testKeyspace = "backuptest_event_based_hold"
@@ -388,6 +389,10 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 	tagAFiles := listSnapshotFiles(t, h, tagA.SnapshotTag)
 	assertObjectMetadataAll(t, h.Client, host, location, tagAFiles, true, "", time.Time{})
 	assertShadowedTemporaryManifests(t, h, tagA.SnapshotTag)
+
+	Print("And: fresh snapshot does not populate hold metrics")
+	h.assertBackupMetric("set_event_based_holds", 0)
+	h.assertBackupMetric("removed_event_based_holds", 0)
 
 	tagATOCFiles := make([]string, 0)
 	for _, file := range tagAFiles {
@@ -446,6 +451,26 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 
 	Print("And: files from non-current snapshots don't have event based hold")
 	assertObjectMetadataAll(t, h.Client, host, location, tagAOnlyFiles, false, string(scyllaclient.RetentionModeLocked), baseTime.Add(policy))
+
+	Print("And: second snapshot reports hold metrics")
+	// Note that since backup is executed outside or backup runner, the metrics
+	// are not reset between the runs. This is not a problem here, as we validated
+	// that the first backup didn't report any holds set or removed.
+	// We want to check that the second backup removed holds from first snapshot
+	// only files and that it set holds for the manually tampered TOC files.
+	_, _, tagASSTables, tagAScyllaManifests := listGroupedSnapshotFiles(t, h, tagA.SnapshotTag)
+	_, _, tagBSSTables, tagBScyllaManifests := listGroupedSnapshotFiles(t, h, tagB.SnapshotTag)
+	tagASstDirFiles := strset.New(append(tagASSTables, tagAScyllaManifests...)...)
+	tagBSstDirFiles := strset.New(append(tagBSSTables, tagBScyllaManifests...)...)
+	tocFiles := strset.New(tagATOCFiles...)
+	expectedSet := strset.Intersection(tagBSstDirFiles, tocFiles)
+	expectedRemoved := strset.Difference(tagASstDirFiles, tagBSstDirFiles, tocFiles)
+	h.assertBackupMetric("set_event_based_holds", int64(expectedSet.Size()))
+	h.assertBackupMetric("removed_event_based_holds", int64(expectedRemoved.Size()))
+
+	Print("And: retention lock and versioned files metrics are not reported")
+	h.assertBackupMetric("retention_locked_files", 0)
+	h.assertBackupMetric("versioned_files_count", 0)
 }
 
 func TestBackupEventBasedHoldVanishedDirsIntegration(t *testing.T) {

--- a/pkg/service/backup/model.go
+++ b/pkg/service/backup/model.go
@@ -211,7 +211,9 @@ type RunProgress struct {
 	Skipped     int64 // Amount of skipped bytes because file was present.
 	// Amount of bytes that have been uploaded but due to error have to be
 	// uploaded again.
-	Failed int64
+	Failed            int64
+	FilesCount        int64 // Total file count before deduplication.
+	FilesSkippedCount int64 // Amount of files deleted locally by deduplication.
 
 	files []fileInfo
 }

--- a/pkg/service/backup/service.go
+++ b/pkg/service/backup/service.go
@@ -1184,11 +1184,16 @@ func (s *Service) resumeUploadProgress(prevRunID uuid.UUID) func(context.Context
 			p.Size = prev.Size
 			p.Uploaded = prev.Uploaded
 			p.Skipped = prev.Skipped
+			p.FilesCount = prev.FilesCount
+			p.FilesSkippedCount = prev.FilesSkippedCount
 		} else {
 			diskSize := p.Size
+			diskCount := p.FilesCount
 			p.Size = prev.Size
 			p.Uploaded = 0
 			p.Skipped = prev.Size - diskSize
+			p.FilesCount = prev.FilesCount
+			p.FilesSkippedCount = prev.FilesCount - diskCount
 		}
 	}
 }

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/go-set/strset"
 	"github.com/scylladb/gocqlx/v2"
@@ -84,8 +85,9 @@ func defaultTestTarget(loc backupspec.Location, ks string, dc string, retention 
 type backupTestHelper struct {
 	*CommonTestHelper
 
-	service  *backup.Service
-	location backupspec.Location
+	service    *backup.Service
+	location   backupspec.Location
+	metricsReg *prometheus.Registry
 }
 
 func newBackupTestHelper(t *testing.T, session gocqlx.Session, config backup.Config, location backupspec.Location, clientConf *scyllaclient.Config) *backupTestHelper {
@@ -102,7 +104,10 @@ func newBackupTestHelperWithUser(t *testing.T, session gocqlx.Session, config ba
 
 	hrt := NewHackableRoundTripper(scyllaclient.DefaultTransport())
 	client := newTestClient(t, hrt, logger.Named("client"), clientConf)
-	service := newTestServiceWithUser(t, session, client, config, logger, clusterID, user, pass)
+	// Per-helper registry allowing to verify metrics behavior during test execution
+	metricsReg := prometheus.NewPedanticRegistry()
+	backupMetrics := metrics.NewBackupMetrics().MustRegisterWith(metricsReg)
+	service := newTestServiceWithUser(t, session, client, config, backupMetrics, logger, clusterID, user, pass)
 	cHelper := &CommonTestHelper{
 		Session:   session,
 		Hrt:       hrt,
@@ -122,8 +127,36 @@ func newBackupTestHelperWithUser(t *testing.T, session gocqlx.Session, config ba
 	return &backupTestHelper{
 		CommonTestHelper: cHelper,
 
-		service:  service,
-		location: location,
+		service:    service,
+		location:   location,
+		metricsReg: metricsReg,
+	}
+}
+
+// sumBackupMetric returns the sum over all series of the scylla_manager_backup_<name> metric family.
+func (h *backupTestHelper) sumBackupMetric(name string) int64 {
+	h.T.Helper()
+
+	mfs, err := h.metricsReg.Gather()
+	if err != nil {
+		h.T.Fatal(err)
+	}
+	var sum float64
+	for _, mf := range mfs {
+		if mf.GetName() == "scylla_manager_backup_"+name {
+			for _, m := range mf.GetMetric() {
+				sum += m.GetGauge().GetValue()
+			}
+		}
+	}
+	return int64(sum)
+}
+
+func (h *backupTestHelper) assertBackupMetric(name string, want int64) {
+	h.T.Helper()
+
+	if got := h.sumBackupMetric(name); got != want {
+		h.T.Fatalf("Expected %s metric to be %d, got %d", name, want, got)
 	}
 }
 
@@ -143,13 +176,15 @@ func newTestClient(t *testing.T, hrt *HackableRoundTripper, logger log.Logger, c
 	return c
 }
 
-func newTestServiceWithUser(t *testing.T, session gocqlx.Session, client *scyllaclient.Client, c backup.Config, logger log.Logger, clusterID uuid.UUID, user, pass string) *backup.Service {
+func newTestServiceWithUser(t *testing.T, session gocqlx.Session, client *scyllaclient.Client, c backup.Config,
+	backupMetrics metrics.BackupMetrics, logger log.Logger, clusterID uuid.UUID, user, pass string,
+) *backup.Service {
 	t.Helper()
 
 	s, err := backup.NewService(
 		session,
 		c,
-		metrics.NewBackupMetrics(),
+		backupMetrics,
 		func(_ context.Context, id uuid.UUID) (string, error) {
 			return "test_cluster", nil
 		},
@@ -883,6 +918,12 @@ func TestBackupSmokeIntegration(t *testing.T) {
 	if err := h.service.Backup(ctx, h.ClusterID, h.TaskID, h.RunID, target); err != nil {
 		t.Fatal(err)
 	}
+
+	Print("Then: files count metrics are set for fresh backup")
+	_, _, files, _ := h.listS3Files()
+	h.assertBackupMetric("files_count", int64(len(files)))
+	h.assertBackupMetric("files_skipped_count", 0)
+
 	Print("And: run it again")
 	if err := h.service.Backup(ctx, h.ClusterID, h.TaskID, h.RunID, target); err != nil {
 		t.Fatal(err)
@@ -1050,6 +1091,16 @@ func TestBackupSmokeIntegration(t *testing.T) {
 	if len(filesInfo) != 3*3 {
 		t.Fatalf("len(ListFiles()) = %d, expected %d", len(filesInfo), 3*3)
 	}
+
+	Print("And: files count metrics are set for the third backup")
+	// SnapshotInfo is sorted in descending order, so [0] is the latest backup
+	_, _, thirdFiles, _ := listGroupedSnapshotFiles(t, h, i.SnapshotInfo[0].SnapshotTag)
+	_, _, secondFiles, _ := listGroupedSnapshotFiles(t, h, i.SnapshotInfo[1].SnapshotTag)
+	thirdBackupFiles := strset.New(thirdFiles...)
+	secondBackupFiles := strset.New(secondFiles...)
+	skippedFiles := strset.Intersection(thirdBackupFiles, secondBackupFiles)
+	h.assertBackupMetric("files_count", int64(thirdBackupFiles.Size()))
+	h.assertBackupMetric("files_skipped_count", int64(skippedFiles.Size()))
 
 	assertManifestHasCorrectFormat(t, ctx, h, manifests[0], schemas)
 }

--- a/pkg/service/backup/service_retention_lock_integration_test.go
+++ b/pkg/service/backup/service_retention_lock_integration_test.go
@@ -557,6 +557,18 @@ func TestBackupProtectedManifestsIntegration(t *testing.T) {
 func listSnapshotFiles(t *testing.T, h *backupTestHelper, snapshotTag string) []string {
 	t.Helper()
 
+	manifests, schemas, files, scyllaManifests := listGroupedSnapshotFiles(t, h, snapshotTag)
+	all := make([]string, 0, len(manifests)+len(schemas)+len(files)+len(scyllaManifests))
+	all = append(all, manifests...)
+	all = append(all, schemas...)
+	all = append(all, files...)
+	all = append(all, scyllaManifests...)
+	return all
+}
+
+func listGroupedSnapshotFiles(t *testing.T, h *backupTestHelper, snapshotTag string) (manifests, schemas, files, scyllaManifests []string) {
+	t.Helper()
+
 	filesInfo, err := h.service.ListFiles(t.Context(), h.ClusterID, []backupspec.Location{h.location}, backup.ListFilter{
 		ClusterID:   h.ClusterID,
 		TaskID:      h.TaskID,
@@ -566,30 +578,26 @@ func listSnapshotFiles(t *testing.T, h *backupTestHelper, snapshotTag string) []
 		t.Fatalf("ListFiles for tag %s: %v", snapshotTag, err)
 	}
 
-	var files []string
 	for _, fi := range filesInfo {
-		// Add schema file
 		if fi.Schema != "" {
-			files = append(files, fi.Schema)
+			schemas = append(schemas, fi.Schema)
 		}
-		// Add sstable files and scylla manifests
 		for _, fm := range fi.Files {
 			for _, f := range fm.Files {
 				files = append(files, path.Join(fm.Path, f))
 			}
 			for _, sm := range fm.ScyllaManifests {
-				files = append(files, path.Join(fm.Path, sm))
+				scyllaManifests = append(scyllaManifests, path.Join(fm.Path, sm))
 			}
 		}
 	}
 
-	// Add SM manifests
-	manifests, _, _, _ := h.listS3Files()
-	for _, manifestPath := range manifests {
+	allManifests, _, _, _ := h.listS3Files()
+	for _, manifestPath := range allManifests {
 		if strings.Contains(manifestPath, snapshotTag) {
-			files = append(files, manifestPath)
+			manifests = append(manifests, manifestPath)
 		}
 	}
 
-	return files
+	return manifests, schemas, files, scyllaManifests
 }

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -123,11 +123,16 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 		}
 
 		deduplicatedUUIDSSTables := w.deduplicateUUIDSStables(remoteSSTableBundles, localSSTableBundles)
-		deduplicatedIntSSTables, willCreateVersioned, err := w.deduplicateIntSSTables(ctx, h.IP, dataDst, d.Path, remoteSSTableBundles, localSSTableBundles)
+		deduplicatedIntSSTables, versionedCnt, err := w.deduplicateIntSSTables(ctx, h.IP, dataDst, d.Path, remoteSSTableBundles, localSSTableBundles)
 		if err != nil {
 			return errors.Wrap(err, "deduplication based on .crc32 content")
 		}
-		if willCreateVersioned && w.RetentionLockMode != RetentionLockDisabled {
+		if versionedCnt > 0 {
+			// This metric is used to monitor edge case scenarios - populate it before returning
+			// feature compatibility error and set it only when there is something to report.
+			w.Metrics.SetVersionedFilesCount(w.ClusterID, h.ID, d.Keyspace, d.Table, versionedCnt)
+		}
+		if versionedCnt > 0 && w.RetentionLockMode != RetentionLockDisabled {
 			// Creation of versioned sstable happens by copying old sstable version with appended version
 			// suffix, then removing the original old version, then uploading the new version.
 			// This is not compatible with event based hold backup, where default backup retention policy
@@ -141,7 +146,7 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 				"Then, start the backup task from scratch.", h.IP, d.Keyspace, d.Table)
 		}
 
-		d.willCreateVersioned = willCreateVersioned
+		d.willCreateVersioned = versionedCnt > 0
 		deduplicated := make([]string, 0, len(deduplicatedUUIDSSTables)+len(deduplicatedIntSSTables))
 
 		var totalSkipped int64
@@ -190,10 +195,11 @@ func (w *worker) deduplicateUUIDSStables(remoteSSTables, localSSTables *sstableB
 	return deduplicated
 }
 
-// willCreateVersioned corresponds to snapshotDir.willCreateVersioned.
+// versionedCnt is the sum of local sstable bundle files which couldn't
+// be deduplicated even though they have counterpart remote bundle.
 func (w *worker) deduplicateIntSSTables(ctx context.Context, host string, remoteDir, localDir string,
 	remoteSSTables, localSSTables *sstableBundlesByID,
-) (deduplicated []fileInfo, willCreateVersioned bool, err error) {
+) (deduplicated []fileInfo, versionedCnt int, err error) {
 	// Reference to SSTables 3.0 Data File Format
 	// https://opensource.docs.scylladb.com/stable/architecture/sstable/sstable3/sstables-3-data-file-format.html
 
@@ -206,39 +212,39 @@ func (w *worker) deduplicateIntSSTables(ctx context.Context, host string, remote
 			continue
 		}
 		// At this point analyzed SSTable ID is present in both local and remote dirs.
-		// Not being able to deduplicate it results in setting 'willCreateVersioned' to true.
+		// Not being able to deduplicate it results in increasing versionedCnt.
 		crc32Idx := slices.IndexFunc(localBundle, func(fi fileInfo) bool {
 			return strings.HasSuffix(fi.Name, "Digest.crc32")
 		})
 		if crc32Idx == -1 {
-			willCreateVersioned = true
+			versionedCnt += len(localBundle)
 			continue
 		}
 		crc32FileName := localBundle[crc32Idx].Name
 		if !isSSTableBundleSizeEqual(localBundle, remoteBundle) {
-			willCreateVersioned = true
+			versionedCnt += len(localBundle)
 			continue
 		}
 
 		remoteCRC32Path := path.Join(remoteDir, crc32FileName)
 		remoteCRC32, err := w.Client.RcloneCat(ctx, host, remoteCRC32Path)
 		if err != nil {
-			return nil, true, errors.Wrapf(err, "get content of remote CRC32 %s", remoteCRC32Path)
+			return nil, 0, errors.Wrapf(err, "get content of remote CRC32 %s", remoteCRC32Path)
 		}
 
 		localCRC32Path := path.Join(localDir, crc32FileName)
 		localCRC32, err := w.Client.RcloneCat(ctx, host, localCRC32Path)
 		if err != nil {
-			return nil, true, errors.Wrapf(err, "get content of local CRC32 %s", localCRC32Path)
+			return nil, 0, errors.Wrapf(err, "get content of local CRC32 %s", localCRC32Path)
 		}
 
 		if bytes.Equal(localCRC32, remoteCRC32) {
 			deduplicated = append(deduplicated, localBundle...)
 		} else {
-			willCreateVersioned = true
+			versionedCnt += len(localBundle)
 		}
 	}
-	return deduplicated, willCreateVersioned, nil
+	return deduplicated, versionedCnt, nil
 }
 
 type sstableBundlesByID struct {

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -67,7 +67,7 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 		if applyHolds {
 			// Initialize holdHandler
 			apply := func(ctx context.Context, paths []string, hold bool) error {
-				return w.holdAndWait(ctx, h.IP, dataDst, paths, hold, d.Keyspace, d.Table)
+				return w.holdAndWait(ctx, h.IP, dataDst, paths, hold, h.ID, d.Keyspace, d.Table)
 			}
 			holdHandler = newEventBasedHoldHandler(apply, eventBasedHoldBatchSize)
 			// Feed local files

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -149,7 +149,7 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 		if err != nil {
 			return errors.Wrap(err, "delete deduplicated files")
 		}
-
+		d.Progress.FilesSkippedCount += int64(len(deduplicated))
 		d.SkippedBytesOffset += totalSkipped
 		return nil
 	}

--- a/pkg/service/backup/worker_deduplicate.go
+++ b/pkg/service/backup/worker_deduplicate.go
@@ -94,6 +94,12 @@ func (w *worker) deduplicateHost(ctx context.Context, h hostInfo) error {
 			if strings.HasSuffix(f.Name, backupspec.ScyllaManifest) {
 				return
 			}
+			// Skip versioned files, as deduplication is only interested
+			// in the newest file versions (others have tag suffix which
+			// makes them impossible to deduplicate).
+			if _, version := SplitNameAndVersion(f.Name); version != "" {
+				return
+			}
 			if err := remoteSSTableBundles.add(f.Name, f.Size); err != nil {
 				w.Logger.Error(ctx, "Couldn't create remote sstable bundle info", "file", f.Name, "error", err)
 			}

--- a/pkg/service/backup/worker_event_based_hold.go
+++ b/pkg/service/backup/worker_event_based_hold.go
@@ -67,7 +67,7 @@ func (w *worker) holdSchemaFiles(ctx context.Context, hosts []hostInfo) error {
 
 		// Initialize holdHandler
 		apply := func(ctx context.Context, paths []string, hold bool) error {
-			return w.holdAndWait(ctx, hosts[i].IP, remoteSchemaDir, paths, hold, "", "")
+			return w.holdAndWait(ctx, hosts[i].IP, remoteSchemaDir, paths, hold, "", "", "")
 		}
 		holdHandler := newEventBasedHoldHandler(apply, eventBasedHoldBatchSize)
 		// Feed local files - even though schema files have already been uploaded,
@@ -129,7 +129,7 @@ func (w *worker) holdLocationManifests(ctx context.Context, manifestLimit int, l
 		}
 	}
 	if len(currentNotHeld) > 0 {
-		if err := w.holdAndWait(ctx, hosts[0].IP, loc.RemotePath(""), currentNotHeld, true, "", ""); err != nil {
+		if err := w.holdAndWait(ctx, hosts[0].IP, loc.RemotePath(""), currentNotHeld, true, "", "", ""); err != nil {
 			return errors.Wrap(err, "set missing hold on current manifests")
 		}
 	}
@@ -301,7 +301,7 @@ func (w *worker) releaseAllDirHolds(ctx context.Context, h hostInfo, dir sstable
 
 	remoteDir := h.Location.RemotePath(dir.Path)
 	apply := func(ctx context.Context, paths []string, hold bool) error {
-		return w.holdAndWait(ctx, h.IP, remoteDir, paths, hold, dir.Keyspace, dir.Table)
+		return w.holdAndWait(ctx, h.IP, remoteDir, paths, hold, dir.NodeID, dir.Keyspace, dir.Table)
 	}
 	holdHandler := newEventBasedHoldHandler(apply, eventBasedHoldBatchSize)
 	// No local files - all objects should have holds removed
@@ -346,15 +346,40 @@ func (w *worker) releaseManifestsHold(ctx context.Context, host string, manifest
 			}
 		}
 	}
-	return w.holdAndWait(ctx, host, manifests[0].Location.RemotePath(""), paths, false, "", "")
+	return w.holdAndWait(ctx, host, manifests[0].Location.RemotePath(""), paths, false, "", "", "")
 }
 
-func (w *worker) holdAndWait(ctx context.Context, host, remoteDir string, paths []string, hold bool, keyspace, table string) error {
+// holdAndWait schedules an event based hold job and waits for its completion.
+// The nodeID arg describes the node owning the remote dir.
+// It emits set|remove_event_based_holds metrics only for non-empty keyspace and table args.
+func (w *worker) holdAndWait(ctx context.Context, host, remoteDir string, paths []string, hold bool, nodeID, keyspace, table string) error {
 	jobID, err := w.Client.RcloneBatchEventBasedHold(ctx, host, remoteDir, paths, hold)
 	if err != nil {
 		return errors.Wrap(err, "schedule event based hold job")
 	}
-	return w.waitRetentionJob(ctx, host, jobID, w.retentionLockJobCB(host, jobID, keyspace, table))
+	return w.waitRetentionJob(ctx, host, jobID, w.eventBasedHoldJobCB(host, jobID, hold, nodeID, keyspace, table))
+}
+
+func (w *worker) eventBasedHoldJobCB(host string, jobID int64, hold bool, nodeID, keyspace, table string) retentionJobCB {
+	var done int64
+	return func(job *scyllaclient.RcloneJobProgress) (bool, error) {
+		switch scyllaclient.RcloneJobStatus(job.Status) {
+		case scyllaclient.JobError:
+			return false, errors.Errorf("event based hold job error (%d): %s", jobID, job.Error)
+		case scyllaclient.JobNotFound:
+			return false, errors.Errorf("event based hold job not found (%d)", jobID)
+		case scyllaclient.JobSuccess, scyllaclient.JobRunning:
+			diff := job.Uploaded - done
+			done = job.Uploaded
+			if keyspace != "" && table != "" {
+				w.Metrics.IncreaseEventBasedHolds(w.ClusterID, nodeID, keyspace, table, host, hold, diff)
+			}
+			if scyllaclient.RcloneJobStatus(job.Status) == scyllaclient.JobSuccess {
+				return false, nil
+			}
+		}
+		return true, nil
+	}
 }
 
 // groupManifestsByTagAndHold returns manifests being a part of the current snapshot

--- a/pkg/service/backup/worker_index.go
+++ b/pkg/service/backup/worker_index.go
@@ -129,14 +129,15 @@ func (w *worker) indexSnapshotDirs(ctx context.Context, h hostInfo) ([]snapshotD
 			}
 
 			d.Progress = &RunProgress{
-				ClusterID: w.ClusterID,
-				TaskID:    w.TaskID,
-				RunID:     w.RunID,
-				Host:      d.Host,
-				Unit:      d.Unit,
-				TableName: d.Table,
-				Size:      size,
-				files:     files,
+				ClusterID:  w.ClusterID,
+				TaskID:     w.TaskID,
+				RunID:      w.RunID,
+				Host:       d.Host,
+				Unit:       d.Unit,
+				TableName:  d.Table,
+				Size:       size,
+				FilesCount: int64(len(files)),
+				files:      files,
 			}
 			w.ResumeUploadProgress(ctx, d.Progress)
 			d.SkippedBytesOffset = d.Progress.Skipped

--- a/pkg/service/backup/worker_upload.go
+++ b/pkg/service/backup/worker_upload.go
@@ -335,7 +335,7 @@ func (w *worker) updateProgress(ctx context.Context, d snapshotDir, job *scyllac
 
 func (w *worker) onRunProgress(ctx context.Context, p *RunProgress) {
 	w.Metrics.SetFilesProgress(w.ClusterID, w.Units[p.Unit].Keyspace, p.TableName, p.Host,
-		p.Size, p.Uploaded, p.Skipped, p.Failed, 0, 0)
+		p.Size, p.Uploaded, p.Skipped, p.Failed, p.FilesCount, p.FilesSkippedCount)
 
 	if w.OnRunProgress != nil {
 		w.OnRunProgress(ctx, p)

--- a/pkg/service/backup/worker_upload.go
+++ b/pkg/service/backup/worker_upload.go
@@ -335,7 +335,7 @@ func (w *worker) updateProgress(ctx context.Context, d snapshotDir, job *scyllac
 
 func (w *worker) onRunProgress(ctx context.Context, p *RunProgress) {
 	w.Metrics.SetFilesProgress(w.ClusterID, w.Units[p.Unit].Keyspace, p.TableName, p.Host,
-		p.Size, p.Uploaded, p.Skipped, p.Failed)
+		p.Size, p.Uploaded, p.Skipped, p.Failed, 0, 0)
 
 	if w.OnRunProgress != nil {
 		w.OnRunProgress(ctx, p)

--- a/pkg/service/restore/service_restore_integration_test.go
+++ b/pkg/service/restore/service_restore_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/scylladb/go-log"
 	"github.com/scylladb/gocqlx/v2"
 	"github.com/scylladb/scylla-manager/backupspec"
@@ -53,9 +54,10 @@ import (
 type restoreTestHelper struct {
 	*CommonTestHelper
 
-	service   *Service
-	backupSvc *backup.Service
-	location  backupspec.Location
+	service    *Service
+	backupSvc  *backup.Service
+	location   backupspec.Location
+	metricsReg *prometheus.Registry
 }
 
 func newRestoreTestHelper(t *testing.T, session gocqlx.Session, config Config, location backupspec.Location, clientConf *scyllaclient.Config, user, pass string) *restoreTestHelper {
@@ -67,7 +69,10 @@ func newRestoreTestHelper(t *testing.T, session gocqlx.Session, config Config, l
 	logger := log.NewDevelopmentWithLevel(zapcore.InfoLevel)
 	hrt := NewHackableRoundTripper(scyllaclient.DefaultTransport())
 	client := newTestClient(t, hrt, logger.Named("client"), clientConf)
-	service, backupSvc := newTestService(t, session, client, config, logger, clusterID, user, pass)
+	// Per-helper registry allowing to verify metrics behavior during test execution
+	metricsReg := prometheus.NewPedanticRegistry()
+	backupMetrics := metrics.NewBackupMetrics().MustRegisterWith(metricsReg)
+	service, backupSvc := newTestService(t, session, client, config, backupMetrics, logger, clusterID, user, pass)
 	cHelper := &CommonTestHelper{
 		Session:   session,
 		Hrt:       hrt,
@@ -87,9 +92,37 @@ func newRestoreTestHelper(t *testing.T, session gocqlx.Session, config Config, l
 	return &restoreTestHelper{
 		CommonTestHelper: cHelper,
 
-		service:   service,
-		backupSvc: backupSvc,
-		location:  location,
+		service:    service,
+		backupSvc:  backupSvc,
+		location:   location,
+		metricsReg: metricsReg,
+	}
+}
+
+// sumBackupMetric returns the sum over all series of the scylla_manager_backup_<name> metric family.
+func (h *restoreTestHelper) sumBackupMetric(name string) int64 {
+	h.T.Helper()
+
+	mfs, err := h.metricsReg.Gather()
+	if err != nil {
+		h.T.Fatal(err)
+	}
+	var sum float64
+	for _, mf := range mfs {
+		if mf.GetName() == "scylla_manager_backup_"+name {
+			for _, m := range mf.GetMetric() {
+				sum += m.GetGauge().GetValue()
+			}
+		}
+	}
+	return int64(sum)
+}
+
+func (h *restoreTestHelper) assertBackupMetric(name string, want int64) {
+	h.T.Helper()
+
+	if got := h.sumBackupMetric(name); got != want {
+		h.T.Fatalf("Expected %s metric to be %d, got %d", name, want, got)
 	}
 }
 
@@ -109,7 +142,9 @@ func newTestClient(t *testing.T, hrt *HackableRoundTripper, logger log.Logger, c
 	return c
 }
 
-func newTestService(t *testing.T, session gocqlx.Session, client *scyllaclient.Client, c Config, logger log.Logger, clusterID uuid.UUID, user, pass string) (*Service, *backup.Service) {
+func newTestService(t *testing.T, session gocqlx.Session, client *scyllaclient.Client, c Config,
+	backupMetrics metrics.BackupMetrics, logger log.Logger, clusterID uuid.UUID, user, pass string,
+) (*Service, *backup.Service) {
 	t.Helper()
 
 	configCacheSvc := NewTestConfigCacheSvc(t, clusterID, client.Config().Hosts)
@@ -135,7 +170,7 @@ func newTestService(t *testing.T, session gocqlx.Session, client *scyllaclient.C
 	backupSvc, err := backup.NewService(
 		session,
 		defaultBackupTestConfig(),
-		metrics.NewBackupMetrics(),
+		backupMetrics,
 		func(_ context.Context, id uuid.UUID) (string, error) {
 			return "test_cluster", nil
 		},
@@ -1040,6 +1075,9 @@ func restoreWithVersions(t *testing.T, target Target, keyspace string, loadCnt, 
 	backupProps["method"] = backup.MethodAuto // This additionally validates fallback to rclone on versioned files creation
 	srcH.simpleBackupWithProperties(target.Location[0], backupProps)
 
+	Print("Fresh backup didn't create any versioned files")
+	srcH.assertBackupMetric("versioned_files_count", 0)
+
 	// Corrupting SSTables allows us to force the creation of versioned files
 	Print("Choose SSTables to corrupt")
 	remoteDir := target.Location[0].RemotePath(backupspec.RemoteSSTableDir(srcH.ClusterID, host.Datacenter, host.HostID, corruptedKeyspace, corruptedTable))
@@ -1162,6 +1200,15 @@ func restoreWithVersions(t *testing.T, target Target, keyspace string, loadCnt, 
 			if _, err = srcH.Client.RcloneFileInfo(ctx, host.Addr, corruptedPath); err != nil {
 				t.Fatalf("Validate file %s: %s", corruptedPath, err)
 			}
+		}
+		// The versioned_files_count metric is approximative - it assumes that if any
+		// sstable component is versioned, all will be as well. That's usually the case,
+		// but this test creates versioned files only from the .db sstable components.
+		// Since we don't need this metric to be precise and would like to avoid rewriting
+		// this test, we just validate that this metric is set.
+		Print("Backup creating versioned files has versioned files count metric set")
+		if got := srcH.sumBackupMetric("versioned_files_count"); got <= 0 {
+			t.Fatalf("Expected versioned_files_count metric to be greater than 0, got %d", got)
 		}
 
 		return tag

--- a/schema/v3.x12.0.cql
+++ b/schema/v3.x12.0.cql
@@ -1,0 +1,2 @@
+ALTER TABLE backup_run_progress ADD files_count bigint;
+ALTER TABLE backup_run_progress ADD files_skipped_count bigint;


### PR DESCRIPTION
This PR adds 5 backup related metrics:
- filesCount
- filesSkippedCount
- versionedFilesCount
- setEventBasedHolds
- removedEventBasedHolds

The first two serve as the counterpart to the already existing size based backup metrics.
Third adds the observability over versioned files, so that we can monitor their existence on prod clusters and plan their deprecation.
Last two are metrics monitoring event based hold req count - when combined with new count based metrics and already existing retention_locked_files metric, they would show req count savings achieved thanks to event based hold backup approach. 

The last 3 metrics have slightly different lifecycle - SM actually removes them at the start of the backup execution instead of setting them to -1. I believe that's a better approach, as they use nodeID and ks/tab labels which could become stale over time and would keep on being counted towards metric cardinality increasing its cost.

Fixes https://scylladb.atlassian.net/browse/CLOUD-3256
