### PR TITLE
fix(repair): repair all replicas of a small table

### DIFF
--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -5,6 +5,7 @@ package repair
 import (
 	"context"
 	"net/netip"
+	"slices"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
@@ -73,13 +74,19 @@ func (jt jobType) fullTableRepair() bool {
 }
 
 type job struct {
-	keyspace   string
-	table      string
-	master     netip.Addr
+	keyspace string
+	table    string
+	master   netip.Addr
+	// replicaSet is the replica set of the repaired ranges. It is the unit of
+	// the controller bookkeeping and of the recorded progress.
 	replicaSet []netip.Addr
-	ranges     []scyllaclient.TokenRange
-	intensity  int
-	jobType    jobType
+	// hosts is sent as the 'hosts' param of the repair API call, limiting the
+	// nodes taking part in the repair. Empty means no limit, which lets Scylla
+	// pick the participants on its own.
+	hosts     []netip.Addr
+	ranges    []scyllaclient.TokenRange
+	intensity int
+	jobType   jobType
 }
 
 type jobResult struct {
@@ -280,6 +287,7 @@ func (tg *tableGenerator) newJob() (job, bool) {
 				table:      tg.Table,
 				master:     tg.ms.Select(filtered),
 				replicaSet: filtered,
+				hosts:      tg.repairHosts(jt, filtered),
 				ranges:     ranges,
 				intensity:  intensity,
 				jobType:    jt,
@@ -288,6 +296,49 @@ func (tg *tableGenerator) newJob() (job, bool) {
 	}
 
 	return job{}, false
+}
+
+// repairHosts returns the nodes to be sent as the 'hosts' param of the repair
+// API call for a job of given jobType repairing given replica set.
+//
+// A small table repair is performed with a single API call covering the whole
+// ring, so it spans the ranges of every replica set - not just the one the job
+// was created for. Scylla resolves the participants of such a call as all of
+// the normal token owners, but it intersects them with the 'hosts' param, so
+// passing a single replica set there would leave every replica outside of it
+// unrepaired, see CLOUD-3672.
+//
+// Because of that, no 'hosts' limit is sent for such calls, unless the user
+// narrowed down the nodes taking part in the repair - in which case the limit
+// has to be honored, and all of the table replicas that passed the filtering
+// are sent instead. Note that a filtered repair does not cover all of the
+// replicas, so it does not advance the tombstone gc repair time in Scylla.
+func (tg *tableGenerator) repairHosts(jt jobType, filtered []netip.Addr) []netip.Addr {
+	if jt != smallTableJobType {
+		return filtered
+	}
+	if !tg.target.HostFilter {
+		return nil
+	}
+	return tg.allFilteredReplicas()
+}
+
+// allFilteredReplicas returns all of the table replicas that passed the
+// --dc / --host / --ignore-down-hosts filtering.
+func (tg *tableGenerator) allFilteredReplicas() []netip.Addr {
+	var out []netip.Addr
+	for _, rt := range tg.Ring.ReplicaTokens {
+		for _, h := range filterReplicaSet(rt.ReplicaSet, tg.Ring.HostDC, tg.target) {
+			if !slices.Contains(out, h) {
+				out = append(out, h)
+			}
+		}
+	}
+	// Ensure deterministic order of nodes.
+	slices.SortFunc(out, func(a, b netip.Addr) int {
+		return a.Compare(b)
+	})
+	return out
 }
 
 func (tg *tableGenerator) getRangesToRepair(allRanges []scyllaclient.TokenRange, intensity int) []scyllaclient.TokenRange {

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/netip"
 	"os"
@@ -30,6 +31,7 @@ import (
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/httpx"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/prom"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 	slices2 "github.com/scylladb/scylla-manager/v3/pkg/util2/slices"
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/client/operations"
@@ -739,4 +741,76 @@ func chanClosedWithin(t *testing.T, c chan struct{}, d time.Duration) {
 	case <-time.After(d):
 		t.Fatal("timeout after ", d)
 	}
+}
+
+// scyllaPrometheusPort is the port Scylla exposes its metrics on.
+const scyllaPrometheusPort = "9180"
+
+// nodeRepairWork returns the total number of row hashes exchanged by given node
+// during all of the repairs it took part in, summed over its shards.
+//
+// The counters are bumped on both sides of the row hash exchange, so any node
+// participating in a repair moves them, even when there is nothing to reconcile.
+// A node that was left out of a repair does not move them at all, which makes
+// them a way of telling whether a node was really repaired.
+//
+// Scylla exposes its metrics on the second test network, not on the one the API
+// is served on, so the host is translated between the two.
+func nodeRepairWork(t *testing.T, host string) float64 {
+	t.Helper()
+
+	metricsHost, err := secondNetHost(host)
+	if err != nil {
+		t.Fatalf("Translate %s to the second test network: %s", host, err)
+	}
+	u := "http://" + net.JoinHostPort(metricsHost, scyllaPrometheusPort) + "/metrics?name=repair_hashes_nr"
+
+	resp, err := http.Get(u) //nolint:gosec,noctx
+	if err != nil {
+		t.Fatalf("Get metrics of %s: %s", host, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Get metrics of %s: status %d", host, resp.StatusCode)
+	}
+
+	families, err := prom.ParseText(resp.Body)
+	if err != nil {
+		t.Fatalf("Parse metrics of %s: %s", host, err)
+	}
+
+	var out float64
+	// Scylla registers its metric groups on startup, so a missing metric means
+	// that it was renamed or removed - fail instead of reporting no repair work.
+	for _, name := range []string{"scylla_repair_rx_hashes_nr", "scylla_repair_tx_hashes_nr"} {
+		family, ok := families[name]
+		if !ok {
+			t.Fatalf("Scylla on %s does not expose %s metric", host, name)
+		}
+		for _, m := range family.GetMetric() {
+			if counter := m.GetCounter(); counter != nil {
+				out += counter.GetValue()
+			}
+		}
+	}
+	return out
+}
+
+// secondNetHost translates an address from the test network to the second test
+// network, keeping the host part of the address.
+func secondNetHost(host string) (string, error) {
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return "", err
+	}
+	s := addr.String()
+	sep := "."
+	if !addr.Is4() {
+		sep = ":"
+	}
+	i := strings.LastIndex(s, sep)
+	if i < 0 {
+		return "", errors.New("unexpected address format: " + s)
+	}
+	return ToCanonicalIP(IPFromSecondTestNet(s[i+1:])), nil
 }

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -220,7 +220,9 @@ func parseRepairAsyncReq(t *testing.T, req *http.Request) repairReq {
 		}
 		sched.rangesParallelism = rangesParallelism
 	}
-	if sched.keyspace == "" || sched.table == "" || len(sched.replicaSet) == 0 {
+	// The hosts param is optional: a small table repair sends no host limit,
+	// so that all of the table replicas take part in it.
+	if sched.keyspace == "" || sched.table == "" || (len(sched.replicaSet) == 0 && !sched.smallTableOptimization) {
 		t.Error("Not fully initialized old repair sched req")
 		return repairReq{}
 	}

--- a/pkg/service/repair/model.go
+++ b/pkg/service/repair/model.go
@@ -40,7 +40,12 @@ type Target struct {
 	Host                netip.Addr                       `json:"host"`
 	KeyspaceReplication scyllaclient.KeyspaceReplication `json:"keyspace_replication"`
 	// Down hosts excluded from repair by the --ignore-down-hosts flag.
-	IgnoreHosts         []netip.Addr                 `json:"ignore_hosts,omitempty"`
+	IgnoreHosts []netip.Addr `json:"ignore_hosts,omitempty"`
+	// HostFilter is true when the user explicitly narrowed the set of nodes
+	// taking part in the repair with the --dc, --host or --ignore-down-hosts
+	// flag. It cannot be derived from the fields above, as DC is always filled
+	// with all of the cluster DCs when --dc is not set.
+	HostFilter          bool                         `json:"host_filter"`
 	FailFast            bool                         `json:"fail_fast"`
 	Continue            bool                         `json:"continue"`
 	Intensity           Intensity                    `json:"intensity"`

--- a/pkg/service/repair/service.go
+++ b/pkg/service/repair/service.go
@@ -150,6 +150,10 @@ func (s *Service) GetTarget(ctx context.Context, clusterID uuid.UUID, properties
 	if err := validateIgnoreDownNodes(t, status); err != nil {
 		return t, err
 	}
+	// Record whether the user narrowed down the set of nodes taking part in the
+	// repair. It has to be taken from the raw properties, as t.DC is filled with
+	// all of the cluster DCs when --dc is not set.
+	t.HostFilter = len(props.DC) > 0 || props.Host != "" || props.IgnoreDownHosts
 
 	// Get potential units - all tables matched by keyspace flag
 	f, err := ksfilter.NewFilter(props.Keyspace)

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -2676,3 +2676,110 @@ func TestTabletRepairInteractionIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestServiceRepairSmallTableOptimizationRepairsAllNodesIntegration(t *testing.T) {
+	// End-to-end companion of the CLOUD-3672 regression tests above.
+	//
+	// Instead of asserting the shape of the repair API call, this test runs a real
+	// repair and verifies via Scylla's per-node repair metrics that every node
+	// holding the table actually did some repair work. The row hash counters are
+	// bumped on both the master and the followers during the hash exchange, even
+	// when there is nothing to reconcile, so a node that took part in the repair
+	// always moves them, and a node that was left out never does.
+	//
+	// Before the fix SM sends 'hosts' set to a single replica set, which silences
+	// every replica outside of it - their counters stay untouched.
+	//
+	// NOTE: the repair metrics are cluster wide, Scylla exposes no per table
+	// counter. Any other repair running on the cluster in between the two
+	// snapshots below would be counted as this repair's work, and could make the
+	// test pass even without the fix. That is why this test must not be run in
+	// parallel with any other repair - don't add t.Parallel() to it.
+	const (
+		testKeyspace = "test_repair_small_table_all_nodes"
+		testTable    = "test_table_0"
+	)
+
+	session := CreateScyllaManagerDBSession(t)
+	h := newRepairTestHelper(t, session, repair.DefaultConfig())
+	clusterSession := CreateSessionAndDropAllKeyspaces(t, h.Client)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	Print("Given: small table replicated to a subset of nodes in every DC")
+	createVnodeKeyspace(t, clusterSession, testKeyspace, 2, 2)
+	WriteData(t, clusterSession, testKeyspace, 1, testTable)
+	defer dropKeyspace(t, clusterSession, testKeyspace)
+	// Flush, so that the data is on disk and the sizes below are not 0.
+	FlushTable(t, h.Client, ManagedClusterHosts(), testKeyspace, testTable)
+
+	Print("And: the ring consists of more than one replica set")
+	// With a single replica set covering the whole ring, the one call SM makes
+	// would legitimately reach every node, and the test would pass even without
+	// the fix. Guard the premise explicitly, so that such a topology fails the
+	// test instead of silently making it vacuous.
+	ring, err := h.Client.DescribeVnodeRing(ctx, testKeyspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allReplicas := strset.New()
+	for _, rt := range ring.ReplicaTokens {
+		for _, r := range rt.ReplicaSet {
+			allReplicas.Add(r.String())
+		}
+	}
+	if len(ring.ReplicaTokens) < 2 || allReplicas.Size() <= ring.RF {
+		t.Fatalf("Test requires a ring with more than one replica set and more replicas (%d) than RF (%d), got %d replica sets",
+			allReplicas.Size(), ring.RF, len(ring.ReplicaTokens))
+	}
+
+	Print("And: the table is spread across all of the cluster nodes")
+	// Every node must hold a part of the table, otherwise a node doing no repair
+	// work would not prove anything.
+	for _, host := range ManagedClusterHosts() {
+		size, err := h.Client.TableDiskSize(ctx, host, testKeyspace, testTable)
+		if err != nil {
+			t.Fatalf("Get table size on %s: %s", host, err)
+		}
+		t.Logf("Table size on %s: %d bytes", host, size)
+		if size == 0 {
+			t.Fatalf("Host %s holds no data of %s.%s, cannot validate repair coverage",
+				host, testKeyspace, testTable)
+		}
+	}
+
+	repairWork := func() map[string]float64 {
+		t.Helper()
+		out := make(map[string]float64)
+		for _, host := range ManagedClusterHosts() {
+			out[host] = nodeRepairWork(t, host)
+		}
+		return out
+	}
+
+	Print("And: repair work counters before the repair")
+	before := repairWork()
+
+	Print("When: run repair")
+	h.runRepair(ctx, map[string]any{
+		"keyspace":              []string{testKeyspace + "." + testTable},
+		"small_table_threshold": 1 * 1024 * 1024 * 1024,
+	})
+
+	Print("Then: repair is done")
+	h.assertDone(longWait)
+
+	Print("And: every node did some repair work")
+	after := repairWork()
+	var idle []string
+	for _, host := range ManagedClusterHosts() {
+		delta := after[host] - before[host]
+		t.Logf("Repair work on %s: %.0f -> %.0f (delta %.0f)", host, before[host], after[host], delta)
+		if delta <= 0 {
+			idle = append(idle, host)
+		}
+	}
+	if len(idle) > 0 {
+		t.Fatalf("Nodes %v did no repair work, so they were not repaired", idle)
+	}
+}

--- a/pkg/service/repair/testdata/ServiceGetTargetIntegration/complex.golden.json
+++ b/pkg/service/repair/testdata/ServiceGetTargetIntegration/complex.golden.json
@@ -12,6 +12,7 @@
     "dc1"
   ],
   "keyspace_replication": "all",
+  "host_filter": true,
   "fail_fast": false,
   "continue": false,
   "intensity": 1,

--- a/pkg/service/repair/testdata/ServiceGetTargetIntegration/filter_dc.golden.json
+++ b/pkg/service/repair/testdata/ServiceGetTargetIntegration/filter_dc.golden.json
@@ -29,6 +29,7 @@
     "dc1"
   ],
   "keyspace_replication": "all",
+  "host_filter": true,
   "fail_fast": false,
   "continue": true,
   "intensity": 1,

--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -80,7 +80,7 @@ func (w *worker) runRepair(ctx context.Context, j job) (out error) {
 		ranges = j.ranges
 	}
 
-	jobID, err = w.client.Repair(ctx, j.keyspace, j.table, j.master.String(), slices.MapToString(j.replicaSet), ranges, j.intensity, j.jobType == smallTableJobType)
+	jobID, err = w.client.Repair(ctx, j.keyspace, j.table, j.master.String(), slices.MapToString(j.hosts), ranges, j.intensity, j.jobType == smallTableJobType)
 	if err != nil {
 		return errors.Wrap(err, "schedule repair")
 	}
@@ -89,7 +89,7 @@ func (w *worker) runRepair(ctx context.Context, j job) (out error) {
 		"keyspace", j.keyspace,
 		"table", j.table,
 		"master", j.master,
-		"hosts", j.replicaSet,
+		"hosts", j.hosts,
 		"ranges", len(ranges),
 		"intensity", j.intensity,
 		"job_id", jobID,


### PR DESCRIPTION
Closes https://scylladb.atlassian.net/browse/CLOUD-3672

A table under `--small-table-threshold` (default 1 GiB) is repaired with a single `small_table_optimization` call covering the whole ring, and the remaining replica sets are skipped. SM still set the `hosts` param of that call to a **single replica set**.

Scylla resolves the participants of a small table repair as all normal token owners, but then intersects them with `hosts`, so passing one replica set silences every replica outside it. On a ring with more nodes than RF those replicas were never repaired — while SM still reported the table as fully repaired.

Reported by @asias on scylladb/scylladb#31271:

> Assume we have 4 nodes in the cluster, RF=3. Does SM send one repair request that limit the hosts to 3 nodes (say n1,n2,n3 which are the owners of the token range that SM uses)? This is problematic because we never repair n4 due to the hosts filter.

## Fix

- **No host filter requested:** send no `hosts` limit, so all token owners take part.
- **Filter requested** (`--dc` / `--host` / `--ignore-down-hosts`): pass all table replicas that passed the filtering, so the limit is still honored. Such a repair does not cover all replicas, so it does not advance the tombstone GC repair time in Scylla.

The nodes sent as `hosts` are kept in a new `job` field rather than reusing `replicaSet`, which is the unit of the intensity controller bookkeeping and of the recorded per host progress. Whether a filter was requested cannot be derived from `Target.DC` (filled with all cluster DCs when `--dc` is unset), so it is recorded while parsing the task properties.

## Test

The new integration test validates that the table is spread across all nodes and that the ring has more than one replica set, then snapshots Scylla's per node repair row hash counters, runs a real repair, and requires every node to have moved them. The counters are bumped on both sides of the row hash exchange even with nothing to reconcile, so a participating node always moves them and an excluded node never does.

**Before the fix** — `.12` and `.23` hold ~900 KB of the table each, yet do zero repair work:

```
Table size on 192.168.200.11: 891376 bytes
Table size on 192.168.200.12: 906160 bytes
Table size on 192.168.200.13: 901872 bytes
Table size on 192.168.200.21: 893650 bytes
Table size on 192.168.200.22: 887484 bytes
Table size on 192.168.200.23: 914054 bytes

Repair work on 192.168.200.11: 1446 -> 2047   (delta 601)
Repair work on 192.168.200.12: 17901 -> 17901 (delta 0)
Repair work on 192.168.200.13: 16174 -> 16433 (delta 259)
Repair work on 192.168.200.21: 34983 -> 35151 (delta 168)
Repair work on 192.168.200.22: 30907 -> 31081 (delta 174)
Repair work on 192.168.200.23: 3843 -> 3843   (delta 0)

Nodes [192.168.200.12 192.168.200.23] did no repair work, so they were not repaired
--- FAIL: TestServiceRepairSmallTableOptimizationRepairsAllNodesIntegration (8.79s)
```

**After the fix** — every node does repair work:

```
Repair work on 192.168.200.11: 2047 -> 2220   (delta 173)
Repair work on 192.168.200.12: 17901 -> 18076 (delta 175)
Repair work on 192.168.200.13: 16433 -> 16605 (delta 172)
Repair work on 192.168.200.21: 35151 -> 36107 (delta 956)
Repair work on 192.168.200.22: 31081 -> 31256 (delta 175)
Repair work on 192.168.200.23: 3843 -> 4104   (delta 261)

--- PASS: TestServiceRepairSmallTableOptimizationRepairsAllNodesIntegration (8.23s)
```

Full `./pkg/service/repair` integration suite passes (12/12).

Two golden files gain `host_filter: true` — `filter_dc` and `complex` are the only `GetTarget` inputs that set `dc`.

