### PR TITLE
Fix repair filtering params

### DIFF
--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -61,7 +61,6 @@ type jobType int
 const (
 	normalJobType jobType = iota
 	skipJobType
-	mergeRangesJobType
 	smallTableJobType
 	tabletJobType
 )
@@ -183,8 +182,6 @@ func (g *generator) newTableGenerator(keyspace string, tp tablePlan, ring scylla
 		jt = tabletJobType
 	case tp.Small:
 		jt = smallTableJobType
-	case len(ring.ReplicaTokens) == 1 && tp.Small:
-		jt = mergeRangesJobType
 	default:
 		jt = normalJobType
 	}

--- a/pkg/service/repair/generator.go
+++ b/pkg/service/repair/generator.go
@@ -4,7 +4,9 @@ package repair
 
 import (
 	"context"
+	stdmaps "maps"
 	"net/netip"
+	"slices"
 	"sync/atomic"
 
 	"github.com/pkg/errors"
@@ -79,6 +81,15 @@ type job struct {
 	ranges     []scyllaclient.TokenRange
 	intensity  int
 	jobType    jobType
+	// Scylla repair API filtering params.
+	// A full table repair job (see jobType.fullTableRepair) computes them
+	// against the full table replica set. Tablet repair sets them only
+	// when they actually filter anything out, as unnecessary filtering
+	// params stop it from advancing table last repair timestamp, which
+	// breaks incremental repair and tombstone_gc mode repair features.
+	// Other jobs always filter by their specific replica set.
+	hostFilter []netip.Addr
+	dcFilter   []string
 }
 
 type jobResult struct {
@@ -180,7 +191,10 @@ func (g *generator) newTableGenerator(keyspace string, tp tablePlan, ring scylla
 	switch {
 	case tabletKs:
 		jt = tabletJobType
-	case tp.Small:
+	// Small vnode table opt is not compatible with --host,
+	// as --host forces us to schedule separate repair
+	// for each filtered replica set.
+	case tp.Small && !g.target.Host.IsValid():
 		jt = smallTableJobType
 	default:
 		jt = normalJobType
@@ -267,6 +281,7 @@ func (tg *tableGenerator) newJob() (job, bool) {
 				continue
 			}
 			jt := tg.JobType
+			dcFilter, hostFilter := tg.repairFilters(jt, filtered)
 			// Some repair jobType repair an entire table with a single API call,
 			// so the remaining job are skipped (and sent only for recording progress).
 			if tg.JobType.fullTableRepair() {
@@ -280,11 +295,55 @@ func (tg *tableGenerator) newJob() (job, bool) {
 				ranges:     ranges,
 				intensity:  intensity,
 				jobType:    jt,
+				dcFilter:   dcFilter,
+				hostFilter: hostFilter,
 			}, true
 		}
 	}
 
 	return job{}, false
+}
+
+func (tg *tableGenerator) repairFilters(jt jobType, repSet []netip.Addr) (dc []string, hosts []netip.Addr) {
+	switch jt {
+	case tabletJobType:
+		// Select dc/host filtering based on full replica set.
+		// Don't set no-op filters.
+		full := tg.fullTableReplicaSet()
+		return tg.tableDcFilter(full), tg.tableHostFilter(full)
+	case smallTableJobType:
+		// Set host filter to the filtered full replica set.
+		// Side note: vnode repair API does not allow using both dc and host filters.
+		return nil, filterReplicaSet(tg.fullTableReplicaSet(), tg.Ring.HostDC, tg.target)
+	default:
+		// Set host filtering to exact repaired replica set
+		return nil, slices.Clone(repSet)
+	}
+}
+
+// fullTableReplicaSet returns the union of all replica sets in the ring.
+func (tg *tableGenerator) fullTableReplicaSet() []netip.Addr {
+	return slices.Collect(stdmaps.Keys(tg.Ring.HostDC))
+}
+
+// tableDcFilter returns the dc filter that should be used for repairing given replica set.
+// In case dc filter wouldn't have any effect, nil is returned instead.
+func (tg *tableGenerator) tableDcFilter(repSet []netip.Addr) []string {
+	dcFiltered := filterReplicaSetByDc(repSet, tg.Ring.HostDC, tg.target.DC)
+	if len(dcFiltered) == len(repSet) {
+		return nil
+	}
+	return slices.Clone(tg.target.DC)
+}
+
+// tableHostFilter returns the host filter that should be used for repairing given replica set.
+// In case host filter wouldn't have any effect, nil is returned instead.
+func (tg *tableGenerator) tableHostFilter(repSet []netip.Addr) []netip.Addr {
+	hostFiltered := filterReplicaSetByHost(repSet, tg.target.Host, tg.target.IgnoreHosts)
+	if len(hostFiltered) == len(repSet) {
+		return nil
+	}
+	return hostFiltered
 }
 
 func (tg *tableGenerator) getRangesToRepair(allRanges []scyllaclient.TokenRange, intensity int) []scyllaclient.TokenRange {

--- a/pkg/service/repair/generator_test.go
+++ b/pkg/service/repair/generator_test.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 ScyllaDB
+
+package repair
+
+import (
+	"cmp"
+	"net/netip"
+	"slices"
+	"testing"
+
+	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
+)
+
+// TestRepairFilters verifies that the dc/host filtering params
+// produced by repairFilters are:
+// - correct - they result in expected replica set
+// - are not a no-op - they are not set when not needed
+func TestRepairFilters(t *testing.T) {
+	var (
+		h1 = netip.MustParseAddr("192.168.100.11") // dc1
+		h2 = netip.MustParseAddr("192.168.100.12") // dc1
+		h3 = netip.MustParseAddr("192.168.100.21") // dc2
+		h4 = netip.MustParseAddr("192.168.100.22") // dc2
+	)
+	ring := scyllaclient.Ring{
+		HostDC: map[netip.Addr]string{h1: "dc1", h2: "dc1", h3: "dc2", h4: "dc2"},
+	}
+
+	testCases := []struct {
+		name       string
+		target     Target
+		jobType    jobType
+		repSet     []netip.Addr
+		hostFilter []netip.Addr
+		dcFilter   []string
+	}{
+		{
+			name:    "tablet repair without filtering has no filtering params",
+			target:  Target{DC: []string{"dc1", "dc2"}},
+			jobType: tabletJobType,
+			repSet:  []netip.Addr{h1, h2, h3, h4},
+		},
+		{
+			name:     "tablet repair sets effective dc filter",
+			target:   Target{DC: []string{"dc1"}},
+			jobType:  tabletJobType,
+			repSet:   []netip.Addr{h1, h2},
+			dcFilter: []string{"dc1"},
+		},
+		{
+			name:       "small table repair sets effective host filter",
+			target:     Target{DC: []string{"dc1", "dc2"}, IgnoreHosts: []netip.Addr{h4}},
+			jobType:    smallTableJobType,
+			repSet:     []netip.Addr{h1, h2, h3},
+			hostFilter: []netip.Addr{h1, h2, h3},
+		},
+		{
+			name:       "tablet repair combines dc and host filters",
+			target:     Target{DC: []string{"dc2"}, IgnoreHosts: []netip.Addr{h4}},
+			jobType:    tabletJobType,
+			repSet:     []netip.Addr{h3},
+			hostFilter: []netip.Addr{h1, h2, h3},
+			dcFilter:   []string{"dc2"},
+		},
+		{
+			name:       "small table repair keeps no-op host filter",
+			target:     Target{DC: []string{"dc1", "dc2"}},
+			jobType:    smallTableJobType,
+			repSet:     []netip.Addr{h1, h2, h3, h4},
+			hostFilter: []netip.Addr{h1, h2, h3, h4},
+		},
+		{
+			name:       "small table repair encodes dc filter into host filter",
+			target:     Target{DC: []string{"dc1"}},
+			jobType:    smallTableJobType,
+			repSet:     []netip.Addr{h1, h2},
+			hostFilter: []netip.Addr{h1, h2},
+		},
+		{
+			name:       "small table repair encodes combined dc and host filters into host filter",
+			target:     Target{DC: []string{"dc2"}, IgnoreHosts: []netip.Addr{h4}},
+			jobType:    smallTableJobType,
+			repSet:     []netip.Addr{h3},
+			hostFilter: []netip.Addr{h3},
+		},
+		{
+			name:       "not full table repair filters by its replica set",
+			target:     Target{DC: []string{"dc1"}, IgnoreHosts: []netip.Addr{h2}},
+			jobType:    normalJobType,
+			repSet:     []netip.Addr{h1},
+			hostFilter: []netip.Addr{h1},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tg := &tableGenerator{
+				generatorTools: generatorTools{target: tc.target},
+				Ring:           ring,
+			}
+
+			dcFilter, hostFilter := tg.repairFilters(tc.jobType, tc.repSet)
+			if !equalAddrs(hostFilter, tc.hostFilter) {
+				t.Errorf("got host filter %v, expected %v", hostFilter, tc.hostFilter)
+			}
+			if !equalSlices(dcFilter, tc.dcFilter) {
+				t.Errorf("got dc filter %v, expected %v", dcFilter, tc.dcFilter)
+			}
+		})
+	}
+}
+
+func equalAddrs(a, b []netip.Addr) bool {
+	f := func(x, y netip.Addr) int { return x.Compare(y) }
+	return slices.Equal(slices.SortedFunc(slices.Values(a), f), slices.SortedFunc(slices.Values(b), f))
+}
+
+func equalSlices[T cmp.Ordered](a, b []T) bool {
+	return slices.Equal(slices.Sorted(slices.Values(a)), slices.Sorted(slices.Values(b)))
+}

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/netip"
 	"os"
@@ -30,6 +31,7 @@ import (
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/db"
 	. "github.com/scylladb/scylla-manager/v3/pkg/testutils/testconfig"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/httpx"
+	"github.com/scylladb/scylla-manager/v3/pkg/util/prom"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/uuid"
 	slices2 "github.com/scylladb/scylla-manager/v3/pkg/util2/slices"
 	"github.com/scylladb/scylla-manager/v3/swagger/gen/scylla/v1/client/operations"
@@ -738,4 +740,76 @@ func chanClosedWithin(t *testing.T, c chan struct{}, d time.Duration) {
 	case <-time.After(d):
 		t.Fatal("timeout after ", d)
 	}
+}
+
+// scyllaPrometheusPort is the port Scylla exposes its metrics on.
+const scyllaPrometheusPort = "9180"
+
+// nodeRepairWork returns the total number of row hashes exchanged by given node
+// during all of the repairs it took part in, summed over its shards.
+//
+// The counters are bumped on both sides of the row hash exchange, so any node
+// participating in a repair moves them, even when there is nothing to reconcile.
+// A node that was left out of a repair does not move them at all, which makes
+// them a way of telling whether a node was really repaired.
+//
+// Scylla exposes its metrics on the second test network, not on the one the API
+// is served on, so the host is translated between the two.
+func nodeRepairWork(t *testing.T, host string) float64 {
+	t.Helper()
+
+	metricsHost, err := secondNetHost(host)
+	if err != nil {
+		t.Fatalf("Translate %s to the second test network: %s", host, err)
+	}
+	u := "http://" + net.JoinHostPort(metricsHost, scyllaPrometheusPort) + "/metrics?name=repair_hashes_nr"
+
+	resp, err := http.Get(u) //nolint:gosec,noctx
+	if err != nil {
+		t.Fatalf("Get metrics of %s: %s", host, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Get metrics of %s: status %d", host, resp.StatusCode)
+	}
+
+	families, err := prom.ParseText(resp.Body)
+	if err != nil {
+		t.Fatalf("Parse metrics of %s: %s", host, err)
+	}
+
+	var out float64
+	// Scylla registers its metric groups on startup, so a missing metric means
+	// that it was renamed or removed - fail instead of reporting no repair work.
+	for _, name := range []string{"scylla_repair_rx_hashes_nr", "scylla_repair_tx_hashes_nr"} {
+		family, ok := families[name]
+		if !ok {
+			t.Fatalf("Scylla on %s does not expose %s metric", host, name)
+		}
+		for _, m := range family.GetMetric() {
+			if counter := m.GetCounter(); counter != nil {
+				out += counter.GetValue()
+			}
+		}
+	}
+	return out
+}
+
+// secondNetHost translates an address from the test network to the second test
+// network, keeping the host part of the address.
+func secondNetHost(host string) (string, error) {
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return "", err
+	}
+	s := addr.String()
+	sep := "."
+	if !addr.Is4() {
+		sep = ":"
+	}
+	i := strings.LastIndex(s, sep)
+	if i < 0 {
+		return "", errors.New("unexpected address format: " + s)
+	}
+	return ToCanonicalIP(IPFromSecondTestNet(s[i+1:])), nil
 }

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -220,7 +220,8 @@ func parseRepairAsyncReq(t *testing.T, req *http.Request) repairReq {
 		}
 		sched.rangesParallelism = rangesParallelism
 	}
-	if sched.keyspace == "" || sched.table == "" || len(sched.replicaSet) == 0 {
+	// Small vnode table repair does not need to set exact replica set
+	if sched.keyspace == "" || sched.table == "" || (len(sched.replicaSet) == 0 && !sched.smallTableOptimization) {
 		t.Error("Not fully initialized old repair sched req")
 		return repairReq{}
 	}

--- a/pkg/service/repair/helper_integration_test.go
+++ b/pkg/service/repair/helper_integration_test.go
@@ -102,15 +102,17 @@ type repairReq struct {
 	host     netip.Addr
 	keyspace string
 	table    string
-	// always set for vnode
+	// always set for regular vnode, optional with small table opt
 	replicaSet []netip.Addr
 	ranges     []scyllaclient.TokenRange
+	// optional tablet version of replicaSet - contains host IDs
+	hostFilter []string
+	// optional for both vnode and tablet
+	dcFilter []string
 	// optional for vnode
 	smallTableOptimization bool
 	rangesParallelism      int
 	// optional for tablet
-	dcFilter        []string
-	hostFilter      []netip.Addr
 	incrementalMode string
 }
 
@@ -222,6 +224,9 @@ func parseRepairAsyncReq(t *testing.T, req *http.Request) repairReq {
 		}
 		sched.rangesParallelism = rangesParallelism
 	}
+	if dcs := req.URL.Query().Get("dataCenters"); dcs != "" {
+		sched.dcFilter = strings.Split(dcs, ",")
+	}
 	// Small vnode table repair does not need to set exact replica set
 	if sched.keyspace == "" || sched.table == "" || (len(sched.replicaSet) == 0 && !sched.smallTableOptimization) {
 		t.Error("Not fully initialized old repair sched req")
@@ -246,7 +251,7 @@ func parseTabletRepairReq(t *testing.T, req *http.Request) repairReq {
 		sched.dcFilter = strings.Split(dcFilter, ",")
 	}
 	if hostsFilter := req.URL.Query().Get("hosts_filter"); hostsFilter != "" {
-		sched.hostFilter = slices2.Map(strings.Split(hostsFilter, ","), netip.MustParseAddr)
+		sched.hostFilter = strings.Split(hostsFilter, ",")
 	}
 	if incrementalMode := req.URL.Query().Get("incremental_mode"); incrementalMode != "" {
 		sched.incrementalMode = incrementalMode

--- a/pkg/service/repair/plan.go
+++ b/pkg/service/repair/plan.go
@@ -343,14 +343,31 @@ func MaxRingParallel(ring scyllaclient.Ring, dcs []string) int {
 	}
 }
 
-// Filters replica set according to --dc, --ignore-down-hosts, --host.
+// Filters replica set by dc and host filters.
 func filterReplicaSet(replicaSet []netip.Addr, hostDC map[netip.Addr]string, target Target) []netip.Addr {
-	if target.Host.IsValid() && !slices.Contains(replicaSet, target.Host) {
+	hostFiltered := filterReplicaSetByHost(replicaSet, target.Host, target.IgnoreHosts)
+	return filterReplicaSetByDc(hostFiltered, hostDC, target.DC)
+}
+
+// filterReplicaSetByHost according to --host and --ignore-down-hosts.
+func filterReplicaSetByHost(replicaSet []netip.Addr, host netip.Addr, ignoreHosts []netip.Addr) []netip.Addr {
+	if host.IsValid() && !slices.Contains(replicaSet, host) {
 		return nil
 	}
 	var out []netip.Addr
 	for _, h := range replicaSet {
-		if slice.ContainsString(target.DC, hostDC[h]) && !slices.Contains(target.IgnoreHosts, h) {
+		if !slices.Contains(ignoreHosts, h) {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// filterReplicaSetByDc according to --dc.
+func filterReplicaSetByDc(replicaSet []netip.Addr, hostDC map[netip.Addr]string, dcs []string) []netip.Addr {
+	var out []netip.Addr
+	for _, h := range replicaSet {
+		if slice.ContainsString(dcs, hostDC[h]) {
 			out = append(out, h)
 		}
 	}

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -2666,3 +2666,110 @@ func TestTabletRepairInteractionIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestServiceRepairSmallTableOptimizationRepairsAllNodesIntegration(t *testing.T) {
+	// End-to-end companion of the CLOUD-3672 regression tests above.
+	//
+	// Instead of asserting the shape of the repair API call, this test runs a real
+	// repair and verifies via Scylla's per-node repair metrics that every node
+	// holding the table actually did some repair work. The row hash counters are
+	// bumped on both the master and the followers during the hash exchange, even
+	// when there is nothing to reconcile, so a node that took part in the repair
+	// always moves them, and a node that was left out never does.
+	//
+	// Before the fix SM sends 'hosts' set to a single replica set, which silences
+	// every replica outside of it - their counters stay untouched.
+	//
+	// NOTE: the repair metrics are cluster wide, Scylla exposes no per table
+	// counter. Any other repair running on the cluster in between the two
+	// snapshots below would be counted as this repair's work, and could make the
+	// test pass even without the fix. That is why this test must not be run in
+	// parallel with any other repair - don't add t.Parallel() to it.
+	const (
+		testKeyspace = "test_repair_small_table_all_nodes"
+		testTable    = "test_table_0"
+	)
+
+	session := CreateScyllaManagerDBSession(t)
+	h := newRepairTestHelper(t, session, repair.DefaultConfig())
+	clusterSession := CreateSessionAndDropAllKeyspaces(t, h.Client)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	Print("Given: small table replicated to a subset of nodes in every DC")
+	createVnodeKeyspace(t, clusterSession, testKeyspace, 2, 2)
+	WriteData(t, clusterSession, testKeyspace, 1, testTable)
+	defer dropKeyspace(t, clusterSession, testKeyspace)
+	// Flush, so that the data is on disk and the sizes below are not 0.
+	FlushTable(t, h.Client, ManagedClusterHosts(), testKeyspace, testTable)
+
+	Print("And: the ring consists of more than one replica set")
+	// With a single replica set covering the whole ring, the one call SM makes
+	// would legitimately reach every node, and the test would pass even without
+	// the fix. Guard the premise explicitly, so that such a topology fails the
+	// test instead of silently making it vacuous.
+	ring, err := h.Client.DescribeVnodeRing(ctx, testKeyspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	allReplicas := strset.New()
+	for _, rt := range ring.ReplicaTokens {
+		for _, r := range rt.ReplicaSet {
+			allReplicas.Add(r.String())
+		}
+	}
+	if len(ring.ReplicaTokens) < 2 || allReplicas.Size() <= ring.RF {
+		t.Fatalf("Test requires a ring with more than one replica set and more replicas (%d) than RF (%d), got %d replica sets",
+			allReplicas.Size(), ring.RF, len(ring.ReplicaTokens))
+	}
+
+	Print("And: the table is spread across all of the cluster nodes")
+	// Every node must hold a part of the table, otherwise a node doing no repair
+	// work would not prove anything.
+	for _, host := range ManagedClusterHosts() {
+		size, err := h.Client.TableDiskSize(ctx, host, testKeyspace, testTable)
+		if err != nil {
+			t.Fatalf("Get table size on %s: %s", host, err)
+		}
+		t.Logf("Table size on %s: %d bytes", host, size)
+		if size == 0 {
+			t.Fatalf("Host %s holds no data of %s.%s, cannot validate repair coverage",
+				host, testKeyspace, testTable)
+		}
+	}
+
+	repairWork := func() map[string]float64 {
+		t.Helper()
+		out := make(map[string]float64)
+		for _, host := range ManagedClusterHosts() {
+			out[host] = nodeRepairWork(t, host)
+		}
+		return out
+	}
+
+	Print("And: repair work counters before the repair")
+	before := repairWork()
+
+	Print("When: run repair")
+	h.runRepair(ctx, map[string]any{
+		"keyspace":              []string{testKeyspace + "." + testTable},
+		"small_table_threshold": 1 * 1024 * 1024 * 1024,
+	})
+
+	Print("Then: repair is done")
+	h.assertDone(longWait)
+
+	Print("And: every node did some repair work")
+	after := repairWork()
+	var idle []string
+	for _, host := range ManagedClusterHosts() {
+		delta := after[host] - before[host]
+		t.Logf("Repair work on %s: %.0f -> %.0f (delta %.0f)", host, before[host], after[host], delta)
+		if delta <= 0 {
+			idle = append(idle, host)
+		}
+	}
+	if len(idle) > 0 {
+		t.Fatalf("Nodes %v did no repair work, so they were not repaired", idle)
+	}
+}

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/netip"
 	"slices"
@@ -1723,15 +1724,16 @@ func TestServiceRepairIntegration(t *testing.T) {
 			testTable    = "test_table_0"
 		)
 
-		Print("Given: small and fully replicated table")
+		Print("Given: small table")
 		// Small table optimisation is not supported for tablet keyspaces
-		createVnodeKeyspace(t, clusterSession, testKeyspace, 3, 0)
+		createVnodeKeyspace(t, clusterSession, testKeyspace, 2, 1)
 		WriteData(t, clusterSession, testKeyspace, 1, testTable)
 		defer dropKeyspace(t, clusterSession, testKeyspace)
 
 		h := newRepairTestHelper(t, session, defaultConfig())
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+
+		ipCmp := func(a, b netip.Addr) int { return a.Compare(b) }
+		allHosts := slices.SortedFunc(slices.Values(slices2.Map(h.GetAllHosts(), netip.MustParseAddr)), ipCmp)
 
 		var (
 			repairCalled int32
@@ -1743,6 +1745,13 @@ func TestServiceRepairIntegration(t *testing.T) {
 					if r.smallTableOptimization {
 						optUsed.Store(true)
 					}
+					// Expect no dc filter (we don't set it for vnode repair),
+					// and exact host filter (it's ok even if no-op for vnode repair).
+					slices.SortFunc(r.replicaSet, ipCmp)
+					if r.dcFilter != nil || !slices.Equal(r.replicaSet, allHosts) {
+						t.Errorf("Table %q: expected just the no-op host filter %v, got dc=%v, hosts=%v",
+							r.fullTable(), allHosts, r.dcFilter, r.replicaSet)
+					}
 				}
 				return nil, nil
 			}),
@@ -1751,7 +1760,7 @@ func TestServiceRepairIntegration(t *testing.T) {
 		))
 
 		Print("When: run repair")
-		h.runRepair(ctx, map[string]any{
+		h.runRepair(t.Context(), map[string]any{
 			"keyspace":              []string{testKeyspace + "." + testTable},
 			"dc":                    []string{"dc1", "dc2"},
 			"intensity":             1,
@@ -1779,6 +1788,42 @@ func TestServiceRepairIntegration(t *testing.T) {
 
 		if p.TokenRanges != p.Success {
 			t.Fatalf("Expected full success, got %d/%d", p.Success, p.TokenRanges)
+		}
+
+		// Expect --dc to be encoded into the host filter
+		expectedHostFilter := slices.SortedFunc(slices.Values(slices2.Map(h.GetHostsFromDC("dc1"), netip.MustParseAddr)), ipCmp)
+		var dcRepairCalled int32
+		h.Hrt.SetInterceptor(combineInterceptors(
+			httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				if r, ok := parseRepairReq(t, req); ok {
+					if !r.smallTableOptimization {
+						t.Errorf("Table %q: small table optimization wasn't used", r.fullTable())
+					}
+					slices.SortFunc(r.replicaSet, ipCmp)
+					if r.dcFilter != nil || !slices.Equal(r.replicaSet, expectedHostFilter) {
+						t.Errorf("Table %q: expected just the host filter %v, got dc=%v, hosts=%v",
+							r.fullTable(), expectedHostFilter, r.dcFilter, r.replicaSet)
+					}
+				}
+				return nil, nil
+			}),
+			countInterceptor(&dcRepairCalled, isRepairReq),
+			repairMockInterceptor(t, repairStatusDone),
+		))
+
+		Print("When: run repair with dc filter")
+		h.RunID = uuid.NewTime()
+		h.runRepair(t.Context(), map[string]any{
+			"keyspace":              []string{testKeyspace + "." + testTable},
+			"dc":                    []string{"dc1"},
+			"small_table_threshold": 1 * 1024 * 1024 * 1024,
+		})
+
+		Print("Then: repair is done")
+		h.assertDone(longWait)
+
+		if v := atomic.LoadInt32(&dcRepairCalled); v != 1 {
+			t.Fatalf("Expected 1 repair request, got %v", v)
 		}
 	})
 
@@ -2138,6 +2183,25 @@ func TestServiceRepairIntegration(t *testing.T) {
 		WriteData(t, clusterSession, tabletSingleDCKs, 1, "tab")
 		WriteData(t, clusterSession, vnodeKs, 1, "tab")
 
+		t.Run("Repairing tablet table should succeed", func(t *testing.T) {
+			h := newRepairTestHelper(t, session, defaultConfig())
+
+			h.Hrt.SetInterceptor(httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				if isTabletRepairReq(req) {
+					r := parseTabletRepairReq(t, req)
+					if r.dcFilter != nil || r.hostFilter != nil {
+						t.Errorf("Table %q: expected no filtering params, got dc=%v, host=%v", r.fullTable(), r.dcFilter, r.hostFilter)
+					}
+				}
+				return nil, nil
+			}))
+
+			h.runRepair(t.Context(), map[string]any{
+				"keyspace": []string{tabletMultiDCKs, tabletSingleDCKs},
+			})
+			h.assertDone(longWait)
+		})
+
 		t.Run("Repairing tablet table with --host should fail at generating target", func(t *testing.T) {
 			h := newRepairTestHelper(t, session, defaultConfig())
 			_, err := h.generateTarget(map[string]any{
@@ -2155,12 +2219,23 @@ func TestServiceRepairIntegration(t *testing.T) {
 			defer cancel()
 
 			host := netip.MustParseAddr(h.GetHostsFromDC("dc2")[0])
-			h.Hrt.SetInterceptor(repairReqAssertHostInterceptor(t, host))
+			// Expect fallback to regular vnode repair,
+			// as small table opt can't handle --host filtering.
+			h.Hrt.SetInterceptor(combineInterceptors(
+				httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					if r, ok := parseRepairReq(t, req); ok && r.smallTableOptimization {
+						t.Errorf("Table %q: unexpected small table optimization", r.fullTable())
+					}
+					return nil, nil
+				}),
+				repairReqAssertHostInterceptor(t, host),
+			))
 
 			h.runRepair(ctx, map[string]any{
-				"dc":       []string{"dc2"},
-				"keyspace": []string{tabletSingleDCKs, vnodeKs},
-				"host":     host.String(),
+				"dc":                    []string{"dc2"},
+				"keyspace":              []string{tabletSingleDCKs, vnodeKs},
+				"host":                  host.String(),
+				"small_table_threshold": 1024 * 1024 * 1024 * 1024, // Ensure theoretical small vnode table opt eligibility
 			})
 			h.assertDone(shortWait)
 		})
@@ -2196,18 +2271,120 @@ func TestServiceRepairIntegration(t *testing.T) {
 			})
 			defer startNodeFunc()
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			h.runRepair(ctx, map[string]any{
+			// Expect dc filter set due to --dc
+			var tabletRepairCalled int32
+			h.Hrt.SetInterceptor(combineInterceptors(
+				httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					if isTabletRepairReq(req) {
+						r := parseTabletRepairReq(t, req)
+						if !slices.Equal(r.dcFilter, []string{"dc1"}) {
+							t.Errorf("Table %q: expected dc filter %v, got %v", r.fullTable(), []string{"dc1"}, r.dcFilter)
+						}
+					}
+					return nil, nil
+				}),
+				countInterceptor(&tabletRepairCalled, isTabletRepairReq),
+			))
+
+			h.runRepair(t.Context(), map[string]any{
 				"keyspace": []string{tabletMultiDCKs, vnodeKs},
 				"dc":       []string{"dc1"},
 			})
 
-			rd := scyllaclient.NewRingDescriber(ctx, h.Client)
-			if rd.IsTabletKeyspace("test_repair") {
-				h.assertDonePartialTabletRepair(longWait, startNodeFunc)
-			} else {
-				h.assertDone(2 * longWait)
+			h.assertDonePartialTabletRepair(longWait, startNodeFunc)
+
+			if v := atomic.LoadInt32(&tabletRepairCalled); v != 1 {
+				t.Fatalf("Expected 1 tablet repair request, got %v", v)
+			}
+		})
+
+		t.Run("Repairing table with node down and --ignore-down-nodes should succeed", func(t *testing.T) {
+			h := newRepairTestHelper(t, session, defaultConfig())
+
+			down := h.GetHostsFromDC("dc2")[0]
+			h.StopNode(down)
+			startNodeFunc := sync.OnceFunc(func() {
+				h.StartNode(down, globalNodeInfo)
+			})
+			defer startNodeFunc()
+
+			// Get running nodes ID
+			ctx := t.Context()
+			hostIDs, err := h.Client.HostIDs(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			delete(hostIDs, down)
+			expectedHostFilter := slices.Sorted(maps.Values(hostIDs))
+
+			// Expect host filter set due to --ignore-down-hosts
+			var tabletRepairCalled int32
+			h.Hrt.SetInterceptor(combineInterceptors(
+				httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					if isTabletRepairReq(req) {
+						r := parseTabletRepairReq(t, req)
+						slices.Sort(r.hostFilter)
+						if !slices.Equal(r.hostFilter, expectedHostFilter) {
+							t.Errorf("Table %q: expected host filter %v, got %v", r.fullTable(), expectedHostFilter, r.hostFilter)
+						}
+					}
+					return nil, nil
+				}),
+				countInterceptor(&tabletRepairCalled, isTabletRepairReq),
+			))
+
+			h.runRepair(ctx, map[string]any{
+				"keyspace":          []string{tabletMultiDCKs, vnodeKs},
+				"ignore_down_hosts": true,
+			})
+
+			h.assertDonePartialTabletRepair(longWait, startNodeFunc)
+
+			if v := atomic.LoadInt32(&tabletRepairCalled); v != 1 {
+				t.Fatalf("Expected 1 tablet repair request, got %v", v)
+			}
+		})
+
+		t.Run("Repairing small vnode table with --dc and --ignore-down-nodes should succeed", func(t *testing.T) {
+			h := newRepairTestHelper(t, session, defaultConfig())
+
+			down := h.GetHostsFromDC("dc1")[0]
+			h.StopNode(down)
+			defer h.StartNode(down, globalNodeInfo)
+
+			// Expect --dc and --ignore-down-hosts to be encoded into the host filter
+			ipCmp := func(a, b netip.Addr) int { return a.Compare(b) }
+			liveHosts := slices.DeleteFunc(h.GetHostsFromDC("dc1"), func(host string) bool { return host == down })
+			expectedHostFilter := slices.SortedFunc(slices.Values(slices2.Map(liveHosts, netip.MustParseAddr)), ipCmp)
+
+			var repairCalled int32
+			h.Hrt.SetInterceptor(combineInterceptors(
+				httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					if isRepairAsyncReq(req) {
+						r := parseRepairAsyncReq(t, req)
+						if !r.smallTableOptimization {
+							t.Errorf("Table %q: small table optimization wasn't used", r.fullTable())
+						}
+						slices.SortFunc(r.replicaSet, ipCmp)
+						if r.dcFilter != nil || !slices.Equal(r.replicaSet, expectedHostFilter) {
+							t.Errorf("Table %q: expected just the host filter %v, got dc=%v, hosts=%v",
+								r.fullTable(), expectedHostFilter, r.dcFilter, r.replicaSet)
+						}
+					}
+					return nil, nil
+				}),
+				countInterceptor(&repairCalled, isRepairAsyncReq),
+			))
+
+			h.runRepair(t.Context(), map[string]any{
+				"keyspace":          []string{vnodeKs},
+				"dc":                []string{"dc1"},
+				"ignore_down_hosts": true,
+			})
+			h.assertDone(longWait)
+
+			if v := atomic.LoadInt32(&repairCalled); v != 1 {
+				t.Fatalf("Expected 1 repair request, got %v", v)
 			}
 		})
 	})
@@ -2224,25 +2401,22 @@ func TestServiceRepairIntegration(t *testing.T) {
 			t2       = "test_table_2"
 		)
 		testCases := []struct {
-			ks            string
-			tab           []string
-			api           string
-			singleCall    bool
-			loadBalancing bool
+			ks         string
+			tab        []string
+			api        string
+			singleCall bool
 		}{
 			{
-				ks:            tabletKS,
-				tab:           []string{t1, t2},
-				api:           tabletRepairEndpoint,
-				singleCall:    true,
-				loadBalancing: true,
+				ks:         tabletKS,
+				tab:        []string{t1, t2},
+				api:        tabletRepairEndpoint,
+				singleCall: true,
 			},
 			{
-				ks:            vnodeKs,
-				tab:           []string{t1, t2},
-				api:           repairAsyncEndpoint,
-				singleCall:    false,
-				loadBalancing: true,
+				ks:         vnodeKs,
+				tab:        []string{t1, t2},
+				api:        repairAsyncEndpoint,
+				singleCall: false,
 			},
 		}
 
@@ -2257,16 +2431,15 @@ func TestServiceRepairIntegration(t *testing.T) {
 
 		tabRepairEndpoint := make(map[string]string) // The endpoint used for repairing the table
 		tabCallCnt := make(map[string]int)           // The amount of API calls needed for repairing the table
-		tabLoadBalancing := make(map[string]bool)    // Was load balancing enabled when table was repaired
-		loadBalancing := true                        // Keeps track of current load balancing setting
 		mu := sync.Mutex{}
 		h.Hrt.SetInterceptor(httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			if enabled, ok := newTabletLoadBalancingReq(t, req); ok {
-				mu.Lock()
-				loadBalancing = enabled
-				mu.Unlock()
+			if _, ok := newTabletLoadBalancingReq(t, req); ok {
+				t.Error("Tablet load balancing shouldn't be touched during repair")
 			}
 			if r, ok := parseRepairReq(t, req); ok {
+				if r.dcFilter != nil || r.hostFilter != nil {
+					t.Errorf("Table %q: dc/host filters shouldn't be set when not needed, dc=%v, host=%v", r.fullTable(), r.dcFilter, r.hostFilter)
+				}
 				mu.Lock()
 				tabCallCnt[r.fullTable()]++
 				// Ensure single repair endpoint per table
@@ -2276,14 +2449,6 @@ func TestServiceRepairIntegration(t *testing.T) {
 					}
 				} else {
 					tabRepairEndpoint[r.fullTable()] = req.URL.Path
-				}
-				// Ensure single tablet load balancing setting per table
-				if enabled, ok := tabLoadBalancing[r.fullTable()]; ok {
-					if enabled != loadBalancing {
-						t.Error("Mixing load balancing for the same table")
-					}
-				} else {
-					tabLoadBalancing[r.fullTable()] = loadBalancing
 				}
 				mu.Unlock()
 			}
@@ -2308,9 +2473,6 @@ func TestServiceRepairIntegration(t *testing.T) {
 				}
 				if cnt := tabCallCnt[fn]; cnt <= 0 || ((cnt == 1) != tc.singleCall) {
 					t.Errorf("Table %q: expected single_call=%v, got %d", fn, tc.singleCall, cnt)
-				}
-				if enabled := tabLoadBalancing[fn]; enabled != tc.loadBalancing {
-					t.Errorf("Table %q: expected tablet load balancing: %v, got %v", fn, tc.loadBalancing, enabled)
 				}
 			}
 		}

--- a/pkg/service/repair/service_repair_integration_test.go
+++ b/pkg/service/repair/service_repair_integration_test.go
@@ -1800,18 +1800,12 @@ func TestServiceRepairIntegration(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		var (
-			optUsed         = atomic.Bool{}
-			mergedRangeUsed = atomic.Bool{}
-		)
+		optUsed := atomic.Bool{}
 		h.Hrt.SetInterceptor(combineInterceptors(
 			httpx.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 				if r, ok := parseRepairReq(t, req); ok {
 					if r.smallTableOptimization {
 						optUsed.Store(true)
-					}
-					if slices.Equal(r.ranges, []scyllaclient.TokenRange{{StartToken: dht.Murmur3MinToken, EndToken: dht.Murmur3MaxToken}}) {
-						mergedRangeUsed.Store(true)
 					}
 				}
 				return nil, nil
@@ -1831,10 +1825,6 @@ func TestServiceRepairIntegration(t *testing.T) {
 		// small_table_optimization shouldn't be used on big tables
 		if optUsed.Load() {
 			t.Fatal("small_table_optimisation was used")
-		}
-		// merged ranges optimization shouldn't be used on big tables
-		if mergedRangeUsed.Load() {
-			t.Fatal("merged ranges optimization was used")
 		}
 
 		p, err := h.service.GetProgress(context.Background(), h.ClusterID, h.TaskID, h.RunID)

--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/scylladb/go-log"
-	"github.com/scylladb/scylla-manager/v3/pkg/dht"
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/slice"
@@ -69,13 +68,6 @@ func (w *worker) runRepair(ctx context.Context, j job) (out error) {
 		return w.fullTabletTableRepair(ctx, j.keyspace, j.table, j.master.String())
 	case smallTableJobType:
 		ranges = nil
-	case mergeRangesJobType:
-		ranges = []scyllaclient.TokenRange{
-			{
-				StartToken: dht.Murmur3MinToken,
-				EndToken:   dht.Murmur3MaxToken,
-			},
-		}
 	default:
 		ranges = j.ranges
 	}

--- a/pkg/service/repair/worker.go
+++ b/pkg/service/repair/worker.go
@@ -4,6 +4,7 @@ package repair
 
 import (
 	"context"
+	"net/netip"
 	"time"
 
 	"github.com/pkg/errors"
@@ -11,6 +12,7 @@ import (
 	"github.com/scylladb/scylla-manager/v3/pkg/scyllaclient"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/retry"
 	"github.com/scylladb/scylla-manager/v3/pkg/util/slice"
+	"github.com/scylladb/scylla-manager/v3/pkg/util2/maps"
 	"github.com/scylladb/scylla-manager/v3/pkg/util2/slices"
 )
 
@@ -65,14 +67,14 @@ func (w *worker) runRepair(ctx context.Context, j job) (out error) {
 	var ranges []scyllaclient.TokenRange
 	switch j.jobType {
 	case tabletJobType:
-		return w.fullTabletTableRepair(ctx, j.keyspace, j.table, j.master.String())
+		return w.fullTabletTableRepair(ctx, j)
 	case smallTableJobType:
 		ranges = nil
 	default:
 		ranges = j.ranges
 	}
 
-	jobID, err = w.client.Repair(ctx, j.keyspace, j.table, j.master.String(), slices.MapToString(j.replicaSet), ranges, j.intensity, j.jobType == smallTableJobType)
+	jobID, err = w.client.Repair(ctx, j.keyspace, j.table, j.master.String(), slices.MapToString(j.hostFilter), ranges, j.intensity, j.jobType == smallTableJobType)
 	if err != nil {
 		return errors.Wrap(err, "schedule repair")
 	}
@@ -81,7 +83,7 @@ func (w *worker) runRepair(ctx context.Context, j job) (out error) {
 		"keyspace", j.keyspace,
 		"table", j.table,
 		"master", j.master,
-		"hosts", j.replicaSet,
+		"hosts", j.hostFilter,
 		"ranges", len(ranges),
 		"intensity", j.intensity,
 		"job_id", jobID,
@@ -162,8 +164,10 @@ func (w *worker) isTableDeleted(ctx context.Context, j job) bool {
 	return !exists
 }
 
-func (w *worker) fullTabletTableRepair(ctx context.Context, keyspace, table, host string) error {
-	hostFilter, err := w.hostFilter(ctx)
+func (w *worker) fullTabletTableRepair(ctx context.Context, j job) error {
+	host := j.master.String()
+	// Convert host filter from IPs to host IDs
+	hostFilter, err := w.hostToID(ctx, j.hostFilter)
 	if err != nil {
 		return errors.Wrap(err, "create host filter")
 	}
@@ -172,13 +176,13 @@ func (w *worker) fullTabletTableRepair(ctx context.Context, keyspace, table, hos
 	if w.apiSupport.incrementalRepair {
 		incrementalMode = w.target.IncrementalMode
 	}
-	id, err := w.client.TabletRepair(ctx, keyspace, table, host, w.target.DC, hostFilter, incrementalMode)
+	id, err := w.client.TabletRepair(ctx, j.keyspace, j.table, host, j.dcFilter, hostFilter, incrementalMode)
 	if err != nil {
 		convertedErr := w.convertColocatedTableRepairErr(err)
 		if convertedErr == nil {
 			w.logger.Info(ctx, "Skipping repair of colocated table, because its base table is repaired",
-				"keyspace", keyspace,
-				"table", table,
+				"keyspace", j.keyspace,
+				"table", j.table,
 				"initial error", err)
 			return nil
 		}
@@ -186,8 +190,10 @@ func (w *worker) fullTabletTableRepair(ctx context.Context, keyspace, table, hos
 	}
 
 	w.logger.Info(ctx, "Repairing entire tablet table",
-		"keyspace", keyspace,
-		"table", table,
+		"keyspace", j.keyspace,
+		"table", j.table,
+		"hosts", j.hostFilter,
+		"dcs", j.dcFilter,
 		"task ID", id,
 	)
 
@@ -208,15 +214,27 @@ func (w *worker) fullTabletTableRepair(ctx context.Context, keyspace, table, hos
 	}
 }
 
-func (w *worker) hostFilter(ctx context.Context) ([]string, error) {
-	if len(w.target.IgnoreHosts) == 0 {
+func (w *worker) hostToID(ctx context.Context, hosts []netip.Addr) ([]string, error) {
+	if len(hosts) == 0 {
 		return nil, nil
 	}
-	status, err := w.client.Status(ctx)
+	rawHostIDs, err := w.client.HostIDs(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "get status")
+		return nil, errors.Wrap(err, "get host IDs")
 	}
-	return status.Up().HostIDs(), nil
+	hostIDs, err := maps.MapKeyWithError(rawHostIDs, netip.ParseAddr)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		id, ok := hostIDs[h]
+		if !ok {
+			return nil, errors.Errorf("missing host ID of host %s", h)
+		}
+		out = append(out, id)
+	}
+	return out, nil
 }
 
 // convertColocatedTableRepairErr checks if the error returned from scheduling tablet repair


### PR DESCRIPTION
This PR supersedes https://github.com/scylladb/scylla-manager/pull/4909 mostly according to https://github.com/scylladb/scylla-manager/pull/4909#discussion_r3901884699.
It's goal is to fix the following:
- for small vnode table opt repair - pass dc/host filter not limited by the first encountered replica set, but based on the full table replica set (resulted in partial repair)
- for tablet repair - pass dc/host filter only when it's not a no-op (resulted in not advancing table's repair timestamp)

This PR does not tackle the problem related to including partial replica set in repair job for full table repairs (causes misleading progress and unnecessary DB writes), as fixing it turned out to be slightly more complex and would require more changes to full table repair/progress flow. Therefor it's better suited for a separate PR (probably as a part of addressing https://scylladb.atlassian.net/browse/CLOUD-2919).

The original PR didn't tackle the tablet repair problem.
Also, it tired to use the same approach for detecting filtering as on the scylla side:
If filtering flags like --dc, --ignore-down-hosts, --host are set, then filtering is set.

First of all, this is not the best behavior from UX POV (setting --dc=dc1 on a single dc cluster shouldn't have negative consequences), but it makes more sense on scylla side due to implementation difficulties, repair scope limited to a single table and exact (as opposed to SM pattern) input.

For SM, this would mean that filtering is applied even when --dc=* (pattern usage) or when --ignore-down-hosts but all are up. We should be more robust than that and actually check if given filtering configuration is a no-op or not before sending the filtering params to scylla.

This PR fixes that by calculating dc/host filtering params on the generator side.
Generator has the exact info about repaired token ring and all its replicas, so it can easily see if host or dc filtering is a no-op. Then, repair worker should simply apply filters passed alongside repair job instead of trying to set them based on replica set and and target.

This PR cherry-picks the extensive e2e test validating actually repaired ranges via scylla metrics.
It also adds/extends a few tests based on sent repair request API params. 

Fixes https://scylladb.atlassian.net/browse/CLOUD-3672
