### PR TITLE
Expose and document event based hold backup

### DIFF
--- a/docs/source/backup/retention-lock.rst
+++ b/docs/source/backup/retention-lock.rst
@@ -3,7 +3,7 @@ Retention Lock
 ==============
 
 ScyllaDB Manager can protect snapshot files from accidental or malicious deletion
-by applying object-level retention locks on snapshot files stored in backup bucket.
+by applying object retention locks or event based holds on snapshot files stored in backup bucket.
 When retention lock is enabled, snapshot files in the backup location cannot be
 deleted until the retention period expires.
 
@@ -16,7 +16,10 @@ Retention lock is currently supported for :doc:`Google Cloud Storage <setup-gcs>
 How It Works
 ============
 
-When retention lock is enabled on a backup task, ScyllaDB Manager applies object-level retention
+Object retention lock modes (``unlocked``, ``locked``)
+------------------------------------------------------
+
+When object retention lock is enabled on a backup task, ScyllaDB Manager applies object-level retention
 to all snapshot files from given backup task execution. This includes schema files, SSTable files,
 and manifest files. The retention lock is applied during dedicated stage (``RETENTION_LOCK``) that
 runs after backup is finalized and all snapshot files are already in backup location.
@@ -27,14 +30,51 @@ contained in the snapshot tag, and lasts for the specified retention days.
 This means that a snapshot with ``--retention-days 30`` will have its files protected for exactly 30 days
 from when the snapshot was taken, regardless of how long the backup task takes to complete.
 
+This approach results in making a per-file request for both newly uploaded and deduplicated files.
+When making highly deduplicated backups to a colder storage tier (low storage costs, high request costs),
+consider using ``event-based-hold`` mode which avoids making additional requests for deduplicated files.
+
+Event based hold mode (``event-based-hold``)
+--------------------------------------------
+
+This mode utilizes the following cloud provider features for protecting snapshot files:
+
+* `Default bucket event based holds <https://docs.cloud.google.com/storage/docs/object-holds#default-holds>`_ - uploaded
+  objects have event based hold set. This hold needs to be removed before protected object can be deleted.
+* `Bucket retention lock <https://docs.cloud.google.com/storage/docs/bucket-lock>`_ - removing event based hold from an
+  object starts specified retention period during which the object can't be deleted.
+
+ScyllaDB Manager utilizes those bucket features in the following way:
+
+* Newly uploaded snapshot files automatically have event based hold applied.
+* Deduplicated snapshot files keep their hold.
+* Files referenced by previous snapshot which are not a part of the current one have their event based holds released. This starts their retention period.
+
+The retention period is configured via bucket configuration, not the ``--retention-days`` or ``--retention`` flags.
+ScyllaDB Manager won't attempt to purge stale snapshots according to backup task retention policy,
+if they are still protected by either event based holds or already started retention period.
+
+The main benefit of this approach is that it makes only a single per-file request and does not repeat those requests for deduplicated files.
+When making highly deduplicated backups to a colder storage tier (low storage costs, high request costs),
+it's possible that the request costs can dominate the overall backup costs.
+``event-based-hold`` mode aims to reduce costs in such scenarios.
+
+Note that since the holds for previous snapshot are released only during the backup task execution,
+corresponding files won't be removed from the backup storage for at least ``bucket_retention_period + backup_task_interval``.
+
+Note that because all objects uploaded to the bucket are subject to the default retention policy,
+files coming from aborted backups, temporary manifests and permission check files can't be removed
+until their holds are released and the retention period expires.
+
 Modes
 =====
 
-Retention lock supports three modes controlled by the :ref:`sctool backup --retention-lock-mode <sctool-backup>` flag:
+Retention lock supports the following modes controlled by the :ref:`sctool backup --retention-lock-mode <sctool-backup>` flag:
 
 * ``disabled`` (default): No retention lock is applied to snapshot files.
 * ``unlocked``: Retention lock is applied but can be shortened or removed with special permissions (see `Prerequisites`_).
 * ``locked``: Retention lock is applied and cannot be overridden. Once set, the lock cannot be removed or shortened, even by the bucket owner.
+* ``event-based-hold``: While referenced by the newest snapshot, files are protected by default event based holds. After that, they are protected by default retention period.
 
 Override Lock
 =============
@@ -56,11 +96,22 @@ Prerequisites
 
    .. group-tab:: Google Cloud Storage
 
-      .. rubric:: Bucket configuration
+      .. rubric:: Bucket configuration for ``unlocked`` and ``locked`` modes
 
       The GCS bucket used as the backup location must have **Object Retention** enabled.
       Refer to the `Enable and use object retention configurations documentation <https://docs.cloud.google.com/storage/docs/using-object-lock>`_
       for instructions on creating a bucket with Object Retention enabled.
+
+      .. rubric:: Bucket configuration for ``event-based-hold`` mode
+
+      The GCS bucket used as the backup location must have a **default retention policy** configured -
+      it defines the protection period of snapshot files (see `How It Works`_).
+      Refer to the `Use and lock retention policies <https://docs.cloud.google.com/storage/docs/using-bucket-lock#set-policy>`_
+      for instructions on setting a default retention policy on a bucket.
+
+      It is also recommended to enable the **default event based hold** option on the bucket,
+      so that the initial request setting the hold can be avoided.
+      Refer to the `Use object holds <https://docs.cloud.google.com/storage/docs/holding-objects#set-default-hold>`_ for details.
 
       .. rubric:: Permissions
 
@@ -68,7 +119,7 @@ Prerequisites
       on the backup bucket:
 
       * ``storage.objects.update`` — required for updating object metadata.
-      * ``storage.objects.setRetention`` — required for applying retention locks to snapshot files.
+      * ``storage.objects.setRetention`` — required for applying retention locks to snapshot files in ``unlocked`` and ``locked`` modes.
       * ``storage.objects.overrideUnlockedRetention`` — required when using the ``--override-retention-lock`` flag
         to modify or remove existing locks in ``unlocked`` mode.
 
@@ -97,10 +148,17 @@ You can also :ref:`update an existing backup task <backup-update>` to enable ret
 
    sctool backup update -c <cluster ID> <backup task ID> --retention-lock-mode unlocked --retention-days 14
 
-Note that when retention lock is enabled:
+Note that when ``unlocked`` or ``locked`` retention lock mode is enabled:
 
 * ``--retention-days`` should be set to a positive value.
 * Count-based ``--retention`` should not be set.
+
+The ``event-based-hold`` mode can be combined with any retention policy, but the most intuitive
+configuration is to set ``--retention-days`` to the same value as the bucket's retention period:
+
+.. code-block:: none
+
+   sctool backup -c <cluster ID> -L gcs:<bucket> --retention-lock-mode event-based-hold --retention-days <bucket retention period days>
 
 Changing retention lock configuration
 -------------------------------------
@@ -114,6 +172,14 @@ deviating from them may lead to errors during the purge stage (see `Shared files
 * When changing from ``unlocked`` to ``locked``, use the ``--override-retention-lock`` flag (see `Override Lock`_).
 * In ``locked`` mode, ``--retention-days`` should only be **increased**, not decreased.
 * Decreasing ``--retention-days`` in ``unlocked`` mode should be accompanied by the ``--override-retention-lock`` flag (see `Override Lock`_).
+
+.. warning::
+
+   Changing the retention lock mode between ``unlocked``/``locked`` and ``event-based-hold``
+   (in either direction) is **not supported**. These approaches to protecting snapshot files
+   are not compatible with each other and require different bucket configurations.
+   To switch between them, create a new backup task pointing to a different backup location
+   configured for the desired mode.
 
 Shared files
 ============

--- a/docs/source/sctool/partials/sctool_backup.yaml
+++ b/docs/source/sctool/partials/sctool_backup.yaml
@@ -139,17 +139,29 @@ options:
     - name: retention-lock-mode
       default_value: disabled
       usage: |
-        Set object retention lock mode for snapshot files.
-        When enabled, snapshot files in the backup location are protected from deletion until the retention period (set by '--retention-days') expires.
+        Set retention lock mode for snapshot files.
+        When enabled, snapshot files in the backup location are protected from deletion until the retention period expires.
         Supported for GCS cloud provider only.
         Supported values:
 
         * 'disabled': No retention lock is applied to snapshot files (default).
-        * 'unlocked': Retention lock is applied but can be shortened or removed with special permissions.
-        * 'locked': Retention lock is applied and cannot be overridden.
+        * 'unlocked': Object retention lock is applied but can be shortened or removed with special permissions.
+        * 'locked': Object retention lock is applied and cannot be overridden.
+        * 'event-based-hold': While referenced by the newest snapshot, files are protected by default event based holds.
+          After that, they are protected by default retention period.
 
-        Requires '--retention-days' to be set to a positive value.
-        Count-based '--retention' mustn't be set when retention lock is enabled.
+        The 'unlocked' and 'locked' modes protect snapshot files for the retention period set by '--retention-days'.
+        They work by applying or refreshing object retention locks on both new and deduplicated snapshot files.
+        They require '--retention-days' to be set to a positive value and count-based '--retention' mustn't be set.
+
+        The 'event-based-hold' mode requires prior configuration of default retention period on the backup bucket level.
+        The default event based hold configuration is also strongly recommended (saves on request count).
+        It works by applying event based holds on newly uploaded snapshot files. If such file is still referenced by the next snapshot,
+        it keeps its hold set. Otherwise, the hold is removed and the default retention period starts ticking.
+        This means that snapshot files can be purged only after bucket_retention_period + backup_task_interval has passed.
+        It works with any '--retention' and '--retention-days' settings, as snapshots still protected by the event based holds
+        or retention period won't be purged even if backup task retention policy qualifies them as stale.
+        Changing retention lock mode between 'unlocked'/'locked' and 'event-based-hold' is not supported.
 
         Using retention lock requires additional configuration and has its own limitations,
         which are described in details in https://manager.docs.scylladb.com/stable/backup/retention-lock.

--- a/docs/source/sctool/partials/sctool_backup_update.yaml
+++ b/docs/source/sctool/partials/sctool_backup_update.yaml
@@ -140,17 +140,29 @@ options:
     - name: retention-lock-mode
       default_value: disabled
       usage: |
-        Set object retention lock mode for snapshot files.
-        When enabled, snapshot files in the backup location are protected from deletion until the retention period (set by '--retention-days') expires.
+        Set retention lock mode for snapshot files.
+        When enabled, snapshot files in the backup location are protected from deletion until the retention period expires.
         Supported for GCS cloud provider only.
         Supported values:
 
         * 'disabled': No retention lock is applied to snapshot files (default).
-        * 'unlocked': Retention lock is applied but can be shortened or removed with special permissions.
-        * 'locked': Retention lock is applied and cannot be overridden.
+        * 'unlocked': Object retention lock is applied but can be shortened or removed with special permissions.
+        * 'locked': Object retention lock is applied and cannot be overridden.
+        * 'event-based-hold': While referenced by the newest snapshot, files are protected by default event based holds.
+          After that, they are protected by default retention period.
 
-        Requires '--retention-days' to be set to a positive value.
-        Count-based '--retention' mustn't be set when retention lock is enabled.
+        The 'unlocked' and 'locked' modes protect snapshot files for the retention period set by '--retention-days'.
+        They work by applying or refreshing object retention locks on both new and deduplicated snapshot files.
+        They require '--retention-days' to be set to a positive value and count-based '--retention' mustn't be set.
+
+        The 'event-based-hold' mode requires prior configuration of default retention period on the backup bucket level.
+        The default event based hold configuration is also strongly recommended (saves on request count).
+        It works by applying event based holds on newly uploaded snapshot files. If such file is still referenced by the next snapshot,
+        it keeps its hold set. Otherwise, the hold is removed and the default retention period starts ticking.
+        This means that snapshot files can be purged only after bucket_retention_period + backup_task_interval has passed.
+        It works with any '--retention' and '--retention-days' settings, as snapshots still protected by the event based holds
+        or retention period won't be purged even if backup task retention policy qualifies them as stale.
+        Changing retention lock mode between 'unlocked'/'locked' and 'event-based-hold' is not supported.
 
         Using retention lock requires additional configuration and has its own limitations,
         which are described in details in https://manager.docs.scylladb.com/stable/backup/retention-lock.

--- a/pkg/command/backup/res.yaml
+++ b/pkg/command/backup/res.yaml
@@ -64,17 +64,29 @@ method: |
   which are described in details in https://manager.docs.scylladb.com/stable/backup/native-backup.
 
 retention-lock-mode: |
-  Set object retention lock mode for snapshot files.
-  When enabled, snapshot files in the backup location are protected from deletion until the retention period (set by '--retention-days') expires.
+  Set retention lock mode for snapshot files.
+  When enabled, snapshot files in the backup location are protected from deletion until the retention period expires.
   Supported for GCS cloud provider only.
   Supported values:
 
   * 'disabled': No retention lock is applied to snapshot files (default).
-  * 'unlocked': Retention lock is applied but can be shortened or removed with special permissions.
-  * 'locked': Retention lock is applied and cannot be overridden.
+  * 'unlocked': Object retention lock is applied but can be shortened or removed with special permissions.
+  * 'locked': Object retention lock is applied and cannot be overridden.
+  * 'event-based-hold': While referenced by the newest snapshot, files are protected by default event based holds.
+    After that, they are protected by default retention period.
 
-  Requires '--retention-days' to be set to a positive value.
-  Count-based '--retention' mustn't be set when retention lock is enabled.
+  The 'unlocked' and 'locked' modes protect snapshot files for the retention period set by '--retention-days'.
+  They work by applying or refreshing object retention locks on both new and deduplicated snapshot files.
+  They require '--retention-days' to be set to a positive value and count-based '--retention' mustn't be set.
+  
+  The 'event-based-hold' mode requires prior configuration of default retention period on the backup bucket level.
+  The default event based hold configuration is also strongly recommended (saves on request count).
+  It works by applying event based holds on newly uploaded snapshot files. If such file is still referenced by the next snapshot,
+  it keeps its hold set. Otherwise, the hold is removed and the default retention period starts ticking.
+  This means that snapshot files can be purged only after bucket_retention_period + backup_task_interval has passed.
+  It works with any '--retention' and '--retention-days' settings, as snapshots still protected by the event based holds
+  or retention period won't be purged even if backup task retention policy qualifies them as stale.
+  Changing retention lock mode between 'unlocked'/'locked' and 'event-based-hold' is not supported.
   
   Using retention lock requires additional configuration and has its own limitations,
   which are described in details in https://manager.docs.scylladb.com/stable/backup/retention-lock.

--- a/pkg/service/backup/event_based_hold_interceptor_integration_test.go
+++ b/pkg/service/backup/event_based_hold_interceptor_integration_test.go
@@ -363,6 +363,7 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 	props["retention"] = 0
 	props["retention_days"] = 2
 	props["method"] = backup.MethodAuto
+	props["retention_lock_mode"] = backup.RetentionLockEventBasedHold
 	rawProps, err := json.Marshal(props)
 	if err != nil {
 		t.Fatal(err)
@@ -371,7 +372,6 @@ func TestBackupEventBasedHoldIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	target.RetentionLockMode = backup.RetentionLockEventBasedHold
 	// To skip not interesting schema sstables
 	target.Units = []backup.Unit{{Keyspace: testKeyspace}}
 
@@ -506,6 +506,7 @@ func TestBackupEventBasedHoldVanishedDirsIntegration(t *testing.T) {
 	props["dc"] = []string{"dc1", "dc2"} // Ensure all nodes are backed up
 	props["retention"] = 7               // Just to keep purge out of the equation
 	props["method"] = backup.MethodAuto  // Just to not run into problems with GCS native backup support
+	props["retention_lock_mode"] = backup.RetentionLockEventBasedHold
 
 	makeTarget := func() backup.Target {
 		rawProps, err := json.Marshal(props)
@@ -516,8 +517,7 @@ func TestBackupEventBasedHoldVanishedDirsIntegration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		target.RetentionLockMode = backup.RetentionLockEventBasedHold // Bypass target validation for not yet exposed mode
-		target.Units = []backup.Unit{{Keyspace: keyspace}}            // Just to skip not interesting schema sstables
+		target.Units = []backup.Unit{{Keyspace: keyspace}} // Just to skip not interesting schema sstables
 		return target
 	}
 

--- a/pkg/service/backup/model.go
+++ b/pkg/service/backup/model.go
@@ -311,17 +311,24 @@ func (p taskProperties) validate(dcs []string, dcMap map[string][]string) error 
 		return errors.New("unknown Method: " + string(p.Method))
 	}
 	if !slices.Contains([]RetentionLockMode{
-		RetentionLockDisabled, RetentionLockUnlocked, RetentionLockLocked,
+		RetentionLockDisabled, RetentionLockUnlocked, RetentionLockLocked, RetentionLockEventBasedHold,
 	}, p.RetentionLockMode) {
 		return errors.New("unknown retention lock mode: " + string(p.RetentionLockMode))
 	}
-	if p.RetentionLockMode != RetentionLockDisabled {
+	// Retention policy restrictions apply only to the object retention lock modes,
+	// as the post hold release retention period is configured on bucket level.
+	if p.RetentionLockMode == RetentionLockUnlocked || p.RetentionLockMode == RetentionLockLocked {
 		if p.RetentionDays == nil || *p.RetentionDays <= 0 {
-			return util.ErrValidate(errors.New("retention days must be set when retention lock is enabled"))
+			return util.ErrValidate(errors.Errorf("retention days must be set when retention lock mode %q is used", p.RetentionLockMode))
 		}
 		if p.Retention != nil && *p.Retention > 0 {
-			return util.ErrValidate(errors.New("count-based retention mustn't be set when retention lock is enabled"))
+			return util.ErrValidate(errors.Errorf("count-based retention mustn't be set when retention lock mode %q is used", p.RetentionLockMode))
 		}
+	}
+	if p.OverrideRetentionLock && (p.RetentionLockMode == RetentionLockDisabled || p.RetentionLockMode == RetentionLockEventBasedHold) {
+		return util.ErrValidate(errors.Errorf("retention lock cannot be overridden when retention lock mode %q is used", p.RetentionLockMode))
+	}
+	if p.RetentionLockMode != RetentionLockDisabled {
 		for _, l := range p.Location {
 			if l.Provider != backupspec.GCS {
 				return util.ErrValidate(errors.Errorf(
@@ -329,9 +336,6 @@ func (p taskProperties) validate(dcs []string, dcMap map[string][]string) error 
 						"it's supported only for %s", l.Provider, backupspec.GCS))
 			}
 		}
-	}
-	if p.RetentionLockMode == RetentionLockDisabled && p.OverrideRetentionLock {
-		return util.ErrValidate(errors.New("retention lock cannot be overridden when it is disabled"))
 	}
 
 	// Validate location DCs

--- a/pkg/service/backup/model_test.go
+++ b/pkg/service/backup/model_test.go
@@ -54,6 +54,129 @@ func TestDCLimitMarshalUnmarshalText(t *testing.T) {
 	}
 }
 
+func TestTaskPropertiesValidate(t *testing.T) {
+	t.Parallel()
+
+	gcs := backupspec.Location{Provider: backupspec.GCS, Path: "bucket"}
+	s3 := backupspec.Location{Provider: backupspec.S3, Path: "bucket"}
+
+	table := []struct {
+		Name   string
+		Mutate func(p *taskProperties)
+		Error  bool
+	}{
+		{
+			Name:   "unknown retention lock mode",
+			Mutate: func(p *taskProperties) { p.RetentionLockMode = "unknown" },
+			Error:  true,
+		},
+		{
+			Name:   "disabled retention lock with override",
+			Mutate: func(p *taskProperties) { p.OverrideRetentionLock = true },
+			Error:  true,
+		},
+		{
+			Name: "unlocked retention lock without retention days",
+			Mutate: func(p *taskProperties) {
+				p.RetentionLockMode = RetentionLockUnlocked
+			},
+			Error: true,
+		},
+		{
+			Name: "locked retention lock with count-based retention",
+			Mutate: func(p *taskProperties) {
+				p.RetentionLockMode = RetentionLockLocked
+				p.RetentionDays = new(7)
+				p.Retention = new(3)
+			},
+			Error: true,
+		},
+		{
+			Name: "locked retention lock on non-GCS location",
+			Mutate: func(p *taskProperties) {
+				p.RetentionLockMode = RetentionLockLocked
+				p.RetentionDays = new(7)
+				p.Location = []backupspec.Location{s3}
+			},
+			Error: true,
+		},
+		{
+			Name: "locked retention lock with retention days",
+			Mutate: func(p *taskProperties) {
+				p.RetentionLockMode = RetentionLockLocked
+				p.RetentionDays = new(7)
+			},
+		},
+		{
+			Name: "unlocked retention lock with override",
+			Mutate: func(p *taskProperties) {
+				p.RetentionLockMode = RetentionLockUnlocked
+				p.RetentionDays = new(7)
+				p.OverrideRetentionLock = true
+			},
+		},
+		{
+			Name: "event based hold without retention days",
+			Mutate: func(p *taskProperties) {
+				p.RetentionLockMode = RetentionLockEventBasedHold
+			},
+		},
+		{
+			Name: "event based hold with retention days",
+			Mutate: func(p *taskProperties) {
+				p.RetentionLockMode = RetentionLockEventBasedHold
+				p.RetentionDays = new(7)
+			},
+		},
+		{
+			Name: "event based hold with count-based retention",
+			Mutate: func(p *taskProperties) {
+				p.RetentionLockMode = RetentionLockEventBasedHold
+				p.Retention = new(3)
+			},
+		},
+		{
+			Name: "event based hold with override",
+			Mutate: func(p *taskProperties) {
+				p.RetentionLockMode = RetentionLockEventBasedHold
+				p.OverrideRetentionLock = true
+			},
+			Error: true,
+		},
+		{
+			Name: "event based hold on non-GCS location",
+			Mutate: func(p *taskProperties) {
+				p.RetentionLockMode = RetentionLockEventBasedHold
+				p.Location = []backupspec.Location{s3}
+			},
+			Error: true,
+		},
+	}
+
+	dcs := []string{"dc1"}
+	dcMap := map[string][]string{"dc1": {"h1"}}
+
+	for i := range table {
+		test := table[i]
+
+		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+
+			p := defaultTaskProperties()
+			p.Location = []backupspec.Location{gcs}
+			test.Mutate(&p)
+
+			err := p.validate(dcs, dcMap)
+			if test.Error && err == nil {
+				t.Fatal("validate() expected error, got nil")
+			}
+			if !test.Error && err != nil {
+				t.Fatalf("validate() unexpected error: %s", err)
+			}
+		})
+	}
+}
+
 func TestExtractLocations(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/service/backup/service_backup_integration_test.go
+++ b/pkg/service/backup/service_backup_integration_test.go
@@ -707,12 +707,12 @@ func TestGetTargetErrorIntegration(t *testing.T) {
 		{
 			Name:  "retention lock enabled without retention days",
 			JSON:  `{"retention_lock_mode": "unlocked", "location": ["s3:backuptest-get-target-error"]}`,
-			Error: "retention days must be set when retention lock is enabled",
+			Error: `retention days must be set when retention lock mode "unlocked" is used`,
 		},
 		{
 			Name:  "retention lock enabled with count-based retention",
 			JSON:  `{"retention_lock_mode": "unlocked", "retention_days": 7, "retention": 3, "location": ["s3:backuptest-get-target-error"]}`,
-			Error: "count-based retention mustn't be set when retention lock is enabled",
+			Error: `count-based retention mustn't be set when retention lock mode "unlocked" is used`,
 		},
 		{
 			Name:  "retention lock enabled with non-gcs provider",
@@ -722,7 +722,17 @@ func TestGetTargetErrorIntegration(t *testing.T) {
 		{
 			Name:  "override retention lock when disabled",
 			JSON:  `{"retention_lock_mode": "disabled", "override_retention_lock": true, "location": ["s3:backuptest-get-target-error"]}`,
-			Error: "retention lock cannot be overridden when it is disabled",
+			Error: `retention lock cannot be overridden when retention lock mode "disabled" is used`,
+		},
+		{
+			Name:  "override retention lock with event based hold",
+			JSON:  `{"retention_lock_mode": "event-based-hold", "override_retention_lock": true, "location": ["s3:backuptest-get-target-error"]}`,
+			Error: `retention lock cannot be overridden when retention lock mode "event-based-hold" is used`,
+		},
+		{
+			Name:  "event based hold with non-gcs provider",
+			JSON:  `{"retention_lock_mode": "event-based-hold", "location": ["s3:backuptest-get-target-error"]}`,
+			Error: "retention lock is not supported for s3 provider",
 		},
 	}
 

--- a/pkg/service/backup/service_retention_lock_integration_test.go
+++ b/pkg/service/backup/service_retention_lock_integration_test.go
@@ -447,7 +447,8 @@ func TestBackupProtectedManifestsIntegration(t *testing.T) {
 			nextID := RawWriteData(t, clusterSession, tc.keyspace, 0, 1, replication, true)
 
 			props := defaultTestProperties(location, tc.keyspace)
-			// Just to satisfy retention lock validation.
+			props["retention_lock_mode"] = tc.retentionLockMode
+			// Required by the unlocked mode validation.
 			// Different retention policy will be used for purge purposes.
 			props["retention_days"] = 1
 			// Tests forcing GCS provider need to use method auto to avoid
@@ -462,8 +463,6 @@ func TestBackupProtectedManifestsIntegration(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// Added here to bypass validation, as this method is not yet exposed
-			target.RetentionLockMode = tc.retentionLockMode
 			// Inject purge so that it keeps only the last snapshot
 			target.RetentionMap = backup.RetentionMap{h.TaskID: {Retention: 1}}
 			// To skip not interesting schema sstables

--- a/pkg/service/one2onerestore/helpers_integration_test.go
+++ b/pkg/service/one2onerestore/helpers_integration_test.go
@@ -69,11 +69,6 @@ func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {
 	taskID := uuid.NewTime()
 	runID := uuid.NewTime()
 
-	retMode, ok := props["retention_lock_mode"].(backup.RetentionLockMode)
-	if ok && retMode == backup.RetentionLockEventBasedHold {
-		delete(props, "retention_lock_mode")
-	}
-
 	rawProps, err := json.Marshal(props)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "marshal properties"))
@@ -82,9 +77,6 @@ func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {
 	target, err := h.backupSvc.GetTarget(ctx, h.clusterID, rawProps)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "generate target"))
-	}
-	if ok && retMode == backup.RetentionLockEventBasedHold {
-		target.RetentionLockMode = backup.RetentionLockEventBasedHold
 	}
 
 	err = h.backupSvc.Backup(ctx, h.clusterID, taskID, runID, target)

--- a/pkg/service/restore/helper_integration_test.go
+++ b/pkg/service/restore/helper_integration_test.go
@@ -259,11 +259,6 @@ func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {
 	ctx := context.Background()
 	h.srcCluster.RunID = uuid.NewTime()
 
-	retMode, ok := props["retention_lock_mode"].(backup.RetentionLockMode)
-	if ok && retMode == backup.RetentionLockEventBasedHold {
-		delete(props, "retention_lock_mode")
-	}
-
 	rawProps, err := json.Marshal(props)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "marshal properties"))
@@ -272,9 +267,6 @@ func (h *testHelper) runBackup(t *testing.T, props map[string]any) string {
 	target, err := h.srcBackupSvc.GetTarget(ctx, h.srcCluster.ClusterID, rawProps)
 	if err != nil {
 		t.Fatal(errors.Wrap(err, "generate target"))
-	}
-	if ok && retMode == backup.RetentionLockEventBasedHold {
-		target.RetentionLockMode = backup.RetentionLockEventBasedHold
 	}
 
 	err = h.srcBackupSvc.Backup(ctx, h.srcCluster.ClusterID, h.srcCluster.TaskID, h.srcCluster.RunID, target)


### PR DESCRIPTION
This PR:
- allows --retention-lock-mode=event-based-hold to pass backup target validation
- cleans up test code from workarounds needed to bypass this validation
- adds sctool and regular docs

Fixes https://scylladb.atlassian.net/browse/CLOUD-3224