### PR TITLE
Test against scylla 2026.3 instead of 2025.4

### DIFF
--- a/.github/cfg/integration-test-cfg.yaml
+++ b/.github/cfg/integration-test-cfg.yaml
@@ -8,29 +8,14 @@
   tablets: enabled
   ssl-enabled: false
 
-- scylla-version: scylla:2025.4.10
-  ip-family: IPV4
-  tablets: disabled
-  ssl-enabled: true
-  backup-method: native
-  restore-method: rclone
-
-- scylla-version: scylla:2025.4.10
-  ip-family: IPV6
-  tablets: enabled
-  ssl-enabled: false
-  backup-method: rclone
-  restore-method: rclone
-  backup-provider: gcs
-
-- scylla-version: scylla:2026.1.7
+- scylla-version: scylla:2026.1.10
   ip-family: IPV4
   tablets: enabled
   ssl-enabled: true
   backup-method: native
   restore-method: native
 
-- scylla-version: scylla:2026.1.7
+- scylla-version: scylla:2026.1.10
   ip-family: IPV6
   tablets: disabled
   ssl-enabled: false
@@ -38,19 +23,34 @@
   restore-method: rclone
   backup-provider: localstorage
 
-- scylla-version: scylla:2026.2.0
+- scylla-version: scylla:2026.2.4
   ip-family: IPV4
   tablets: enabled
   ssl-enabled: true
   backup-method: rclone
   restore-method: native
 
-- scylla-version: scylla:2026.2.0
+- scylla-version: scylla:2026.2.4
   ip-family: IPV6
   tablets: disabled
   ssl-enabled: false
   backup-method: rclone
   restore-method: rclone
+
+- scylla-version: scylla:2026.3.0-rc2
+  ip-family: IPV4
+  tablets: disabled
+  ssl-enabled: true
+  backup-method: native
+  restore-method: rclone
+
+- scylla-version: scylla:2026.3.0-rc2
+  ip-family: IPV6
+  tablets: enabled
+  ssl-enabled: false
+  backup-method: rclone
+  restore-method: rclone
+  backup-provider: gcs
 
 - scylla-version: scylla-nightly:latest
   ip-family: IPV4

--- a/.github/workflows/integration-tests-2026.1.10-IPV4-tablets-native-native.yaml
+++ b/.github/workflows/integration-tests-2026.1.10-IPV4-tablets-native-native.yaml
@@ -2,11 +2,11 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla:2026.2.0
+    scylla-version: scylla:2026.1.10
     ip-family: IPV4
     tablets: enabled
     ssl-enabled: "true"
-    backup-method: rclone
+    backup-method: native
     restore-method: native
 jobs:
     backup:
@@ -108,7 +108,7 @@ jobs:
               run: make pkg-integration-test TABLETS=${{ env.tablets }} BACKUP_PROVIDER=${{ env.backup-provider }} PKG=./pkg/service/one2onerestore
             - name: Verify SM server startup
               run: make run-server SSL_ENABLED=${{ env.ssl-enabled }} IP_FAMILY=${{ env.ip-family }}
-name: integration-tests-2026.2.0-IPV4-tablets-rclone-native
+name: integration-tests-2026.1.10-IPV4-tablets-native-native
 "on":
     pull_request:
         paths-ignore:

--- a/.github/workflows/integration-tests-2026.1.10-IPV6-nossl-rclone-rclone-localstorage.yaml
+++ b/.github/workflows/integration-tests-2026.1.10-IPV6-nossl-rclone-rclone-localstorage.yaml
@@ -2,12 +2,13 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla:2025.4.10
-    ip-family: IPV4
+    scylla-version: scylla:2026.1.10
+    ip-family: IPV6
     tablets: disabled
-    ssl-enabled: "true"
-    backup-method: native
+    ssl-enabled: "false"
+    backup-method: rclone
     restore-method: rclone
+    backup-provider: localstorage
 jobs:
     backup:
         name: Test backup
@@ -108,7 +109,7 @@ jobs:
               run: make pkg-integration-test TABLETS=${{ env.tablets }} BACKUP_PROVIDER=${{ env.backup-provider }} PKG=./pkg/service/one2onerestore
             - name: Verify SM server startup
               run: make run-server SSL_ENABLED=${{ env.ssl-enabled }} IP_FAMILY=${{ env.ip-family }}
-name: integration-tests-2025.4.10-IPV4-native-rclone
+name: integration-tests-2026.1.10-IPV6-nossl-rclone-rclone-localstorage
 "on":
     pull_request:
         paths-ignore:

--- a/.github/workflows/integration-tests-2026.2.4-IPV4-tablets-rclone-native.yaml
+++ b/.github/workflows/integration-tests-2026.2.4-IPV4-tablets-rclone-native.yaml
@@ -2,12 +2,12 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla:2026.2.0
-    ip-family: IPV6
-    tablets: disabled
-    ssl-enabled: "false"
+    scylla-version: scylla:2026.2.4
+    ip-family: IPV4
+    tablets: enabled
+    ssl-enabled: "true"
     backup-method: rclone
-    restore-method: rclone
+    restore-method: native
 jobs:
     backup:
         name: Test backup
@@ -108,7 +108,7 @@ jobs:
               run: make pkg-integration-test TABLETS=${{ env.tablets }} BACKUP_PROVIDER=${{ env.backup-provider }} PKG=./pkg/service/one2onerestore
             - name: Verify SM server startup
               run: make run-server SSL_ENABLED=${{ env.ssl-enabled }} IP_FAMILY=${{ env.ip-family }}
-name: integration-tests-2026.2.0-IPV6-nossl-rclone-rclone
+name: integration-tests-2026.2.4-IPV4-tablets-rclone-native
 "on":
     pull_request:
         paths-ignore:

--- a/.github/workflows/integration-tests-2026.2.4-IPV6-nossl-rclone-rclone.yaml
+++ b/.github/workflows/integration-tests-2026.2.4-IPV6-nossl-rclone-rclone.yaml
@@ -2,13 +2,12 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla:2025.4.10
+    scylla-version: scylla:2026.2.4
     ip-family: IPV6
-    tablets: enabled
+    tablets: disabled
     ssl-enabled: "false"
     backup-method: rclone
     restore-method: rclone
-    backup-provider: gcs
 jobs:
     backup:
         name: Test backup
@@ -109,7 +108,7 @@ jobs:
               run: make pkg-integration-test TABLETS=${{ env.tablets }} BACKUP_PROVIDER=${{ env.backup-provider }} PKG=./pkg/service/one2onerestore
             - name: Verify SM server startup
               run: make run-server SSL_ENABLED=${{ env.ssl-enabled }} IP_FAMILY=${{ env.ip-family }}
-name: integration-tests-2025.4.10-IPV6-tablets-nossl-rclone-rclone-gcs
+name: integration-tests-2026.2.4-IPV6-nossl-rclone-rclone
 "on":
     pull_request:
         paths-ignore:

--- a/.github/workflows/integration-tests-2026.3.0-rc2-IPV4-native-rclone.yaml
+++ b/.github/workflows/integration-tests-2026.3.0-rc2-IPV4-native-rclone.yaml
@@ -2,13 +2,12 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla:2026.1.7
-    ip-family: IPV6
+    scylla-version: scylla:2026.3.0-rc2
+    ip-family: IPV4
     tablets: disabled
-    ssl-enabled: "false"
-    backup-method: rclone
+    ssl-enabled: "true"
+    backup-method: native
     restore-method: rclone
-    backup-provider: localstorage
 jobs:
     backup:
         name: Test backup
@@ -109,7 +108,7 @@ jobs:
               run: make pkg-integration-test TABLETS=${{ env.tablets }} BACKUP_PROVIDER=${{ env.backup-provider }} PKG=./pkg/service/one2onerestore
             - name: Verify SM server startup
               run: make run-server SSL_ENABLED=${{ env.ssl-enabled }} IP_FAMILY=${{ env.ip-family }}
-name: integration-tests-2026.1.7-IPV6-nossl-rclone-rclone-localstorage
+name: integration-tests-2026.3.0-rc2-IPV4-native-rclone
 "on":
     pull_request:
         paths-ignore:

--- a/.github/workflows/integration-tests-2026.3.0-rc2-IPV6-tablets-nossl-rclone-rclone-gcs.yaml
+++ b/.github/workflows/integration-tests-2026.3.0-rc2-IPV6-tablets-nossl-rclone-rclone-gcs.yaml
@@ -2,12 +2,13 @@ concurrency:
     cancel-in-progress: true
     group: int-${{ github.workflow }}-${{ github.ref }}
 env:
-    scylla-version: scylla:2026.1.7
-    ip-family: IPV4
+    scylla-version: scylla:2026.3.0-rc2
+    ip-family: IPV6
     tablets: enabled
-    ssl-enabled: "true"
-    backup-method: native
-    restore-method: native
+    ssl-enabled: "false"
+    backup-method: rclone
+    restore-method: rclone
+    backup-provider: gcs
 jobs:
     backup:
         name: Test backup
@@ -108,7 +109,7 @@ jobs:
               run: make pkg-integration-test TABLETS=${{ env.tablets }} BACKUP_PROVIDER=${{ env.backup-provider }} PKG=./pkg/service/one2onerestore
             - name: Verify SM server startup
               run: make run-server SSL_ENABLED=${{ env.ssl-enabled }} IP_FAMILY=${{ env.ip-family }}
-name: integration-tests-2026.1.7-IPV4-tablets-native-native
+name: integration-tests-2026.3.0-rc2-IPV6-tablets-nossl-rclone-rclone-gcs
 "on":
     pull_request:
         paths-ignore:

--- a/README.md
+++ b/README.md
@@ -15,22 +15,22 @@ Scylla Manager consists of tree components:
 
 ## Scylla integration status
 
-| ScyllaDB version | Workflows                                                                                                                        | Limitations                                                               |
-|------------------|----------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| **2025.1.14**    | ![integration-tests-2025.1.14-IPV4]<br/>![integration-tests-2025.1.14-IPV6-tablets-nossl]                                        | Restoration of **Authentication** and **Service Levels** is not supported |
-| **2025.4.10**    | ![integration-tests-2025.4.10-IPV4-native-rclone]<br/>![integration-tests-2025.4.10-IPV6-tablets-nossl-rclone-rclone-gcs]        | Restoration of **Authentication** and **Service Levels** is not supported |
-| **2026.1.7**     | ![integration-tests-2026.1.7-IPV4-tablets-native-native]<br/>![integration-tests-2026.1.7-IPV6-nossl-rclone-rclone-localstorage] | Restoration of **Authentication** and **Service Levels** is not supported |
-| **2026.2.0**     | ![integration-tests-2026.2.0-IPV4-tablets-rclone-native]<br/>![integration-tests-2026.2.0-IPV6-nossl-rclone-rclone]              | Restoration of **Authentication** and **Service Levels** is not supported |
-| **latest**       | ![integration-tests-latest-IPV4-native-native-gcs]<br/>![integration-tests-latest-IPV6-tablets-nossl-rclone-rclone]              | Restoration of **Authentication** and **Service Levels** is not supported |
+| ScyllaDB version | Workflows                                                                                                                          | Limitations                                                               |
+|------------------|------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| **2025.1.14**    | ![integration-tests-2025.1.14-IPV4]<br/>![integration-tests-2025.1.14-IPV6-tablets-nossl]                                          | Restoration of **Authentication** and **Service Levels** is not supported |
+| **2026.1.10**    | ![integration-tests-2026.1.10-IPV4-tablets-native-native]<br/>![integration-tests-2026.1.10-IPV6-nossl-rclone-rclone-localstorage] | Restoration of **Authentication** and **Service Levels** is not supported |
+| **2026.2.4**     | ![integration-tests-2026.2.4-IPV4-tablets-rclone-native]<br/>![integration-tests-2026.2.4-IPV6-nossl-rclone-rclone]                | Restoration of **Authentication** and **Service Levels** is not supported |
+| **2026.3.0-rc2** | ![integration-tests-2026.3.0-rc2-IPV4-native-rclone]<br/>![integration-tests-2026.3.0-rc2-IPV6-tablets-nossl-rclone-rclone-gcs]    | Restoration of **Authentication** and **Service Levels** is not supported |
+| **latest**       | ![integration-tests-latest-IPV4-native-native-gcs]<br/>![integration-tests-latest-IPV6-tablets-nossl-rclone-rclone]                | Restoration of **Authentication** and **Service Levels** is not supported |
 
 [integration-tests-2025.1.14-IPV4]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2025.1.14-IPV4.yaml/badge.svg?branch=master
 [integration-tests-2025.1.14-IPV6-tablets-nossl]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2025.1.14-IPV6-tablets-nossl.yaml/badge.svg?branch=master
-[integration-tests-2025.4.10-IPV4-native-rclone]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2025.4.10-IPV4-native-rclone.yaml/badge.svg?branch=master
-[integration-tests-2025.4.10-IPV6-tablets-nossl-rclone-rclone-gcs]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2025.4.10-IPV6-tablets-nossl-rclone-rclone-gcs.yaml/badge.svg?branch=master
-[integration-tests-2026.1.7-IPV4-tablets-native-native]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2026.1.7-IPV4-tablets-native-native.yaml/badge.svg?branch=master
-[integration-tests-2026.1.7-IPV6-nossl-rclone-rclone-localstorage]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2026.1.7-IPV6-nossl-rclone-rclone-localstorage.yaml/badge.svg?branch=master
-[integration-tests-2026.2.0-IPV4-tablets-rclone-native]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2026.2.0-IPV4-tablets-rclone-native.yaml/badge.svg?branch=master
-[integration-tests-2026.2.0-IPV6-nossl-rclone-rclone]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2026.2.0-IPV6-nossl-rclone-rclone.yaml/badge.svg?branch=master
+[integration-tests-2026.1.10-IPV4-tablets-native-native]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2026.1.10-IPV4-tablets-native-native.yaml/badge.svg?branch=master
+[integration-tests-2026.1.10-IPV6-nossl-rclone-rclone-localstorage]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2026.1.10-IPV6-nossl-rclone-rclone-localstorage.yaml/badge.svg?branch=master
+[integration-tests-2026.2.4-IPV4-tablets-rclone-native]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2026.2.4-IPV4-tablets-rclone-native.yaml/badge.svg?branch=master
+[integration-tests-2026.2.4-IPV6-nossl-rclone-rclone]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2026.2.4-IPV6-nossl-rclone-rclone.yaml/badge.svg?branch=master
+[integration-tests-2026.3.0-rc2-IPV4-native-rclone]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2026.3.0-rc2-IPV4-native-rclone.yaml/badge.svg?branch=master
+[integration-tests-2026.3.0-rc2-IPV6-tablets-nossl-rclone-rclone-gcs]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-2026.3.0-rc2-IPV6-tablets-nossl-rclone-rclone-gcs.yaml/badge.svg?branch=master
 [integration-tests-latest-IPV4-native-native-gcs]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-latest-IPV4-native-native-gcs.yaml/badge.svg?branch=master
 [integration-tests-latest-IPV6-tablets-nossl-rclone-rclone]: https://github.com/scylladb/scylla-manager/actions/workflows/integration-tests-latest-IPV6-tablets-nossl-rclone-rclone.yaml/badge.svg?branch=master
 


### PR DESCRIPTION
Scylla 2025.4 is no longer supported:
https://docs.scylladb.com/stable/versioning/version-support.html
Scylla 2026.3 has rc image. Because of that, scylla 2025.4 is
removed and scylla 2026.3 is added to SM CI test matrix.

This commit also bumps other available patch versions.